### PR TITLE
feat(bench): reld participates in the benchmark via its driver shim (BR-4a)

### DIFF
--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -45,6 +45,12 @@ struct Args {
     /// Working directory for generated workloads.
     #[arg(long)]
     workdir: Option<PathBuf>,
+
+    /// Explicit path to the reld driver shim (e.g. `ld.reld`), produced by
+    /// `ci/install-driver-shims.sh`. If omitted, the bench looks for `ld.reld` next to its own
+    /// executable.
+    #[arg(long)]
+    reld: Option<PathBuf>,
 }
 
 /// Workload sizes. Small is where incremental linking will eventually matter most; large is
@@ -71,6 +77,42 @@ fn default_linkers() -> Vec<&'static str> {
     vec!["bfd", "lld", "mold", "wild"]
 }
 
+/// Locate the `ld.reld` driver shim produced by `ci/install-driver-shims.sh`.
+///
+/// Resolution order:
+/// 1. `explicit`, if given and it exists on disk.
+/// 2. `ld.reld` (or `ld.reld.exe` on Windows) next to the running bench binary.
+///
+/// Returns `None` if neither location has a file, so the caller can report reld as `n/a`
+/// honestly rather than pass a bogus path to `-fuse-ld=`.
+fn discover_reld(explicit: &Option<PathBuf>) -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok();
+    discover_reld_in(explicit, exe.as_deref().and_then(Path::parent))
+}
+
+/// Core of [`discover_reld`], with the "next to the bench binary" directory injected so tests can
+/// exercise the resolution logic hermetically against a temp dir instead of the real executable
+/// directory (which parallel tests would otherwise race on).
+fn discover_reld_in(explicit: &Option<PathBuf>, sibling_dir: Option<&Path>) -> Option<PathBuf> {
+    if let Some(p) = explicit
+        && p.exists()
+    {
+        return Some(p.clone());
+    }
+
+    let dir = sibling_dir?;
+    let name = if cfg!(windows) {
+        "ld.reld.exe"
+    } else {
+        "ld.reld"
+    };
+    let candidate = dir.join(name);
+    if candidate.exists() {
+        return Some(candidate);
+    }
+    None
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
@@ -91,6 +133,26 @@ fn main() -> Result<()> {
     for l in &requested {
         available.push((l.clone(), probe_linker(&args.cc, l, &root).unwrap_or(false)));
     }
+
+    // reld is measured through its `ld.reld` driver shim, invoked via `-fuse-ld=<abs-path>`.
+    // The column's display label ("reld") is decoupled from the `-fuse-ld` value (the shim's
+    // absolute path) so the table stays honest about what's actually being run.
+    let reld_shim = discover_reld(&args.reld).and_then(|p| std::fs::canonicalize(&p).ok());
+    let reld_shim_str = reld_shim.as_ref().map(|p| p.to_string_lossy().into_owned());
+    let reld_unavailable_reason = if reld_shim_str.is_none() {
+        Some("no ld.reld shim discovered (run ci/install-driver-shims.sh)")
+    } else {
+        None
+    };
+    let reld_ok = match &reld_shim_str {
+        Some(linker) => probe_linker(&args.cc, linker, &root).unwrap_or(false),
+        None => false,
+    };
+    let reld_unavailable_reason = if reld_shim_str.is_some() && !reld_ok {
+        Some("probe link failed")
+    } else {
+        reld_unavailable_reason
+    };
 
     println!("## Link Benchmark: {}", target_triple());
     println!();
@@ -122,9 +184,13 @@ fn main() -> Result<()> {
                 Err(_) => print!(" n/a |"),
             }
         }
-        // reld does not exist yet. Publishing the column now, empty, keeps the chart's
-        // shape stable and makes the gap visible rather than implied.
-        println!(" n/a |");
+        match (&reld_shim_str, reld_ok) {
+            (Some(linker), true) => match time_link(&args, &dir, &objects, linker) {
+                Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
+                Err(_) => println!(" n/a |"),
+            },
+            _ => println!(" n/a |"),
+        }
     }
 
     println!();
@@ -132,6 +198,9 @@ fn main() -> Result<()> {
         if !ok {
             println!("<!-- linker {l} not available on this runner -->");
         }
+    }
+    if let Some(reason) = reld_unavailable_reason {
+        println!("<!-- linker reld not available: {reason} -->");
     }
     Ok(())
 }
@@ -228,4 +297,81 @@ fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Resu
     }
     samples.sort();
     Ok(samples[samples.len() / 2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unique temp directory per test, so the (hermetic) discovery tests never touch the real
+    /// executable directory or race each other.
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "reld-bench-test-{}-{}-{tag}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn shim_name() -> &'static str {
+        if cfg!(windows) {
+            "ld.reld.exe"
+        } else {
+            "ld.reld"
+        }
+    }
+
+    #[test]
+    fn discover_reld_returns_explicit_path_when_it_exists() {
+        let dir = unique_tmp_dir("explicit");
+        let shim = dir.join("ld.reld");
+        std::fs::write(&shim, "#!/bin/sh\n").unwrap();
+
+        // Explicit takes precedence even when a sibling dir would also match.
+        let found = discover_reld_in(&Some(shim.clone()), Some(&dir));
+        assert_eq!(found, Some(shim));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discover_reld_returns_none_for_missing_explicit_path_and_empty_sibling() {
+        let dir = unique_tmp_dir("missing");
+        let missing = dir.join("ld.reld"); // never created
+        // Explicit does not exist and the sibling dir has no shim → None.
+        let found = discover_reld_in(&Some(missing), Some(&dir));
+        assert_eq!(found, None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discover_reld_falls_back_to_none_without_explicit_or_sibling_shim() {
+        let dir = unique_tmp_dir("empty");
+        let found = discover_reld_in(&None, Some(&dir));
+        assert_eq!(found, None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discover_reld_finds_sibling_shim() {
+        let dir = unique_tmp_dir("sibling");
+        let shim = dir.join(shim_name());
+        std::fs::write(&shim, "#!/bin/sh\n").unwrap();
+
+        let found = discover_reld_in(&None, Some(&dir));
+        assert_eq!(found, Some(shim));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discover_reld_returns_none_when_no_sibling_dir() {
+        // `current_exe()` failing (sibling dir = None) must degrade to None, not panic.
+        assert_eq!(discover_reld_in(&None, None), None);
+    }
 }


### PR DESCRIPTION
Implements a focused slice of **BR-4** (#17). Closes #23. Follows BR-1 (#20) and BR-2 (#22).

## What
Makes `reld` produce a **real measurement** in `reld-bench` instead of the hardcoded `n/a` — the user-facing goal of "reld participates in the benchmark."

reld is a native ELF linker on Linux (inherited from wild), driven via `clang -fuse-ld=<ld.reld>`; `ci/install-driver-shims.sh` already produces the `ld.reld` shim next to the `reld` binary. `reld-bench` now:
- discovers the shim (`--reld <path>` override, else `ld.reld` next to the bench binary),
- probes it once and times it per scenario **exactly like the other linkers**,
- prints the real seconds in the `reld` column, or a clean `n/a` + an explanatory `<!-- linker reld not available: ... -->` comment when no shim is found or the probe fails.

The published Linux benchmark now gets a real reld number. The clang/`-fuse-ld` harness can't drive reld on Windows/macOS (there reld integrates via rustc `-Clinker`), so it honestly shows `n/a` on those hosts — a Windows/macOS bench path is future work (BR-4b), along with the `SCHEMA_VERSION=2` `mode`/`engine`/`target` fields and the 3-OS workflow matrix.

## Contract
The stdout table scraped by `ci/benchmark_stats.py` is unchanged: same `## Link Benchmark: <triple>` heading, same columns in the same order with `reld` always last, same header/separator shapes, same `n/a` cell format.

## Testing
- Scoped to `crates/reld-testkit/src/bin/reld-bench.rs` only. `fmt`/`clippy -p reld-testkit --all-targets` clean.
- **Windows bench run** renders correctly: competitors measured, reld `n/a` with the new comment, table shape intact.
- **Rusqlite regression e2e** (the committed `ci/e2e/sqlite-bridge` fixture) still links via reld and runs (`OK`, exit 0) — the bridge is untouched by this change.
- Unit tests for shim discovery are **hermetic** (injected temp directory) and pass 5/5 under default `cargo test` parallelism.

## Review
Independent review confirmed the table-scraping contract is preserved and no competitor column can be dropped/misaligned. It reproduced a flaky test (two tests racing on the real executable directory); that is fixed here by making `discover_reld`'s sibling-dir lookup injectable so tests use temp dirs — verified non-flaky across repeated runs.

A real (non-`n/a`) reld measurement only occurs on Linux with a genuine shim, so it is validated by inspection + the discovery unit tests here and will be exercised by the Linux benchmark job, not by this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
