### PR TITLE
test(ci): run reld-bench on the Windows and macOS CI legs (BR-4c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,25 @@ jobs:
           if ($output -notmatch "OK") { throw "sqlite-bridge e2e output did not contain OK marker" }
           if ($output -notmatch "linked SQLite") { throw "sqlite-bridge e2e output did not contain 'linked SQLite' marker" }
 
+      - name: Windows MSVC reld-bench smoke
+        if: matrix.kind == 'windows-msvc'
+        shell: pwsh
+        run: |
+          & $env:CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker lld --trials 2 --warmup 1 | Tee-Object benchmark-windows-msvc.md
+          if ($LASTEXITCODE -ne 0) { throw "reld-bench exited with code $LASTEXITCODE" }
+          if (-not (Test-Path benchmark-windows-msvc.md)) { throw "benchmark-windows-msvc.md not produced" }
+          $table = Get-Content benchmark-windows-msvc.md -Raw
+          if (-not ($table | Select-String -Pattern '## Link Benchmark:' -Quiet)) { throw "benchmark table missing '## Link Benchmark:' heading" }
+          if (-not ($table | Select-String -Pattern '\| *reld *\|' -Quiet)) { throw "benchmark table missing reld column" }
+
+      - name: Upload Windows MSVC benchmark artifact
+        if: always() && matrix.kind == 'windows-msvc'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-windows-msvc
+          path: benchmark-windows-msvc.md
+          if-no-files-found: warn
+
       - name: macOS native tests
         if: matrix.kind == 'macos-arm64'
         shell: bash
@@ -371,6 +390,23 @@ jobs:
           $CARGO_COMMAND test -p reld --bins 2>&1 | tee -a platform-tests.log
           $CARGO_COMMAND test -p reld --test acceptance-policy 2>&1 | tee -a platform-tests.log
           $CARGO_COMMAND test -p reld --test acceptance -- --list 2>&1 | tee -a platform-tests.log
+
+      - name: macOS reld-bench smoke
+        if: matrix.kind == 'macos-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker lld --trials 2 --warmup 1 | tee benchmark-macos-arm64.md
+          grep -q '## Link Benchmark:' benchmark-macos-arm64.md || { echo "benchmark table missing '## Link Benchmark:' heading" >&2; exit 1; }
+          grep -qE '\| *reld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing reld column" >&2; exit 1; }
+
+      - name: Upload macOS benchmark artifact
+        if: always() && matrix.kind == 'macos-arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-macos-arm64
+          path: benchmark-macos-arm64.md
+          if-no-files-found: warn
 
       - name: Publish Linux counts and skips
         if: always() && matrix.kind == 'linux-gnu'


### PR DESCRIPTION
Implements a step toward the 3-OS graph (phase **BR-4**, #17). Closes #27. Follows BR-4a (#24) and BR-4b (#26).

## What
Proves the benchmark harness runs on the **Windows and macOS** CI runners — the prerequisite before the published benchmark can trust those runners (the future 3-OS publish matrix). Adds one `reld-bench` step + one artifact-upload step to each of the `windows-msvc` and `macos-arm64` legs of `phase1-native`:

- Runs `reld-bench --release --cc clang --linker lld --trials 2 --warmup 1` after that leg's native-tests step (so the binary is already built).
- Asserts a well-formed table (`## Link Benchmark:` heading + a `| reld |` column), failing the step otherwise.
- Uploads the table as a per-OS artifact (`benchmark-windows-msvc` / `benchmark-macos-arm64`).

reld itself charts `n/a` on these legs — clang can't drive reld off-Linux (reld integrates via rustc `-Clinker` there); that's honest and expected. Unlike the nightly `benchmark-stats.yml`, this runs on **every PR**, so the cross-platform bench path stays continuously verified.

## Out of scope
The 3-OS publish/aggregation matrix in `benchmark-stats.yml`, multi-target rendering, and the Windows/macOS rustc-based reld measurement (so reld shows a real number off-Linux). Those remain separate follow-ups.

## Testing
- Scoped to `.github/workflows/ci.yml` only (36 insertions, 0 deletions — pure addition). YAML validated.
- **Local Windows run** of the same `reld-bench` command renders correctly: `lld` measured, `reld` = honest `n/a`, table shape intact — both assertions pass on it.
- Rusqlite `ci/e2e/sqlite-bridge` regression e2e still links via reld and runs (`OK`, exit 0) — this change doesn't touch reld.
- The new steps execute on this PR's own windows-msvc/macos CI legs.

## Review
Independent review verified (empirically) that a failed `reld-bench` run cannot be reported as a pass on either leg (`$LASTEXITCODE` survives `| Tee-Object` on Windows; `set -o pipefail` on macOS), that no other leg or the summary scripts are affected, and that the per-step linker env var from the BR-2 e2e step does not leak into this step. Its one MEDIUM nit — the macOS `grep` was looser than the Windows check — is fixed here (`grep -qE '\| *reld *\|'`, symmetric with Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
