### PR TITLE
ci: build and run linker artifacts on three hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,20 @@ jobs:
           path: benchmark-windows-msvc.md
           if-no-files-found: warn
 
+      - name: Windows MSVC self-host (link reld with reld-link)
+        if: matrix.kind == 'windows-msvc'
+        shell: pwsh
+        run: |
+          $reld = "$env:GITHUB_WORKSPACE\target\debug\reld-link.exe"
+          if (-not (Test-Path $reld)) { throw "reld-link.exe not found at $reld" }
+          $env:CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = $reld
+          & $env:CARGO_COMMAND build -p reld --bin reld
+          if ($LASTEXITCODE -ne 0) { throw "self-host build (link reld with reld-link) failed" }
+          $out = & "$env:GITHUB_WORKSPACE\target\debug\reld.exe" --version 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "self-linked reld --version failed (exit $LASTEXITCODE)" }
+          Write-Output $out
+          if ($out -notmatch 'Reld') { throw "self-linked reld --version output missing 'Reld' marker" }
+
       - name: macOS native tests
         if: matrix.kind == 'macos-arm64'
         shell: bash

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -61,17 +61,37 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo 'CC_x86_64_pc_windows_msvc=clang-cl' >> "$GITHUB_ENV"
-          echo 'CXX_x86_64_pc_windows_msvc=clang-cl' >> "$GITHUB_ENV"
-          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=lld-link' >> "$GITHUB_ENV"
+          echo 'CC_x86_64_pc_windows_msvc=' >> "$GITHUB_ENV"
+          echo 'CXX_x86_64_pc_windows_msvc=' >> "$GITHUB_ENV"
+          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=' >> "$GITHUB_ENV"
+          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS=' >> "$GITHUB_ENV"
+
+      - name: Clear cross-target linker overrides for native host build
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'CARGO_ENCODED_RUSTFLAGS=' >> "$GITHUB_ENV"
+          echo 'RUSTFLAGS=' >> "$GITHUB_ENV"
+          echo 'SOLDR_LINKER=platform-default' >> "$GITHUB_ENV"
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin)
+              echo 'SDKROOT=' >> "$GITHUB_ENV"
+              echo 'CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=' >> "$GITHUB_ENV"
+              echo 'CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=' >> "$GITHUB_ENV"
+              ;;
+            x86_64-unknown-linux-gnu)
+              echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=' >> "$GITHUB_ENV"
+              echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=' >> "$GITHUB_ENV"
+              ;;
+          esac
 
       - name: Build linker
         shell: bash
         run: |
           set -euo pipefail
-          soldr cargo build --locked --release --package reld --bin reld-link --target "${{ matrix.target }}"
+          soldr cargo build --locked --release --package reld --bin reld-link
           mkdir -p package
-          cp "target/${{ matrix.target }}/release/${{ matrix.executable }}" "package/${{ matrix.executable }}"
+          cp "target/release/${{ matrix.executable }}" "package/${{ matrix.executable }}"
 
       - name: Smoke build artifact
         shell: bash

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -1,0 +1,118 @@
+name: Linker artifacts
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build / ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            artifact: reld-link-linux-x86_64
+            executable: reld-link
+          - name: macos
+            runner: macos-14
+            target: aarch64-apple-darwin
+            artifact: reld-link-macos-arm64
+            executable: reld-link
+          - name: windows
+            runner: windows-2022
+            target: x86_64-pc-windows-msvc
+            artifact: reld-link-windows-x86_64
+            executable: reld-link.exe
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+
+      - name: Setup Soldr target lifecycle
+        id: setup
+        uses: zackees/setup-soldr@main
+        with:
+          cross-targets: ${{ matrix.target }}
+          cache: false
+          prebuild-deps: none
+          linker: platform-default
+
+      - name: Assert target contract
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          CAPABILITIES: ${{ steps.setup.outputs.target-capabilities-json }}
+        run: |
+          set -euo pipefail
+          python -c 'import json, os; p=json.loads(os.environ["CAPABILITIES"]); assert p["canonicalTarget"] == os.environ["TARGET"]; assert "build" in p["supportedOperations"]'
+
+      - name: Build linker
+        shell: bash
+        run: |
+          set -euo pipefail
+          soldr build --locked --release --package reld --bin reld-link --target "${{ matrix.target }}"
+          mkdir -p package
+          cp "target/${{ matrix.target }}/release/${{ matrix.executable }}" "package/${{ matrix.executable }}"
+
+      - name: Smoke build artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s "package/${{ matrix.executable }}"
+          "package/${{ matrix.executable }}" --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: package/${{ matrix.executable }}
+          if-no-files-found: error
+
+  host:
+    name: Host smoke / ${{ matrix.name }}
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            runner: ubuntu-24.04
+            artifact: reld-link-linux-x86_64
+            executable: reld-link
+          - name: macos
+            runner: macos-14
+            artifact: reld-link-macos-arm64
+            executable: reld-link
+          - name: windows
+            runner: windows-2022
+            artifact: reld-link-windows-x86_64
+            executable: reld-link.exe
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: package
+
+      - name: Run deployed linker on host
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          set -euo pipefail
+          chmod +x "package/${{ matrix.executable }}"
+          "package/${{ matrix.executable }}" --version
+
+      - name: Run deployed linker on host
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          & ".\package\${{ matrix.executable }}" --version
+          if ($LASTEXITCODE -ne 0) { throw "deployed linker exited with $LASTEXITCODE" }

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -63,7 +63,7 @@ jobs:
           set -euo pipefail
           echo 'CC_x86_64_pc_windows_msvc=clang-cl' >> "$GITHUB_ENV"
           echo 'CXX_x86_64_pc_windows_msvc=clang-cl' >> "$GITHUB_ENV"
-          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=clang-cl' >> "$GITHUB_ENV"
+          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=lld-link' >> "$GITHUB_ENV"
 
       - name: Build linker
         shell: bash

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -91,7 +91,9 @@ jobs:
           set -euo pipefail
           soldr cargo build --locked --release --package reld --bin reld-link
           mkdir -p package
-          cp "target/release/${{ matrix.executable }}" "package/${{ matrix.executable }}"
+          built="$(find target -type f \( -name 'reld-link' -o -name 'reld-link.exe' \) -print -quit)"
+          test -n "$built"
+          cp "$built" "package/${{ matrix.executable }}"
 
       - name: Smoke build artifact
         shell: bash

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -56,11 +56,20 @@ jobs:
           set -euo pipefail
           python -c 'import json, os; p=json.loads(os.environ["CAPABILITIES"]); assert p["canonicalTarget"] == os.environ["TARGET"]; assert "build" in p["supportedOperations"]'
 
+      - name: Normalize MSVC compiler drivers
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'CC_x86_64_pc_windows_msvc=clang-cl' >> "$GITHUB_ENV"
+          echo 'CXX_x86_64_pc_windows_msvc=clang-cl' >> "$GITHUB_ENV"
+          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=clang-cl' >> "$GITHUB_ENV"
+
       - name: Build linker
         shell: bash
         run: |
           set -euo pipefail
-          soldr build --locked --release --package reld --bin reld-link --target "${{ matrix.target }}"
+          soldr cargo build --locked --release --package reld --bin reld-link --target "${{ matrix.target }}"
           mkdir -p package
           cp "target/${{ matrix.target }}/release/${{ matrix.executable }}" "package/${{ matrix.executable }}"
 

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -45,7 +45,7 @@ jobs:
           cross-targets: ${{ matrix.target }}
           cache: false
           prebuild-deps: none
-          linker: platform-default
+          linker: fast
 
       - name: Assert target contract
         shell: bash

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -63,7 +63,7 @@ jobs:
           set -euo pipefail
           echo 'CC_x86_64_pc_windows_msvc=' >> "$GITHUB_ENV"
           echo 'CXX_x86_64_pc_windows_msvc=' >> "$GITHUB_ENV"
-          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=' >> "$GITHUB_ENV"
+          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=link.exe' >> "$GITHUB_ENV"
           echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS=' >> "$GITHUB_ENV"
 
       - name: Clear cross-target linker overrides for native host build
@@ -76,11 +76,11 @@ jobs:
           case "${{ matrix.target }}" in
             aarch64-apple-darwin)
               echo 'SDKROOT=' >> "$GITHUB_ENV"
-              echo 'CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=' >> "$GITHUB_ENV"
+              echo 'CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=clang' >> "$GITHUB_ENV"
               echo 'CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=' >> "$GITHUB_ENV"
               ;;
             x86_64-unknown-linux-gnu)
-              echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=' >> "$GITHUB_ENV"
+              echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc' >> "$GITHUB_ENV"
               echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=' >> "$GITHUB_ENV"
               ;;
           esac

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -41,6 +41,7 @@ jobs:
         id: setup
         uses: zackees/setup-soldr@main
         with:
+          version: 0.8.43
           cross-targets: ${{ matrix.target }}
           cache: false
           prebuild-deps: none

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -72,7 +72,7 @@ jobs:
           set -euo pipefail
           echo 'CARGO_ENCODED_RUSTFLAGS=' >> "$GITHUB_ENV"
           echo 'RUSTFLAGS=' >> "$GITHUB_ENV"
-          echo 'SOLDR_LINKER=platform-default' >> "$GITHUB_ENV"
+          echo 'SOLDR_LINKER=default' >> "$GITHUB_ENV"
           case "${{ matrix.target }}" in
             aarch64-apple-darwin)
               echo 'SDKROOT=' >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- build the `reld-link` linker on Linux, macOS, and Windows runners
- use setup-soldr's canonical `cross-targets` lifecycle and assert the target contract
- upload each platform binary, download it into a matching host job, and run `--version`

## Coordination

- Depends on https://github.com/zackees/setup-soldr/pull/462
- setup-soldr depends on https://github.com/zackees/soldr/pull/2324

## Checks

- Python YAML parse passed
- git diff --check passed
- The PR also contains the existing Windows self-host CI commit from the source branch