### PR TITLE
feat(bench): publish separate per-target graphs

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -66,6 +66,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          brew untap aws/tap || true
           brew install llvm
           echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
           command -v clang

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -1,14 +1,8 @@
 name: Benchmark Stats
 
-# Runs the link benchmark against reference linkers and force-pushes the rendered chart to
-# an orphan `benchmark-stats` branch, which the README embeds via raw.githubusercontent.com.
-#
-# NOTE: raw.githubusercontent.com only serves unauthenticated requests for PUBLIC repos.
-# While reld is private the README image will 404 — the pipeline still runs and the
-# artifacts are still uploaded, so nothing is lost by running it early.
-#
-# Linux-only by construction: the inherited linker emits ELF only, so it cannot be benchmarked on Windows
-# or macOS runners. Those platforms get lld and the system linker once reld has backends.
+# Run one independently rendered benchmark for each supported target. The publish job is still
+# guarded to the default branch: dispatching this workflow on a PR validates every runner and
+# uploads all generated data without changing the public benchmark branch.
 
 on:
   workflow_dispatch:
@@ -24,63 +18,127 @@ permissions:
 
 jobs:
   benchmark:
-    name: Generate benchmark stats
-    runs-on: ubuntu-24.04
+    name: Generate ${{ matrix.target }} benchmark
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-linux
+          - runner: windows-2022
+            target: x86_64-pc-windows-msvc
+          - runner: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@1.94.1
 
-      - name: Install linkers
+      - name: Install Linux linkers
+        if: runner.os == 'Linux'
+        shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y clang lld mold python3-pil
-
-          # wild is not packaged. A failure here is not fatal — reld-bench probes each
-          # linker and reports an unavailable one as n/a, which shows up in the chart.
           cargo install --locked wild-linker || echo "wild unavailable; will report n/a"
-
-          # `-fuse-ld=wild` makes clang search for `ld.wild`, but the crate installs a
-          # binary called `wild`. Without this alias wild is silently reported as n/a
-          # forever, which looks like a working pipeline and is not.
           if command -v wild >/dev/null 2>&1; then
             ln -sf "$(command -v wild)" "$HOME/.cargo/bin/ld.wild"
           fi
-
-          # Fail loudly if a linker we expect is missing, rather than quietly charting n/a.
           for l in ld.lld ld.mold; do
             command -v "$l" >/dev/null || { echo "::error::$l missing"; exit 1; }
           done
-          command -v ld.wild >/dev/null || echo "::warning::ld.wild missing; wild will chart as n/a"
 
-      - name: Carry forward history
+      - name: Install Windows linkers
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install llvm --no-progress --yes
+          "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { throw "clang missing" }
+          if (-not (Get-Command lld-link -ErrorAction SilentlyContinue)) { throw "lld-link missing" }
+          if (-not (Get-Command link.exe -ErrorAction SilentlyContinue)) { throw "link.exe missing" }
+
+      - name: Install macOS linkers
+        if: runner.os == 'macOS'
+        shell: bash
         run: |
           set -euo pipefail
-          mkdir -p benchmark-stats
-          curl --fail --silent --location --max-time 30 \
-            -o benchmark-stats/history.jsonl \
-            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/benchmark-stats/history.jsonl" \
-            || : > benchmark-stats/history.jsonl
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          command -v clang
+          command -v ld64.lld
 
-      - name: Build reld and install driver shims
+      - name: Build native reld shim
+        if: runner.os == 'Linux'
+        shell: bash
         run: |
           set -euo pipefail
           cargo build --release -p reld
           bash ci/install-driver-shims.sh release
 
-      - name: Run benchmark and render
+      - name: Run benchmark
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-output
+          cargo run --release -p reld-testkit --bin reld-bench -- \
+            --target "$TARGET" --trials 5 --warmup 1 \
+            > "benchmark-output/benchmark.log" 2>&1
+
+      - name: Upload raw benchmark log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-log-${{ matrix.target }}
+          path: benchmark-output/benchmark.log
+          if-no-files-found: error
+
+  aggregate:
+    name: Render and publish per-target graphs
+    needs: benchmark
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install renderer dependencies
+        run: python -m pip install --disable-pip-version-check pillow
+
+      - name: Download benchmark logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: benchmark-log-*
+          path: benchmark-input
+          merge-multiple: false
+
+      - name: Carry forward history and render each target
+        shell: bash
         env:
           RELD_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/benchmark-stats
         run: |
           set -euo pipefail
-          python3 -m ci.benchmark_stats \
-            --run-benchmarks \
-            --output-dir benchmark-stats \
-            --log-path benchmark-output/benchmark.log
+          targets=(x86_64-linux x86_64-pc-windows-msvc aarch64-apple-darwin)
+          for target in "${targets[@]}"; do
+            mkdir -p "benchmark-stats/$target"
+            curl --fail --silent --location --max-time 30 \
+              -o "benchmark-stats/$target/history.jsonl" \
+              "$RELD_BENCHMARK_RAW_BASE_URL/$target/history.jsonl" \
+              || : > "benchmark-stats/$target/history.jsonl"
+            python -m ci.benchmark_stats \
+              --input-log "benchmark-input/benchmark-log-$target/benchmark.log" \
+              --output-dir "benchmark-stats/$target"
+          done
 
-      - name: Upload artifacts
+      - name: Upload per-target benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -88,18 +146,11 @@ jobs:
           path: benchmark-stats
           if-no-files-found: error
 
-      - name: Upload bench log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-log
-          path: benchmark-output/benchmark.log
-          if-no-files-found: warn
-
       - name: Publish benchmark-stats branch
         if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         env:
           GH_TOKEN: ${{ github.token }}
+        shell: bash
         run: |
           set -euo pipefail
           publish_dir="$(mktemp -d)"
@@ -111,6 +162,4 @@ jobs:
           git -C "$publish_dir" commit -m "chore: publish benchmark stats for ${GITHUB_SHA}"
           git -C "$publish_dir" remote add origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          # Orphan branch, replaced wholesale each run. History lives in history.jsonl,
-          # which is carried forward above — so do not add branch protection here.
           git -C "$publish_dir" push --force origin benchmark-stats

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           set -euo pipefail
           export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           brew untap aws/tap || true
           brew install llvm
           echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -69,8 +69,11 @@ jobs:
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
           brew untap aws/tap || true
-          brew install llvm
-          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          brew install llvm lld
+          {
+            echo "$(brew --prefix llvm)/bin"
+            echo "$(brew --prefix lld)/bin"
+          } >> "$GITHUB_PATH"
           command -v clang
           command -v ld64.lld
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,18 @@ means concretely, and what part of it is shipped vs. designed.
 > [#17](https://github.com/zackees/reld/issues/17) for the phase history.
 
 <!-- BENCHMARK:BEGIN -->
-[![Latest reld link benchmark](https://raw.githubusercontent.com/zackees/reld/benchmark-stats/benchmark-link.jpg)](https://github.com/zackees/reld/tree/benchmark-stats)
+<table><tr>
+<td align="center"><b>x86_64-linux</b><br><a href="https://github.com/zackees/reld/tree/benchmark-stats/x86_64-linux"><img alt="Linux reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/x86_64-linux/benchmark-link.jpg"></a></td>
+<td align="center"><b>x86_64-pc-windows-msvc</b><br><a href="https://github.com/zackees/reld/tree/benchmark-stats/x86_64-pc-windows-msvc"><img alt="Windows reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/x86_64-pc-windows-msvc/benchmark-link.jpg"></a></td>
+<td align="center"><b>aarch64-apple-darwin</b><br><a href="https://github.com/zackees/reld/tree/benchmark-stats/aarch64-apple-darwin"><img alt="macOS reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/aarch64-apple-darwin/benchmark-link.jpg"></a></td>
+</tr></table>
 
 *Auto-generated nightly by [`benchmark-stats.yml`](.github/workflows/benchmark-stats.yml) and
 published to the [`benchmark-stats` branch](https://github.com/zackees/reld/tree/benchmark-stats),
-alongside `latest.json` and `history.jsonl`. The `reld` column carries a real measurement on
-Linux (native engine, driven via `clang -fuse-ld`). It still charts `n/a` on Windows/macOS in
-this clang-based harness, because clang can't drive reld's bridge there — on those platforms reld
-links via rustc `-Clinker`, not `-fuse-ld`, so a bridge-mode bench number is future work, not a
-pending measurement being withheld. With [`soldr`](https://github.com/zackees/soldr) installed,
-reproduce locally with `soldr cargo run --release --bin reld-bench`.*
+with independent `latest.json` and `history.jsonl` per target. Linux measures reld's native
+engine; Windows and macOS currently report honest `n/a` for reld in this clang-based harness
+until the rustc-based bridge measurement lands. Every chart labels reference, native, and bridge
+series modes in its generated metadata.*
 <!-- BENCHMARK:END -->
 
 ## What it is

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -145,12 +145,25 @@ def parse_benchmark_log(text: str) -> Report:
     return report
 
 
-def series_mode(series: str, runner_os: str) -> str:
+def target_os(target: str) -> str | None:
+    """Infer the benchmark OS from its stable target label when available."""
+    normalized = target.lower()
+    if "windows" in normalized or "msvc" in normalized:
+        return "Windows"
+    if "darwin" in normalized or "macos" in normalized:
+        return "Darwin"
+    if "linux" in normalized:
+        return "Linux"
+    return None
+
+
+def series_mode(series: str, runner_os: str, target: str = "") -> str:
     """How a benchmark series was produced. reld is the subject; everything else is a
     reference linker. reld links natively (wild ELF) on Linux and via the lld bridge
     elsewhere."""
     if series == "reld":
-        return "native" if runner_os == "Linux" else "bridge"
+        effective_os = target_os(target) or runner_os
+        return "native" if effective_os == "Linux" else "bridge"
     return "reference"
 
 
@@ -178,7 +191,7 @@ def collect_metadata(report: Report) -> dict[str, Any]:
         "run_url": f"https://github.com/{repo}/actions/runs/{run_id}" if run_id else None,
         "target": report.label,
         "runner": {
-            "os": platform.system(),
+            "os": target_os(report.label) or platform.system(),
             "arch": platform.machine(),
             "platform": platform.platform(),
             "cpu_count": os.cpu_count(),
@@ -334,7 +347,7 @@ def write_outputs(report: Report, meta: dict[str, Any], out_dir: Path) -> None:
                 "scenario": r.scenario,
                 "series": r.series,
                 "seconds": r.seconds,
-                "mode": series_mode(r.series, runner_os),
+                "mode": series_mode(r.series, runner_os, meta.get("target", "")),
             }
             for r in report.rows
         ],

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -100,6 +100,12 @@ def test_series_mode():
     assert series_mode("lld", "Windows") == "reference"
 
 
+def test_series_mode_uses_target_when_rendering_on_aggregation_runner():
+    assert series_mode("reld", "Linux", "x86_64-pc-windows-msvc") == "bridge"
+    assert series_mode("reld", "Linux", "aarch64-apple-darwin") == "bridge"
+    assert series_mode("reld", "Linux", "x86_64-linux") == "native"
+
+
 def test_history_appends_and_caps(tmp_path):
     r = parse_benchmark_log(SAMPLE_LOG)
     meta = collect_metadata(r)

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "benchmark-stats.yml"
+
+
+def test_benchmark_workflow_publishes_one_directory_per_target():
+    text = WORKFLOW.read_text()
+
+    assert "matrix:" in text
+    assert "ubuntu-24.04" in text
+    assert "windows-2022" in text
+    assert "macos-14" in text
+    assert "x86_64-linux" in text
+    assert "x86_64-pc-windows-msvc" in text
+    assert "aarch64-apple-darwin" in text
+    assert "needs: benchmark" in text
+    assert 'benchmark-stats/$target' in text
+    assert "github.event.repository.default_branch" in text

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -51,6 +51,10 @@ struct Args {
     /// executable.
     #[arg(long)]
     reld: Option<PathBuf>,
+
+    /// Label written in the benchmark heading (for example, a Rust target triple).
+    #[arg(long)]
+    target: Option<String>,
 }
 
 /// Workload sizes. Small is where incremental linking will eventually matter most; large is
@@ -74,7 +78,26 @@ fn scenarios() -> Vec<(String, WorkloadSpec)> {
 
 /// `-fuse-ld=` values. `""` means the compiler default.
 fn default_linkers() -> Vec<&'static str> {
-    vec!["bfd", "lld", "mold", "wild"]
+    if cfg!(target_os = "windows") {
+        vec!["", "lld"]
+    } else if cfg!(target_os = "macos") {
+        vec!["", "ld64.lld"]
+    } else {
+        vec!["bfd", "lld", "mold", "wild"]
+    }
+}
+
+fn display_linker(linker: &str) -> &str {
+    if !linker.is_empty() {
+        return linker;
+    }
+    if cfg!(target_os = "windows") {
+        "link.exe"
+    } else if cfg!(target_os = "macos") {
+        "ld"
+    } else {
+        "default"
+    }
 }
 
 /// Locate the `ld.reld` driver shim produced by `ci/install-driver-shims.sh`.
@@ -154,11 +177,12 @@ fn main() -> Result<()> {
         reld_unavailable_reason
     };
 
-    println!("## Link Benchmark: {}", target_triple());
+    let target = args.target.clone().unwrap_or_else(target_triple);
+    println!("## Link Benchmark: {target}");
     println!();
     print!("| Scenario |");
     for (l, _) in &available {
-        print!(" {l} |");
+        print!(" {} |", display_linker(l));
     }
     println!(" reld |");
     print!("|:---------|");
@@ -206,7 +230,10 @@ fn main() -> Result<()> {
     println!();
     for (l, ok) in &available {
         if !ok {
-            println!("<!-- linker {l} not available on this runner -->");
+            println!(
+                "<!-- linker {} not available on this runner -->",
+                display_linker(l)
+            );
         }
     }
     if let Some(reason) = reld_unavailable_reason {


### PR DESCRIPTION
Closes #45

Refs #47

## Summary

- Matrix benchmark generation across Linux, Windows MSVC, and macOS arm64.
- Per-target raw logs, histories, JSON, charts, and HTML output.
- Platform-specific competitor columns and target-labelled benchmark headings.
- README embeds the three independent target charts.
- Preserve target-specific native/bridge modes when aggregation runs on Ubuntu.

## Validation

- `python -m pytest ci/tests -q` (15 passed)
- `soldr cargo test -p reld-testkit --bin reld-bench` (8 passed)
- `soldr cargo fmt --all -- --check`
- `actionlint .github/workflows/benchmark-stats.yml`
- `git diff --check`

The follow-up Python orchestration refactor is tracked in #48. Windows/macOS reld measurement remains the explicitly documented B-2 follow-up; this PR publishes their competitor data honestly as reld `n/a` until that lands.