### PR TITLE
docs: reframe reld as a polylinker + sync shipped 3-platform status

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,8 +1,16 @@
 # reld — Design
 
-> **Status: ELF/Linux linking works today, inherited from wild.** Windows/COFF and macOS/Mach-O
-> remain planned. Every performance figure in this document is a *target*, not a measurement;
-> reld-specific results will be published only after the Phase 2 CI benchmark exists.
+> **Status: reld links real programs on all three platforms today.** Linux/ELF links natively
+> (inherited from wild). Windows/COFF and macOS/Mach-O link via a **bridge** to `lld`
+> (`rust-lld`, shipped with every Rust toolchain) — see §4.4 and
+> [issue #17](https://github.com/zackees/reld/issues/17) for the phase history. Native COFF/
+> Mach-O codegen in reld's own engine is still future work. Every performance figure in this
+> document is a *target*, not a measurement, except the Linux `reld` column in the published
+> benchmark, which is now a real CI-generated measurement (§6). reld's bundling of multiple real
+> linkers per platform is the basis for the **polylinker** framing in §4.5 — a flag-aware router
+> that would pick the right bundled engine per requested link configuration (e.g. LTO). That
+> router is **design only** ([#30](https://github.com/zackees/reld/issues/30)); today's routing
+> is by platform/format alone.
 
 ## 1. Position
 
@@ -91,10 +99,18 @@ linker across all target platforms, because a fast non-LTO linker is what the in
 actually needs and because LTO interacts with almost every other subsystem — sequencing it
 early would slow down the thing the project exists to deliver.
 
-Until it is implemented, LTO flags (`-flto`, `--plugin`, `/LTCG`) must be **rejected or ignored
-with a clear, specific diagnostic** — never silently mislinked. Note that `wild` already has a
+**[DESIGN] Routing framing (not yet implemented).** reld does not plan to implement LTO natively
+in its own engine as the primary path. Instead, per the polylinker model (§4.5) and
+[#30](https://github.com/zackees/reld/issues/30), an LTO-shaped link request
+(`-flto`, `--plugin`, `/LTCG`, `/GL`) is meant to be **routed to whichever bundled engine already
+has real LTO support** — today that would be the `lld` bridge (§4.4), which does. This makes LTO
+*delegated*, not rejected, at the product level, while reld's own engine still owns zero LTO
+codegen. **The flag-aware router that would make this real does not exist yet** — see §4.5 for
+status. Until it lands, current behavior stands: LTO flags are **rejected or ignored with a
+clear, specific diagnostic** — never silently mislinked. Note that `wild` already has a
 linker-plugin LTO implementation with known issues; the fork inherits it, so on ELF the starting
-position is "partially works", not "absent". Do not delete that code.
+position is "partially works", not "absent". Do not delete that code. See
+[D13](docs/plan/01-DECISIONS.md) for the locked-decision record of this reframing.
 
 ## 4. Architecture
 
@@ -133,6 +149,90 @@ symbol table, parallel relocation and image write. `radlink`'s 4-way CAS hash tr
 
 Note the caution from §2.3 category 5: mold is *slower than lld single-threaded*. Parallelism
 must be the multiplier on an already-good serial path, not a substitute for one.
+
+### 4.4 Windows/macOS bridge (shipped) vs native backends (future)
+
+Native codegen for PE/COFF (§4.1, §2.1) and Mach-O is not yet built. In the meantime, reld
+**bridges** Windows and macOS links by delegating to `lld` — `lld-link` for COFF, `ld64.lld` for
+Mach-O — both drivers built into the `rust-lld` binary that ships with every Rust toolchain.
+reld discovers the linker, execs it with the original argv, and propagates its exit code and
+diagnostics verbatim; the bridge does no parsing or layout of its own. This is proven by CI
+end-to-end builds on the windows-msvc and macos-arm64 runners that link and run a real
+multi-crate program with a C dependency (`rusqlite` bundled/SQLite).
+
+The bridge is not a native backend and does not reduce the scope of §2.1 or §4.1 — it exists so
+Windows and macOS *work now* while the native engine (§4.1's format abstraction) is built out.
+When the native backend for a platform lands, it becomes the default for that platform and the
+bridge remains available for cases the native engine will not cover (e.g. LTO, full release
+fidelity). See [issue #17](https://github.com/zackees/reld/issues/17) for the phase history
+(BR-1 Windows bridge, BR-3 macOS bridge, BR-4 benchmark integration).
+
+### 4.5 Polylinker: flag-aware routing over bundled engines
+
+**[DESIGN — not yet implemented.]** §4.4 establishes that reld already bundles more than one
+real linker per platform (native engine + lld bridge) and already routes between them — but only
+on the platform/format axis, decided once at dispatch. [#30](https://github.com/zackees/reld/issues/30)
+proposes generalizing that into a **polylinker**: a router that also inspects the *requested
+configuration* (argv flags, env) and picks the bundled engine whose capabilities cover it. This
+section specifies that design so it can be implemented against (B8 in
+[#17](https://github.com/zackees/reld/issues/17), and the daemon router in
+[#19](https://github.com/zackees/reld/issues/19)); none of it is built yet.
+
+**Capability model.** Each bundled engine declares, in a static table (plus a cheap runtime
+probe where useful), which configurations it supports: LTO/ThinLTO, plugin interface,
+GC-sections, ICF, PDB vs. DWARF, identity/reproducible output, incremental linking, and which
+object formats (ELF/COFF/Mach-O) it drives. Example shape (illustrative, not a committed API):
+
+```
+Engine::Native   { formats: [Elf],                lto: false, incremental: true,  ... }
+Engine::LldBridge{ formats: [Coff, MachO, Elf],    lto: true,  incremental: false, ... }
+```
+
+**Routing policy.** On each link:
+
+1. Classify the requested configuration from argv (`-flto`, `--plugin`, `/LTCG`, `/GL`,
+   optimization level, `--icf`, `--gc-sections`, identity/strip flags) and env.
+2. Default to the fastest bundled engine for the platform — the dev-loop path.
+3. Escalate to a more capable bundled engine when the requested configuration demands it (e.g.
+   `-flto` on a platform where the native engine exists but doesn't support LTO → route to the
+   lld bridge instead).
+4. `--engine=<name>` / `RELD_ENGINE` forces a specific bundled engine, bypassing routing
+   entirely — for benchmarking and as an escape hatch.
+
+**Fallback ordering.** If the default (fastest) engine can't satisfy a requested capability, fall
+back to a capable bundled engine rather than failing outright, ordered by (capability match, then
+speed). If **no** bundled engine supports the requested configuration, that is a loud,
+specific error naming the unsupported feature — routing must never silently drop a
+correctness-affecting flag or produce a silent mislink.
+
+**Honesty and logging.** Every routing decision is meant to be logged at note level, in the same
+spirit as the bridge's existing `reld: delegating to <linker> (bridge mode)` line (§4.4, B5):
+`reld: engine=<name> (reason: default|flag:-flto|fallback:<cap>|override)`. The benchmark harness
+already records *which* engine produced a number (§6, the `mode`/`engine` field) — routing
+generalizes that same discipline to ordinary links, not just benchmarks.
+
+**Interaction with incremental linking.** LTO and the incremental daemon path (§4.2) are mutually
+exclusive on a given link (same as gold and MSVC). The router must select one engine and must not
+attempt to combine an LTO-routed link with the incremental path.
+
+**Relationship to native backends.** Routing does not reduce the scope of native COFF/Mach-O
+codegen (§4.1, §2.1, #7/#8) or native LTO (§3.1). It is a *product-level* answer — "can reld
+satisfy this link request today, using something it already bundles" — independent of how many
+of reld's own backends exist. New bundled backends are added by extending the capability table,
+not by forking a new routing path per engine; see
+[`agents/docs/polylinker.md`](agents/docs/polylinker.md).
+
+**Status summary:**
+
+| Component | Status |
+|---|---|
+| Multiple real linkers bundled per platform | Shipped (§4.4) |
+| Routing by platform/format at dispatch | Shipped (§4.4) |
+| Capability table | Design only |
+| Flag/config classification + routing | Design only |
+| Fallback-on-missing-capability | Design only |
+| `--engine=` / `RELD_ENGINE` override | Design only |
+| Per-decision routing log | Design only |
 
 ## 5. Honest risks
 

--- a/README.md
+++ b/README.md
@@ -6,37 +6,106 @@
 Linux, and macOS as co-equal targets, incremental linking as the architecture, and a mandate to
 beat `wild` in every measured category.
 
-> **Status: ELF/Linux linking works today, inherited from wild.** Windows/COFF and macOS/Mach-O
-> are not implemented. Every performance number below remains a **target**, not a measurement.
-> See [DESIGN.md](DESIGN.md).
+`reld` is a **polylinker**: it bundles multiple real linkers per platform (today: its own native
+engine plus an `lld` bridge) behind a single dispatch point, so it can run everywhere *and*,
+eventually, satisfy every requested link configuration by routing to whichever bundled engine
+supports it — fast by default, escalating only when the flags demand it. See
+["Polylinker" below](#polylinker-runs-everywhere-supports-everything-by-routing) for what that
+means concretely, and what part of it is shipped vs. designed.
+
+> **Status: reld links real programs on all three platforms today.** Linux/ELF links natively
+> (inherited from wild). Windows/COFF and macOS/Mach-O link via a **bridge** to `lld` (the
+> `rust-lld` that ships with every Rust toolchain) — proven by CI end-to-end builds on the
+> windows-msvc and macos-arm64 runners. Native COFF/Mach-O codegen in reld's own engine is still
+> **future work**. This bridge is today's *only* routing: it dispatches by platform/format, not
+> by requested flags. The flag-aware router described below (LTO/optimized links → a capable
+> bundled engine) is **design, not yet implemented** — see
+> [#30](https://github.com/zackees/reld/issues/30). Every performance number below remains a
+> **target**, not a measurement, except where noted. See [DESIGN.md](DESIGN.md) and
+> [#17](https://github.com/zackees/reld/issues/17) for the phase history.
 
 <!-- BENCHMARK:BEGIN -->
 [![Latest reld link benchmark](https://raw.githubusercontent.com/zackees/reld/benchmark-stats/benchmark-link.jpg)](https://github.com/zackees/reld/tree/benchmark-stats)
 
 *Auto-generated nightly by [`benchmark-stats.yml`](.github/workflows/benchmark-stats.yml) and
 published to the [`benchmark-stats` branch](https://github.com/zackees/reld/tree/benchmark-stats),
-alongside `latest.json` and `history.jsonl`. The `reld` column remains `n/a` until Phase 2's
-CI-generated measurement lands; Phase 0 does not publish unmeasured results. With
-[`soldr`](https://github.com/zackees/soldr) installed, reproduce locally with
-`soldr cargo run --release --bin reld-bench`.*
+alongside `latest.json` and `history.jsonl`. The `reld` column carries a real measurement on
+Linux (native engine, driven via `clang -fuse-ld`). It still charts `n/a` on Windows/macOS in
+this clang-based harness, because clang can't drive reld's bridge there — on those platforms reld
+links via rustc `-Clinker`, not `-fuse-ld`, so a bridge-mode bench number is future work, not a
+pending measurement being withheld. With [`soldr`](https://github.com/zackees/soldr) installed,
+reproduce locally with `soldr cargo run --release --bin reld-bench`.*
 <!-- BENCHMARK:END -->
 
 ## What it is
 
 `reld` is a source fork of `wild` at commit
-`5793935f1d8b05b9a978ce2089e16e718072e9a9`. The inherited ELF linker works now; the scope then
-expands toward native Windows and macOS backends and incremental linking:
+`5793935f1d8b05b9a978ce2089e16e718072e9a9`. The inherited ELF linker works now, and a bridge to
+`lld` makes Windows and macOS link today too; the scope then expands toward native Windows and
+macOS backends (reld's own COFF/Mach-O codegen) and incremental linking:
 
 | | `wild` | `reld` |
 |---|---|---|
-| Platforms | Linux / ELF | Linux / ELF now; **Windows and macOS planned** |
+| Platforms | Linux / ELF | **Linux / ELF native; Windows / macOS via lld bridge — all three work today** |
 | Incremental linking | on the roadmap | **the architecture** |
 | Optimizes for | the final link | the **edit → link → run** loop |
 | Release-quality output | required | **explicit non-goal** |
 
+### Bridge status
+
+| Platform | Format | Today | Native backend |
+|---|---|---|---|
+| Linux | ELF | **Native** — inherited wild core | Already native |
+| Windows | PE/COFF | **Bridge** — delegates to `lld-link` (`rust-lld`) | Future (issue #7) |
+| macOS | Mach-O | **Bridge** — delegates to `ld64.lld` (`rust-lld`) | Future (issue #8) |
+
+The bridge is a real, CI-proven delegation to the `lld` shipped with every Rust toolchain, not a
+stub — it links and runs a multi-crate, C-dependency (`rusqlite` bundled/SQLite) program on both
+platforms today. It is not reld's own codegen; see
+[issue #17](https://github.com/zackees/reld/issues/17) for the full BR-1…BR-4 phase history and
+[DESIGN.md](DESIGN.md) for the architecture.
+
+## Polylinker: runs everywhere, supports everything, by routing
+
+`reld` bundles more than one real linker per platform — today, its own native engine (Linux/ELF)
+and the `lld` bridge (Windows/COFF, macOS/Mach-O). That makes it a **polylinker**: a single
+binary that can, in principle, satisfy any requested link configuration by routing the request to
+whichever bundled engine already supports it, rather than by implementing every feature natively.
+Concretely (per [#30](https://github.com/zackees/reld/issues/30)):
+
+- **Fast by default.** Ordinary dev-loop links use the fastest engine available for the platform.
+- **Escalate on demand.** A configuration the fast engine can't do — the leading example is
+  **LTO** — gets routed to a bundled engine that *can* (e.g. `lld`'s real LTO/plugin support),
+  instead of being rejected.
+- **Fall back, never mislink.** If the fastest engine lacks a requested capability, reld falls
+  back to a capable bundled engine. If *no* bundled engine supports the configuration, that's a
+  loud, specific error — never a silent mislink.
+- **Explicit override.** `--engine=<name>` / `RELD_ENGINE` will force a specific bundled engine.
+- **Always observable.** Every routing decision is meant to be logged, so a user can always tell
+  which real linker ran and why.
+
+**What's shipped today vs. designed:**
+
+| | Status |
+|---|---|
+| Bundling multiple real linkers per platform | **Shipped** — native ELF engine + lld bridge, see "Bridge status" above |
+| Routing by platform/format (dispatch to native vs. bridge) | **Shipped** |
+| Routing by requested *flags/config* (e.g. `-flto` → capable engine) | **Design only** — not implemented. Tracked by [#30](https://github.com/zackees/reld/issues/30), decision **B8** in [#17](https://github.com/zackees/reld/issues/17), and the daemon router in [#19](https://github.com/zackees/reld/issues/19) |
+| Capability table per bundled engine | **Design only** |
+| Fallback ordering when the fast engine lacks a capability | **Design only** |
+| `--engine=` / `RELD_ENGINE` override | **Design only** |
+| Per-decision routing log line | **Design only** |
+
+Today, an `-flto` link is **not** automatically routed anywhere — see the Stretch goals section
+below for the current, honest state of LTO handling. See [DESIGN.md](DESIGN.md) for the full
+routing design and [`agents/docs/polylinker.md`](agents/docs/polylinker.md) for the contributor-
+facing summary.
+
 ## The four claims
 
-1. **Runs and targets everywhere** — Windows, Linux, macOS. Not "Linux plus ports."
+1. **Runs and targets everywhere** — Windows, Linux, macOS. Not "Linux plus ports." The
+   polylinker framing extends this claim toward "and supports every requested link
+   configuration," via routing — see above; that extension is design-stage, not shipped.
 2. **Incremental** — a one-object change reflows the image instead of rebuilding it.
    Target: **warm relink in low single-digit milliseconds**, largely independent of binary size.
 3. **Faster than `wild` in every category** — cold link, warm full link, warm incremental,
@@ -76,8 +145,16 @@ day, not the one that goes to customers.
 
 **(Thin)LTO is a stretch goal, not a non-goal** — deliberately sequenced after the fast linker
 on all three platforms. The inner loop is the priority; LTO touches nearly every subsystem and
-would slow down the thing this project exists to deliver. Until then, LTO flags are rejected
-with a clear diagnostic rather than silently mislinked.
+would slow down the thing this project exists to deliver.
+
+The framing for *how* LTO gets supported has changed: rather than reld ever implementing LTO
+natively in its own engine, `-flto`/`--plugin`/`/LTCG` links are meant to be **routed to a
+bundled engine that already does LTO** (the polylinker model above) — strictly better for the
+user than rejection, and still zero LTO codegen owned by reld. **That flag-aware router is
+design-stage, not implemented** ([#30](https://github.com/zackees/reld/issues/30), decision B8
+in [#17](https://github.com/zackees/reld/issues/17)); until it lands, LTO flags are rejected or
+ignored with a clear diagnostic rather than silently mislinked, per
+[D13](docs/plan/01-DECISIONS.md).
 
 ## Honest risks
 

--- a/agents/docs/polylinker.md
+++ b/agents/docs/polylinker.md
@@ -1,0 +1,67 @@
+# Polylinker: routing model for contributors
+
+This is a short orientation note for anyone (agent or human) adding a new linker backend or
+touching dispatch code. Full design: [`DESIGN.md`](../../DESIGN.md) §4.4–§4.5. Locked decision:
+[`docs/plan/01-DECISIONS.md`](../../docs/plan/01-DECISIONS.md) D13. Source issue:
+[#30](https://github.com/zackees/reld/issues/30) (extends B8 in
+[#17](https://github.com/zackees/reld/issues/17) and the daemon router in
+[#19](https://github.com/zackees/reld/issues/19)).
+
+## The idea
+
+`reld` is not one linker; it's a **polylinker** — a single binary that bundles multiple real
+linker engines per platform and routes each link request to whichever bundled engine can satisfy
+it. Two engines exist today: reld's own native engine (Linux/ELF) and the `lld` bridge
+(Windows/COFF via `lld-link`, macOS/Mach-O via `ld64.lld`). The framing generalizes: as more
+engines get bundled (e.g. `radlink` per `DESIGN.md` §7), routing decides per-link which one runs,
+rather than reld growing a fork of itself per engine.
+
+The point of the framing: a capability reld's fast default engine doesn't have (the leading
+example is LTO) doesn't have to mean "reject the flag." It can mean "hand this link to a bundled
+engine that already has it." reld's own engine still owns zero LTO codegen; the user still gets
+an LTO-capable link.
+
+## Shipped vs. designed — read this before assuming either
+
+| Layer | Status |
+|---|---|
+| Bundling more than one real linker engine per platform | **Shipped.** Native engine (Linux) + lld bridge (Windows, macOS). |
+| Routing by platform/format, decided once at dispatch | **Shipped.** This is today's entire routing logic — it is not flag-aware. |
+| Capability table (per-engine declared support for LTO, GC-sections, ICF, PDB/DWARF, incremental, formats, ...) | **Design only.** No such table exists in code yet. |
+| Flag-aware router (inspect argv/env, classify requested config, pick engine) | **Design only.** Not implemented. Tracked as B8 (#17) / #30 / #19. |
+| Fallback ordering when the default engine lacks a capability | **Design only.** |
+| `--engine=` / `RELD_ENGINE` explicit override | **Design only.** |
+| Per-decision routing log line (`reld: engine=<name> (reason: ...)`) | **Design only.** The bridge does log a `reld: delegating to <linker> (bridge mode)` note today (§4.4) — that's the shipped precedent the design generalizes, not the routing log itself. |
+| LTO delegated to a capable engine on request | **Design only.** Today, LTO flags are rejected/ignored with a diagnostic (D13); they are not routed anywhere yet. |
+
+If you're implementing B8/#19: this table is your scope. If you're just reading the docs to
+understand what reld does *today*, only the first two rows are real.
+
+## The rule for new backends
+
+When a new bundled engine is added (a new bridge target, or eventually a new native format
+backend), it goes in **behind the capability table** — declare what it supports, let the router
+(once it exists) pick it when appropriate — rather than as a parallel, hand-forked dispatch path
+or a duplicated set of `bail!`/flag-handling arms copied from an existing engine's integration.
+The two `bail!` sites replaced by the lld bridge (`DESIGN.md` §4.4, historically
+`crates/reld-core/src/lib.rs:266-267`) are the precedent for "one dispatch point per format, not
+one per engine."
+
+Concretely, avoid:
+
+- Forking a second copy of argv-parsing / flag-classification logic per engine.
+- Hardcoding a new engine's selection logic ad hoc at a call site instead of extending the
+  (eventual) capability table.
+- Silent behavior differences between engines for the same requested configuration — if two
+  bundled engines disagree on what a flag means, that's a capability-table entry and a routing
+  decision, not something to paper over.
+
+## Non-negotiables carried over from the design
+
+- **Never a silent mislink.** An unroutable/unsupported configuration is a loud, specific error,
+  not a best-effort fallback that silently drops a correctness-affecting flag.
+- **LTO and the incremental daemon path are mutually exclusive** on a given link (same as gold
+  and MSVC) — the router must not try to combine them.
+- **Routing decisions are observable.** Whatever engine actually ran, and why, should be visible
+  to the user (and, for the benchmark harness, recorded in the published data — see `DESIGN.md`
+  §6's `mode`/`engine` field).

--- a/docs/plan/01-DECISIONS.md
+++ b/docs/plan/01-DECISIONS.md
@@ -260,27 +260,50 @@ Phase 3 (`/OPT:REF` equivalent). **ICF is deferred indefinitely** — it is a si
 (radlink's is ~630 lines of generation-tagged concurrent hash tables) and reld optimizes the
 dev loop, where output size is irrelevant.
 
-## D13 — (Thin)LTO. **Locked: stretch goal, sequenced after the fast linker. Not a non-goal.**
+## D13 — (Thin)LTO. **REVISED after #30. Locked: routed to a capable bundled engine, not rejected outright. Native LTO codegen remains a deferred stretch goal, not a non-goal.**
 
-LTO is **deferred, not rejected**. The fast linker across Linux, Windows and macOS is the
-priority; LTO interacts with nearly every subsystem (symbol resolution, archive extraction,
-section layout, debug info) and pulling it forward would slow down the thing the project exists
-to deliver. See `DESIGN.md` §3.1.
+**Original text (superseded below):** LTO was deferred, with its flags rejected/ignored via a
+specific diagnostic until reld implemented LTO natively per format.
+
+**Revision (per [#30](https://github.com/zackees/reld/issues/30), the polylinker issue, and
+decision **B8** in [#17](https://github.com/zackees/reld/issues/17)):** reld already bundles more
+than one real linker per platform (the native engine + the `lld` bridge, see `DESIGN.md` §4.4).
+Once that's true, "reject LTO" is no longer the honest best available answer — a bundled engine
+(`lld`) already has real LTO support. The product-level decision changes from *reject* to
+*route*:
+
+- **LTO is delegated to a capable bundled engine** (the polylinker's flag-aware router,
+  `DESIGN.md` §4.5) rather than rejected, wherever a bundled engine supports it. This is strictly
+  better for the user than a rejection diagnostic, and reld's own engine still implements zero
+  LTO codegen.
+- **Native LTO codegen in reld's own engine remains future work**, sequenced after the fast
+  linker across all three platforms — unchanged from the original rationale in `DESIGN.md` §3.1.
+  The revision is about *how the user's LTO request is handled today*, not about reld growing
+  native LTO sooner.
+- **The flag-aware router itself is not yet implemented.** This decision records the target
+  policy for B8/#17 and the daemon router (#19) to implement against; it does not claim the
+  routing exists. **Until the router lands, current behavior is unchanged from the original
+  text**: LTO flags are rejected or ignored with a specific diagnostic naming the feature — never
+  silently mislinked.
 
 Consequences for every phase:
 
 - **Do not delete wild's linker-plugin LTO.** The fork inherits a working-with-known-issues
   implementation on ELF (`linker_plugins.rs`, ~1467 LOC, driven from `lib.rs:325` and
   `lib.rs:374`). P2 must not regress it; pin current behaviour with a smoke test.
-- **Until LTO is implemented on a given format, its flags are rejected or ignored with a
+- **Until the flag-aware router (B8) is implemented, LTO flags are rejected or ignored with a
   specific diagnostic naming the feature** — never silently mislinked. This matters most where
   build systems pass the flag unconditionally: rustc passes `-plugin` on the MinGW gcc path
-  (unless `-fno-use-linker-plugin`), and MSBuild passes `/LTCG`.
-- When LTO does land it will be **incompatible with the incremental path** — gold and MSVC both
-  fall back to a full link for it — so trigger 13 in `09-INCREMENTAL.md` §I1 stays permanent.
+  (unless `-fno-use-linker-plugin`), and MSBuild passes `/LTCG`. Once B8 lands, the same flags
+  route to a capable bundled engine instead of producing that diagnostic.
+- When native LTO does land in reld's own engine it will still be **incompatible with the
+  incremental path** — gold and MSVC both fall back to a full link for it — so trigger 13 in
+  `09-INCREMENTAL.md` §I1 stays permanent. Routing an LTO link to the `lld` bridge is likewise
+  incompatible with the incremental path, for the same reason.
 
 Do not treat "LTO is a non-goal" as current. Earlier drafts of `DESIGN.md` and `README.md` said
-that; both have been corrected.
+that; both have been corrected. Do not treat "the flag-aware router routes LTO today" as current
+either — see `agents/docs/polylinker.md` for the shipped-vs-designed summary.
 
 ## D12 — Test oracle. **Locked: semantic differential, not byte comparison.**
 


### PR DESCRIPTION
Closes #30 (polylinker design + docs). Closes #32 (factual bridge-status sync). Docs only — no code.

## Two things, kept strictly distinct as **shipped** vs **designed**

### Shipped (factual status correction, #32)
The README/DESIGN previously said Windows/macOS are "not implemented / planned" — false after BR-1 (#20) and BR-3 (#31). Corrected to the truth:
- reld links real programs on **all three platforms today**: Linux/ELF **native** (inherited wild core), Windows/COFF and macOS/Mach-O via a **bridge** to `lld` (`lld-link` / `ld64.lld` from `rust-lld`), CI-proven by the rusqlite/C-linking e2e on the windows-msvc and macos-arm64 runners.
- Native COFF/Mach-O codegen (#7/#8) is still **future**; the bridge makes those platforms work now.
- New "Bridge status" table (native vs bridge per platform); benchmark caption corrected (real reld number on Linux; `n/a` on Win/mac in the clang harness because reld links via rustc `-Clinker` there, not `-fuse-ld`).

### Designed (polylinker framing, #30)
Reframes reld as a **polylinker** — a flag-aware router over the bundled engines that satisfies any link configuration by routing to whichever bundled linker supports it (fast default, escalate on demand, fallbacks, never a silent mislink), with **LTO delegated to a capable engine** rather than rejected.
- New DESIGN §4.5 (capability model, routing policy, fallback ordering, honesty/logging).
- New `agents/docs/polylinker.md` — contributor note with an explicit shipped-vs-designed status table and the rule that new backends go behind the capability table, not as forks.
- Decision **D13** revised (original text preserved and marked superseded) from "LTO deferred/rejected" to "LTO delegated to a capable bundled engine; native LTO codegen still future."

## Honesty guardrail
The flag-aware router, capability table, fallbacks, `--engine=`/`RELD_ENGINE`, and LTO-delegation are **DESIGN, not implemented** — today's only routing is by platform/format at dispatch. Every doc marks this explicitly (each new section carries a shipped-vs-designed status table). LTO flags are still rejected/ignored today until B8 (#17) lands; the router implementation is tracked by B8 and the daemon router (#19). Independent review confirmed no sentence claims the router is implemented, bridge stays distinct from native codegen, and the shipped status is factually accurate.

## Testing
Docs only; the rusqlite `ci/e2e/sqlite-bridge` regression still returns `OK` (reld untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
