### PR TITLE
feat(bench): turn on the reld benchmarker — reld charts real numbers (fix output-path bug, surface failures)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -64,6 +64,12 @@ jobs:
             "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/benchmark-stats/history.jsonl" \
             || : > benchmark-stats/history.jsonl
 
+      - name: Build reld and install driver shims
+        run: |
+          set -euo pipefail
+          cargo build --release -p reld
+          bash ci/install-driver-shims.sh release
+
       - name: Run benchmark and render
         env:
           RELD_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/benchmark-stats

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -167,6 +167,10 @@ fn main() -> Result<()> {
     }
     println!("----:|");
 
+    // (linker display name, scenario name, error) for every `time_link` failure, so the
+    // linker's stderr isn't silently discarded behind the table's `n/a` cell — see #38.
+    let mut failures: Vec<(String, String, String)> = Vec::new();
+
     for (name, spec) in scenarios() {
         let dir = root.join(name.split_whitespace().next().unwrap_or("s"));
         let _ = std::fs::remove_dir_all(&dir);
@@ -181,13 +185,19 @@ fn main() -> Result<()> {
             }
             match time_link(&args, &dir, &objects, linker) {
                 Ok(d) => print!(" {:.4} |", d.as_secs_f64()),
-                Err(_) => print!(" n/a |"),
+                Err(e) => {
+                    failures.push((linker.clone(), name.clone(), e.to_string()));
+                    print!(" n/a |");
+                }
             }
         }
         match (&reld_shim_str, reld_ok) {
             (Some(linker), true) => match time_link(&args, &dir, &objects, linker) {
                 Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
-                Err(_) => println!(" n/a |"),
+                Err(e) => {
+                    failures.push(("reld".to_string(), name.clone(), e.to_string()));
+                    println!(" n/a |");
+                }
             },
             _ => println!(" n/a |"),
         }
@@ -202,7 +212,42 @@ fn main() -> Result<()> {
     if let Some(reason) = reld_unavailable_reason {
         println!("<!-- linker reld not available: {reason} -->");
     }
+    for (linker, scenario, error) in &failures {
+        println!("{}", format_failure_comment(linker, scenario, error));
+    }
     Ok(())
+}
+
+/// Max length (in characters) of the sanitized error text embedded in a failure comment, so a
+/// huge linker stderr dump doesn't bloat the log.
+const FAILURE_COMMENT_ERROR_LIMIT: usize = 500;
+
+/// How many leading lines of the linker's error output to keep before sanitizing/truncating.
+const FAILURE_COMMENT_ERROR_LINES: usize = 3;
+
+/// Format a `time_link` failure as a single-line HTML comment, so the linker's stderr is visible
+/// in the benchmark output instead of being silently discarded behind the table's `n/a` cell
+/// (see #38). The result is always safe to emit as one `<!-- ... -->` line: it never contains a
+/// literal `-->` sequence or an embedded newline, and the error text is capped in length.
+fn format_failure_comment(linker: &str, scenario: &str, error: &str) -> String {
+    let head: String = error
+        .lines()
+        .take(FAILURE_COMMENT_ERROR_LINES)
+        .collect::<Vec<_>>()
+        .join("; ");
+    let collapsed = head.split_whitespace().collect::<Vec<_>>().join(" ");
+    let neutralized = collapsed.replace("-->", "- >");
+    let truncated: String = if neutralized.chars().count() > FAILURE_COMMENT_ERROR_LIMIT {
+        let mut s: String = neutralized
+            .chars()
+            .take(FAILURE_COMMENT_ERROR_LIMIT)
+            .collect();
+        s.push_str("...");
+        s
+    } else {
+        neutralized
+    };
+    format!("<!-- linker {linker} link failed ({scenario}): {truncated} -->")
 }
 
 fn target_triple() -> String {
@@ -373,5 +418,42 @@ mod tests {
     fn discover_reld_returns_none_when_no_sibling_dir() {
         // `current_exe()` failing (sibling dir = None) must degrade to None, not panic.
         assert_eq!(discover_reld_in(&None, None), None);
+    }
+
+    #[test]
+    fn format_failure_comment_neutralizes_collapses_and_caps() {
+        // Embedded `-->` must not terminate the comment early, newlines must collapse so the
+        // whole thing stays one line, and a huge dump must be capped in length.
+        let huge_line = "x".repeat(1000);
+        let error =
+            format!("first line has --> in it\nsecond line\n{huge_line}\nfourth line dropped");
+        let comment = format_failure_comment("reld", "large (512 units)", &error);
+
+        assert_eq!(
+            comment.matches("-->").count(),
+            1,
+            "the only `-->` in the comment must be the closing delimiter: {comment}"
+        );
+        assert!(comment.ends_with("-->"));
+        assert!(!comment.contains('\n'), "must be a single line: {comment}");
+        assert!(comment.contains("reld"));
+        assert!(comment.contains("large (512 units)"));
+        assert!(comment.starts_with("<!-- linker reld link failed (large (512 units)): "));
+        assert!(
+            comment.len() < error.len(),
+            "must be capped shorter than the raw error: {comment}"
+        );
+        // Only the first FAILURE_COMMENT_ERROR_LINES lines are considered, so the dropped
+        // fourth line's marker text must not appear.
+        assert!(!comment.contains("fourth line dropped"));
+    }
+
+    #[test]
+    fn format_failure_comment_passes_through_short_single_line_errors() {
+        let comment = format_failure_comment("bfd", "small (16 units)", "undefined symbol: foo");
+        assert_eq!(
+            comment,
+            "<!-- linker bfd link failed (small (16 units)): undefined symbol: foo -->"
+        );
     }
 }

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -324,8 +324,27 @@ fn probe_linker(cc: &str, linker: &str, root: &Path) -> Result<bool> {
     Ok(cmd.output().map(|o| o.status.success()).unwrap_or(false))
 }
 
+/// Build a filesystem-safe output filename for a linker's benchmark artifact. `linker` is the
+/// `-fuse-ld=` value, which for reld is the **absolute path** to the `ld.reld` shim; embedding it
+/// raw would make `dir.join` interpret the path separators as nested directories that don't
+/// exist, so reld (correctly) fails to open its output. Flatten separators so the artifact lands
+/// directly in `dir`.
+fn bench_output_name(linker: &str) -> String {
+    let safe: String = linker
+        .chars()
+        .map(|c| {
+            if matches!(c, '/' | '\\' | ':') {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect();
+    format!("bench-{safe}.bin")
+}
+
 fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Result<Duration> {
-    let out = dir.join(format!("bench-{linker}.bin"));
+    let out = dir.join(bench_output_name(linker));
 
     for _ in 0..args.warmup {
         link_once(args, objects, linker, &out)?;
@@ -454,6 +473,24 @@ mod tests {
         assert_eq!(
             comment,
             "<!-- linker bfd link failed (small (16 units)): undefined symbol: foo -->"
+        );
+    }
+
+    #[test]
+    fn bench_output_name_flattens_path_separators() {
+        // A short name is untouched...
+        assert_eq!(bench_output_name("lld"), "bench-lld.bin");
+        // ...but an absolute path (the reld shim) must not embed separators, or `dir.join` would
+        // create nonexistent nested directories and the link would fail to open its output.
+        let name = bench_output_name("/home/runner/reld/target/release/ld.reld");
+        assert_eq!(name, "bench-_home_runner_reld_target_release_ld.reld.bin");
+        assert!(
+            !name.contains('/'),
+            "no separators in the flattened name: {name}"
+        );
+        assert_eq!(
+            bench_output_name(r"C:\tc\ld.reld"),
+            "bench-C__tc_ld.reld.bin"
         );
     }
 }


### PR DESCRIPTION
**reld now participates in the benchmark with real numbers.** Closes #36, #37, #38.

Three stacked changes that together turn the reld column from `n/a` into a real measurement:

1. **Turn on the benchmarker (#36)** — `benchmark-stats.yml` builds `reld` (release) and runs `ci/install-driver-shims.sh` before the bench, so `reld-bench` discovers the `ld.reld` shim.
2. **Surface link failures (#38)** — `reld-bench` no longer silently charts `n/a` when a link fails; it emits `<!-- linker <name> link failed (<scenario>): <error> -->` (sanitized single-line: `-->` neutralized, whitespace-collapsed, length-capped). This is an honesty fix *and* how the real cause was found.
3. **Fix the output-path bug (resolves #37)** — the surfaced error showed reld failing to *open its output file* at a bogus nested path: `time_link` built `bench-{linker}.bin`, and for reld `{linker}` is the **absolute shim path**, so `dir.join` treated its `/` as directories. Flatten `/`, `\`, `:` in the output name (`bench_output_name` helper + test). **reld's ELF linking was never broken** — #37's "reld fails the workloads" was this harness bug.

## Result — dispatched benchmark on this branch (Linux runner)

| Scenario | bfd | lld | mold | wild | **reld** |
|---|---|---|---|---|---|
| small (16) | 0.039 | 0.0414 | 0.0366 | 0.0282 | **0.0277** |
| medium (128) | 0.0614 | 0.0507 | 0.0553 | 0.0328 | **0.0328** |
| large (512) | 0.1996 | 0.0911 | 0.1182 | 0.0523 | **0.051** |

reld charts a real native-engine number (`mode: native`) and is competitive — matching/edging upstream `wild` and ahead of lld/mold/bfd. (Windows/macOS still chart `n/a` in this clang harness — reld links there via rustc `-Clinker`, not `-fuse-ld` — a separate follow-up, not this PR.)

## Testing
- `reld-bench.rs`: fmt/clippy clean; unit tests for `format_failure_comment` (sanitization) and `bench_output_name` (path flattening) pass.
- **Dispatched the benchmark on this branch twice**: first surfaced the exact error; after the fix, reld charts the numbers above.
- Rusqlite `ci/e2e/sqlite-bridge` regression still links via reld and runs (`OK`) — the bridge is untouched.
- Publish step + its default-branch guard untouched (dispatch on this branch produced artifacts without publishing).

## Review
Independent review of the surfacing change: APPROVE (adversarially verified the failure comment can never break the `benchmark_stats.py` scrape or emit a malformed/`-->`/multi-line comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
