### PR TITLE
feat(bench): benchmark JSON schema v2 — target in history, per-series mode (BR-4b)

### DIFF
--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 HISTORY_MAX_LINES = 1000
 IMAGE_NAME = "benchmark-link.jpg"
 HEADING_PREFIX = "## Link Benchmark:"
@@ -143,6 +143,15 @@ def parse_benchmark_log(text: str) -> Report:
             report.rows.append(Row(scenario=scenario, series=series, seconds=value))
 
     return report
+
+
+def series_mode(series: str, runner_os: str) -> str:
+    """How a benchmark series was produced. reld is the subject; everything else is a
+    reference linker. reld links natively (wild ELF) on Linux and via the lld bridge
+    elsewhere."""
+    if series == "reld":
+        return "native" if runner_os == "Linux" else "bridge"
+    return "reference"
 
 
 def _tool_version(cmd: list[str]) -> str | None:
@@ -316,11 +325,17 @@ def write_outputs(report: Report, meta: dict[str, Any], out_dir: Path) -> None:
     # line for a run that never produced a chart corrupts the series permanently.
     render_jpg(report, meta, out_dir / IMAGE_NAME)
 
+    runner_os = meta.get("runner", {}).get("os", "")
     payload = {
         "schema_version": SCHEMA_VERSION,
         "metadata": meta,
         "results": [
-            {"scenario": r.scenario, "series": r.series, "seconds": r.seconds}
+            {
+                "scenario": r.scenario,
+                "series": r.series,
+                "seconds": r.seconds,
+                "mode": series_mode(r.series, runner_os),
+            }
             for r in report.rows
         ],
     }
@@ -333,6 +348,7 @@ def write_outputs(report: Report, meta: dict[str, Any], out_dir: Path) -> None:
             {
                 "ts": meta["generated_at"],
                 "sha": meta.get("git_sha", ""),
+                "target": meta.get("target", ""),
                 "results": payload["results"],
             },
             separators=(",", ":"),

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from ci.benchmark_stats import (  # noqa: E402
     collect_metadata,
     parse_benchmark_log,
+    series_mode,
     write_outputs,
 )
 
@@ -83,8 +84,20 @@ def test_write_outputs_produces_all_artifacts(tmp_path):
         assert (tmp_path / name).exists(), name
 
     payload = json.loads((tmp_path / "latest.json").read_text())
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert len(payload["results"]) == 15
+    for entry in payload["results"]:
+        assert "mode" in entry
+        if entry["series"] in ("bfd", "lld"):
+            assert entry["mode"] == "reference"
+
+
+def test_series_mode():
+    assert series_mode("reld", "Linux") == "native"
+    assert series_mode("reld", "Windows") == "bridge"
+    assert series_mode("reld", "Darwin") == "bridge"
+    assert series_mode("bfd", "Linux") == "reference"
+    assert series_mode("lld", "Windows") == "reference"
 
 
 def test_history_appends_and_caps(tmp_path):
@@ -94,6 +107,9 @@ def test_history_appends_and_caps(tmp_path):
     write_outputs(r, meta, tmp_path)
     lines = (tmp_path / "history.jsonl").read_text().strip().splitlines()
     assert len(lines) == 2
+    for line in lines:
+        entry = json.loads(line)
+        assert "target" in entry
 
 
 def test_render_refuses_empty(tmp_path):


### PR DESCRIPTION
Implements a foundational slice of **BR-4** (#17). Closes #25. Follows BR-4a (#24).

## What
Makes the published benchmark data multi-platform-ready — the prerequisite for putting Windows/macOS reld numbers on the graph without the series colliding.

- **`history.jsonl` lines now carry `target`** (e.g. `x86_64-linux`). Previously each line was `{ts, sha, results}`; once the benchmark runs on Linux + Windows + macOS, the appended history would be indistinguishable by OS. Now it's keyed.
- **`results` entries gain a `mode`**: `native` for reld on Linux (wild ELF engine), `bridge` for reld on Windows/macOS (lld subprocess), `reference` for the competitor linkers.
- **`SCHEMA_VERSION` 1 → 2.**

Schema/metadata only. The markdown-table contract, the parser (`parse_benchmark_log`), and the chart renderers (`render_jpg`/`render_html`) are untouched — they consume `Report.rows`, never the JSON — so chart output is unaffected.

## Compatibility
Nothing in the repo reads back existing `history.jsonl` content: `write_outputs` only appends raw text and re-truncates, and the workflow just curls the file down as bytes. Old lines (without `target`/`mode`) stay valid; new lines carry the extra fields. No published-series corruption risk.

## Out of scope (later BR-4 slices)
The 3-OS workflow matrix, per-OS competitor sets, the Windows/macOS rustc-based reld bench path, and renderer/chart changes.

## Testing
- Scoped to `ci/benchmark_stats.py` + `ci/tests/test_benchmark_stats.py`. `python -m pytest ci/tests -q` → **13 passed**.
- New `test_series_mode` covers reld×{Linux,Windows,Darwin} and reference×{bfd,lld}; the write_outputs test asserts `schema_version == 2` and `mode` presence; the history test asserts `target` in every line.
- Rusqlite `ci/e2e/sqlite-bridge` regression e2e still links via reld and runs (`OK`, exit 0) — this change doesn't touch reld.

## Review
Independent review returned APPROVE, confirming no history read-back / published-series corruption risk and that `series_mode` is correct for all real (series, os) combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
