### PR TITLE
test(ci): self-host — link reld with reld-link on windows-msvc (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,20 @@ jobs:
           path: benchmark-windows-msvc.md
           if-no-files-found: warn
 
+      - name: Windows MSVC self-host (link reld with reld-link)
+        if: matrix.kind == 'windows-msvc'
+        shell: pwsh
+        run: |
+          $reld = "$env:GITHUB_WORKSPACE\target\debug\reld-link.exe"
+          if (-not (Test-Path $reld)) { throw "reld-link.exe not found at $reld" }
+          $env:CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = $reld
+          & $env:CARGO_COMMAND build -p reld --bin reld
+          if ($LASTEXITCODE -ne 0) { throw "self-host build (link reld with reld-link) failed" }
+          $out = & "$env:GITHUB_WORKSPACE\target\debug\reld.exe" --version 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "self-linked reld --version failed (exit $LASTEXITCODE)" }
+          Write-Output $out
+          if ($out -notmatch 'Reld') { throw "self-linked reld --version output missing 'Reld' marker" }
+
       - name: macOS native tests
         if: matrix.kind == 'macos-arm64'
         shell: bash


### PR DESCRIPTION
Implements #40. Closes #40.

## What
Extends the Windows COFF bridge CI coverage from the small rusqlite fixture (BR-2) to a **large, real Rust binary — reld itself** (~17MB: mimalloc, `object`, `clap`, many crates). Self-host is the strongest single correctness signal (P2/#6).

The new windows-msvc step, after the workspace build produces `reld-link.exe`, sets `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER` to it and `cargo build -p reld --bin reld` — the linker-env change invalidates reld.exe's link fingerprint, so cargo **relinks reld through the bridge** (reld-link → lld-link). Then it runs the self-linked `reld --version`, asserting exit 0 and the `Reld` marker.

## Testing
- **Locally verified end-to-end**: built reld.exe with the default linker, then set the reld-link env and rebuilt — reld.exe genuinely relinked through reld-link (mtime changed, real relink), and `reld --version` → `Reld <sha> (compatible with GNU linkers)`, exit 0. So the step exercises real self-host, not a cached no-op.
- Rusqlite `ci/e2e/sqlite-bridge` regression still `OK` (bridge untouched).
- YAML valid; scope is only `.github/workflows/ci.yml`, only the windows-msvc leg.

## Review
Independent review: APPROVE — confirmed the linker-env change forces a real relink (empirically verified), three explicit gates prevent a false-green (build exit, run exit, `Reld` marker), no env leakage to later steps, scope clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)