### PR TITLE
ci: cache-gated Python linker setup + Linux cross-compile release job (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,7 +527,7 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64
+          sudo apt-get install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
 
       - name: Set up soldr (build cache)
         uses: zackees/setup-soldr@v0
@@ -536,8 +536,16 @@ jobs:
 
       - name: Cross-compile reld (release)
         shell: bash
+        # The workspace pulls in cc-built C libraries (zstd, blake3 SIMD). When
+        # cross-compiling, the `cc` crate must build them with the mingw cross
+        # compiler/archiver, not the host gcc — otherwise the C objects are ELF
+        # and the final PE/COFF link fails with undefined references. Point the
+        # target-scoped CC/CXX/AR (and the Rust linker) at the mingw tools.
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+          CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
+          CXX_x86_64_pc_windows_gnu: x86_64-w64-mingw32-g++
+          AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
         run: |
           set -euxo pipefail
           rustup target add "${{ matrix.target }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,7 +508,16 @@ jobs:
   # Release cross-compilation on cheap, plentiful Linux runners. Building the
   # Windows target from Linux exploits parallel Linux capacity for the compile +
   # link phases (native on-target *test* execution stays on the native matrix
-  # legs above). soldr provides content-addressed build caching across runs.
+  # legs above).
+  #
+  # NOTE: this uses the standard mingw-w64 cross toolchain directly rather than
+  # `soldr cargo`. soldr's current cross-compile path breaks here two ways — its
+  # zccache builds the cc-crate C deps (zstd, blake3) with the host compiler
+  # (host ELF objects -> mingw PE link fails, zackees/soldr#2334) and its
+  # toolchain cache does not rehydrate the target's rust-std on a cache hit
+  # (E0463 can't find crate for std). Once a published soldr cross toolchain
+  # exists (zackees/soldr#2335, `soldr cc --target ...`), this job should switch
+  # to it and drop the mingw CC/CXX/AR wiring. Tracked for reld in follow-up.
   cross-release:
     name: Cross release (linux -> ${{ matrix.target }})
     runs-on: ubuntu-24.04
@@ -529,18 +538,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
 
-      - name: Set up soldr (build cache)
-        uses: zackees/setup-soldr@v0
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
-          cache: true
+          targets: ${{ matrix.target }}
 
       - name: Cross-compile reld (release)
         shell: bash
-        # The workspace pulls in cc-built C libraries (zstd, blake3 SIMD). When
-        # cross-compiling, the `cc` crate must build them with the mingw cross
-        # compiler/archiver, not the host gcc — otherwise the C objects are ELF
-        # and the final PE/COFF link fails with undefined references. Point the
-        # target-scoped CC/CXX/AR (and the Rust linker) at the mingw tools.
+        # The workspace pulls in cc-built C libraries (zstd, blake3 SIMD). Point
+        # the cc crate's target-scoped CC/CXX/AR (and the Rust linker) at the
+        # mingw tools so the C objects are built as PE/COFF and link cleanly.
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
           CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
@@ -548,8 +554,7 @@ jobs:
           AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
         run: |
           set -euxo pipefail
-          rustup target add "${{ matrix.target }}"
-          soldr cargo build --release --target "${{ matrix.target }}" -p reld --bin reld
+          cargo build --release --target "${{ matrix.target }}" -p reld --bin reld
 
       - name: Verify cross-compiled artifact
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           tool: taplo-cli@0.10.0
 
-      - name: Install Linux reference linkers
+      - name: Install Linux clang toolchain
         if: matrix.kind == 'linux-gnu'
         shell: bash
         run: |
@@ -135,22 +135,30 @@ jobs:
           sudo apt-get install -y \
             "clang-22=${CLANG_PACKAGE_VERSION}" \
             "llvm-22-linker-tools=${CLANG_PACKAGE_VERSION}"
-          curl -fsSL -o "${RUNNER_TEMP}/libtinfo5.deb" "https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_${LIBTINFO5_VERSION}_amd64.deb"
-          echo 'b9bb64e716a7d9de05b1b33992763142ca81bcae3a7f8ce7e29fa3c6fd32f1e8  '${RUNNER_TEMP}'/libtinfo5.deb' | sha256sum --check
-          sudo apt-get install -y "${RUNNER_TEMP}/libtinfo5.deb"
-          mkdir -p "${RUNNER_TEMP}/refs" "${RUNNER_TEMP}/ref-bin"
-          curl -fsSL -o "${RUNNER_TEMP}/mold.tar.gz" "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"
-          echo 'a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d  '${RUNNER_TEMP}'/mold.tar.gz' | sha256sum --check
-          tar -xzf "${RUNNER_TEMP}/mold.tar.gz" -C "${RUNNER_TEMP}/refs"
-          curl -fsSL -o "${RUNNER_TEMP}/wild.tar.gz" "https://github.com/davidlattimore/wild/releases/download/${WILD_VERSION}/wild-linker-${WILD_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          echo 'deb6ee0e5caec798053ec4aafaba042e20a8edf91f08cb4d36268571cc628d3b  '${RUNNER_TEMP}'/wild.tar.gz' | sha256sum --check
-          tar -xzf "${RUNNER_TEMP}/wild.tar.gz" -C "${RUNNER_TEMP}/refs"
-          cp "$(find "${RUNNER_TEMP}/refs" -type f -path '*/bin/mold' | head -1)" "${RUNNER_TEMP}/ref-bin/mold"
-          cp "$(find "${RUNNER_TEMP}/refs" -type f -name wild | head -1)" "${RUNNER_TEMP}/ref-bin/ld.wild"
-          ln -s /usr/bin/clang-22 "${RUNNER_TEMP}/ref-bin/clang"
-          ln -s /usr/bin/clang++-22 "${RUNNER_TEMP}/ref-bin/clang++"
-          chmod +x "${RUNNER_TEMP}/ref-bin/mold" "${RUNNER_TEMP}/ref-bin/ld.wild"
-          echo "${RUNNER_TEMP}/ref-bin" >> "${GITHUB_PATH}"
+
+      # The mold/wild release tarballs and the libtinfo5 .deb are the heavy, pinned
+      # downloads paid on every run. Cache them keyed on the pinned versions so
+      # subsequent runs restore them instead of re-fetching. The version-drift
+      # smoke step below is the correctness gate on a cache hit.
+      - name: Restore cached Linux reference linkers
+        if: matrix.kind == 'linux-gnu'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/reld-linker-cache
+          key: linkers-${{ runner.os }}-mold${{ env.MOLD_VERSION }}-wild${{ env.WILD_VERSION }}-libtinfo${{ env.LIBTINFO5_VERSION }}
+
+      - name: Provision cached Linux reference linkers
+        if: matrix.kind == 'linux-gnu'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # Cache-gated: no-op for artifacts already restored above; download +
+          # verify only on a miss. Installs the cached libtinfo5 .deb, symlinks
+          # clang-22/clang++-22, and appends the cache bin dir to GITHUB_PATH.
+          python3 ci/linker_setup.py \
+            --cache-dir "${RUNNER_TEMP}/reld-linker-cache" \
+            --install-debs \
+            --link-clang
 
       - name: Verify and smoke Linux reference linkers
         if: matrix.kind == 'linux-gnu'
@@ -496,3 +504,57 @@ jobs:
           python-version: "3.12"
       - run: python -m pip install --quiet pillow pytest
       - run: python -m pytest ci/tests -q
+
+  # Release cross-compilation on cheap, plentiful Linux runners. Building the
+  # Windows target from Linux exploits parallel Linux capacity for the compile +
+  # link phases (native on-target *test* execution stays on the native matrix
+  # legs above). soldr provides content-addressed build caching across runs.
+  cross-release:
+    name: Cross release (linux -> ${{ matrix.target }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            artifact: reld.exe
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install mingw-w64 cross toolchain
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
+
+      - name: Set up soldr (build cache)
+        uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+
+      - name: Cross-compile reld (release)
+        shell: bash
+        env:
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+        run: |
+          set -euxo pipefail
+          rustup target add "${{ matrix.target }}"
+          soldr cargo build --release --target "${{ matrix.target }}" -p reld --bin reld
+
+      - name: Verify cross-compiled artifact
+        shell: bash
+        run: |
+          set -euxo pipefail
+          out="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
+          test -f "$out"
+          file "$out"
+          file "$out" | grep -q 'PE32'
+
+      - name: Upload cross-compiled release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: reld-${{ matrix.target }}-release
+          path: target/${{ matrix.target }}/release/${{ matrix.artifact }}
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ means concretely, and what part of it is shipped vs. designed.
 > [#17](https://github.com/zackees/reld/issues/17) for the phase history.
 
 <!-- BENCHMARK:BEGIN -->
-<table><tr>
-<td align="center"><b>x86_64-linux</b><br><a href="https://github.com/zackees/reld/tree/benchmark-stats/x86_64-linux"><img alt="Linux reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/x86_64-linux/benchmark-link.jpg"></a></td>
-<td align="center"><b>x86_64-pc-windows-msvc</b><br><a href="https://github.com/zackees/reld/tree/benchmark-stats/x86_64-pc-windows-msvc"><img alt="Windows reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/x86_64-pc-windows-msvc/benchmark-link.jpg"></a></td>
-<td align="center"><b>aarch64-apple-darwin</b><br><a href="https://github.com/zackees/reld/tree/benchmark-stats/aarch64-apple-darwin"><img alt="macOS reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/aarch64-apple-darwin/benchmark-link.jpg"></a></td>
-</tr></table>
+<p align="center"><b>x86_64-linux</b><br>
+<a href="https://github.com/zackees/reld/tree/benchmark-stats/x86_64-linux"><img alt="Linux reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/x86_64-linux/benchmark-link.jpg" width="100%"></a></p>
+
+<p align="center"><b>x86_64-pc-windows-msvc</b><br>
+<a href="https://github.com/zackees/reld/tree/benchmark-stats/x86_64-pc-windows-msvc"><img alt="Windows reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/x86_64-pc-windows-msvc/benchmark-link.jpg" width="100%"></a></p>
+
+<p align="center"><b>aarch64-apple-darwin</b><br>
+<a href="https://github.com/zackees/reld/tree/benchmark-stats/aarch64-apple-darwin"><img alt="macOS reld link benchmark" src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/aarch64-apple-darwin/benchmark-link.jpg" width="100%"></a></p>
 
 *Auto-generated nightly by [`benchmark-stats.yml`](.github/workflows/benchmark-stats.yml) and
 published to the [`benchmark-stats` branch](https://github.com/zackees/reld/tree/benchmark-stats),

--- a/ci/linker_setup.py
+++ b/ci/linker_setup.py
@@ -1,0 +1,278 @@
+"""Cache-gated provisioning of the Linux reference linkers used by CI.
+
+The Phase-1 Linux job pins a set of reference linkers (mold, wild) plus the
+`libtinfo5` runtime that clang's LTO plugin needs. Downloading and extracting
+those artifacts is the "heavy price" paid on every CI run. This module makes
+that work *cache-gated*:
+
+* On a **cache hit** (the artifacts are already present in ``--cache-dir``, e.g.
+  restored by ``actions/cache``), it is a no-op — no download, no extraction.
+* On a **cache miss** it downloads each pinned artifact, verifies it against the
+  pinned SHA-256, and materialises it into ``--cache-dir`` so the surrounding
+  ``actions/cache`` step can persist it for the next run.
+
+A SHA mismatch (e.g. a version was bumped without updating the digest here) is a
+hard, loud failure rather than a silently-wrong linker.
+
+The download/extraction helpers are deliberately isolated from the pure
+"do we already have this?" logic so the latter can be unit-tested without
+touching the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CHUNK = 1 << 20
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """A pinned, checksum-verified download materialised into the cache dir.
+
+    ``kind`` selects how the downloaded file becomes a usable artifact:
+
+    * ``"tarball"`` — extract and copy the member matching ``member_suffix``
+      into ``<cache>/bin/<dest_name>`` and mark it executable.
+    * ``"deb"`` — keep the ``.deb`` in ``<cache>/downloads`` and install it with
+      ``dpkg`` (the download, not the install, is what we cache).
+    """
+
+    name: str
+    url: str
+    sha256: str
+    kind: str
+    dest_name: str = ""
+    member_suffix: str = ""
+
+
+def resolve_artifacts(env: dict[str, str]) -> list[Artifact]:
+    """Build the concrete artifact list from the pinned version env vars.
+
+    Versions come from the workflow ``env:`` block (single source of truth); the
+    SHA-256 digests are pinned here and pair with those exact versions.
+    """
+    mold_version = env["MOLD_VERSION"]
+    wild_version = env["WILD_VERSION"]
+    libtinfo5_version = env["LIBTINFO5_VERSION"]
+    return [
+        Artifact(
+            name="mold",
+            url=(
+                f"https://github.com/rui314/mold/releases/download/v{mold_version}/"
+                f"mold-{mold_version}-x86_64-linux.tar.gz"
+            ),
+            sha256="a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d",
+            kind="tarball",
+            dest_name="mold",
+            member_suffix="bin/mold",
+        ),
+        Artifact(
+            name="wild",
+            url=(
+                f"https://github.com/davidlattimore/wild/releases/download/{wild_version}/"
+                f"wild-linker-{wild_version}-x86_64-unknown-linux-gnu.tar.gz"
+            ),
+            sha256="deb6ee0e5caec798053ec4aafaba042e20a8edf91f08cb4d36268571cc628d3b",
+            kind="tarball",
+            dest_name="ld.wild",
+            member_suffix="wild",
+        ),
+        Artifact(
+            name="libtinfo5",
+            url=(
+                "https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/"
+                f"libtinfo5_{libtinfo5_version}_amd64.deb"
+            ),
+            sha256="b9bb64e716a7d9de05b1b33992763142ca81bcae3a7f8ce7e29fa3c6fd32f1e8",
+            kind="deb",
+        ),
+    ]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def is_satisfied(artifact: Artifact, cache_dir: Path) -> bool:
+    """Whether the materialised artifact already exists in the cache (a hit).
+
+    For tarball artifacts the final binary lives in ``<cache>/bin``; for debs the
+    cache holds the downloaded ``.deb`` in ``<cache>/downloads``.
+    """
+    if artifact.kind == "tarball":
+        return (cache_dir / "bin" / artifact.dest_name).is_file()
+    if artifact.kind == "deb":
+        return download_path(artifact, cache_dir).is_file()
+    raise ValueError(f"unknown artifact kind {artifact.kind!r}")
+
+
+def download_path(artifact: Artifact, cache_dir: Path) -> Path:
+    return cache_dir / "downloads" / f"{artifact.name}{_url_suffix(artifact.url)}"
+
+
+def _url_suffix(url: str) -> str:
+    name = url.rsplit("/", 1)[-1]
+    for suffix in (".tar.gz", ".tgz", ".deb", ".tar.zst"):
+        if name.endswith(suffix):
+            return suffix
+    return ""
+
+
+def needs_download(artifact: Artifact, cache_dir: Path) -> bool:
+    """Whether the raw download must be (re)fetched: absent or wrong digest."""
+    cached = download_path(artifact, cache_dir)
+    if not cached.is_file():
+        return True
+    return sha256_file(cached) != artifact.sha256
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url) as response, dest.open("wb") as handle:  # noqa: S310
+        shutil.copyfileobj(response, handle)
+
+
+def _verify(path: Path, expected: str) -> None:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise SystemExit(
+            f"checksum mismatch for {path.name}: expected {expected}, got {actual}"
+        )
+
+
+def _member_matches(name: str, suffix: str) -> bool:
+    """True if ``name`` is exactly ``suffix`` or a path component ending in it.
+
+    Handles both a top-level member (``wild`` -> ``wild``) and a nested one
+    (``mold-2.41.0-x86_64-linux/bin/mold`` -> ``bin/mold``) without matching an
+    unrelated member such as ``mywild``.
+    """
+    return name == suffix or name.endswith("/" + suffix)
+
+
+def _extract_member(tarball: Path, member_suffix: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tarball, "r:gz") as archive:
+        match = next(
+            (
+                member
+                for member in archive.getmembers()
+                if member.isfile() and _member_matches(member.name, member_suffix)
+            ),
+            None,
+        )
+        if match is None:
+            raise SystemExit(f"{tarball.name}: no member matching {member_suffix!r}")
+        source = archive.extractfile(match)
+        if source is None:  # pragma: no cover - defensive
+            raise SystemExit(f"{tarball.name}: could not read {match.name}")
+        with source, dest.open("wb") as handle:
+            shutil.copyfileobj(source, handle)
+    dest.chmod(0o755)
+
+
+def provision(artifact: Artifact, cache_dir: Path) -> str:
+    """Ensure ``artifact`` is materialised in ``cache_dir``; return hit|miss.
+
+    Cache hit -> no network, no extraction. Cache miss -> download (if the raw
+    file is absent or its digest is stale), verify, and materialise.
+    """
+    if is_satisfied(artifact, cache_dir):
+        return "hit"
+
+    cached = download_path(artifact, cache_dir)
+    if needs_download(artifact, cache_dir):
+        print(f"downloading {artifact.name} from {artifact.url}")
+        _download(artifact.url, cached)
+    _verify(cached, artifact.sha256)
+
+    if artifact.kind == "tarball":
+        dest = cache_dir / "bin" / artifact.dest_name
+        _extract_member(cached, artifact.member_suffix, dest)
+    return "miss"
+
+
+def _install_debs(cache_dir: Path, artifacts: list[Artifact]) -> None:
+    debs = [str(download_path(a, cache_dir)) for a in artifacts if a.kind == "deb"]
+    if debs:
+        subprocess.run(["sudo", "dpkg", "-i", *debs], check=True)
+
+
+def _link_clang(cache_dir: Path) -> None:
+    """Expose the apt-installed clang-22 under stable names in the cache bin dir."""
+    bin_dir = cache_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for link_name, target in (("clang", "/usr/bin/clang-22"), ("clang++", "/usr/bin/clang++-22")):
+        link = bin_dir / link_name
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        link.symlink_to(target)
+
+
+def _append_github_path(bin_dir: Path) -> None:
+    github_path = os.environ.get("GITHUB_PATH")
+    if github_path:
+        with Path(github_path).open("a", encoding="utf-8") as handle:
+            handle.write(f"{bin_dir}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        required=True,
+        help="directory persisted by actions/cache (holds bin/ and downloads/)",
+    )
+    parser.add_argument(
+        "--install-debs",
+        action="store_true",
+        help="dpkg-install cached .deb artifacts (requires sudo)",
+    )
+    parser.add_argument(
+        "--link-clang",
+        action="store_true",
+        help="symlink apt-installed clang-22/clang++-22 into the cache bin dir",
+    )
+    parser.add_argument(
+        "--no-path",
+        action="store_true",
+        help="do not append the cache bin dir to GITHUB_PATH",
+    )
+    args = parser.parse_args()
+
+    cache_dir: Path = args.cache_dir
+    (cache_dir / "bin").mkdir(parents=True, exist_ok=True)
+    (cache_dir / "downloads").mkdir(parents=True, exist_ok=True)
+
+    artifacts = resolve_artifacts(dict(os.environ))
+    for artifact in artifacts:
+        outcome = provision(artifact, cache_dir)
+        print(f"{artifact.name}: {outcome}")
+
+    if args.install_debs:
+        _install_debs(cache_dir, artifacts)
+    if args.link_clang:
+        _link_clang(cache_dir)
+    if not args.no_path:
+        _append_github_path(cache_dir / "bin")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -19,11 +19,14 @@ def test_ci_caches_linux_reference_linkers():
     assert "--link-clang" in text
 
 
-def test_ci_cross_compiles_release_on_linux_with_soldr():
+def test_ci_cross_compiles_release_on_linux():
     text = WORKFLOW.read_text()
 
+    # Release cross-compile of the Windows target on a Linux runner, using the
+    # mingw-w64 cross toolchain. (soldr's cross path is deferred pending
+    # zackees/soldr#2334 / #2335 — see the job comment.)
     assert "cross-release:" in text
-    assert "zackees/setup-soldr@v0" in text
-    assert "soldr cargo build --release" in text
+    assert "cargo build --release" in text
     assert "x86_64-pc-windows-gnu" in text
     assert "gcc-mingw-w64-x86-64" in text
+    assert "CC_x86_64_pc_windows_gnu" in text

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "ci.yml"
+
+
+def test_ci_caches_linux_reference_linkers():
+    text = WORKFLOW.read_text()
+
+    # Linker downloads are cache-gated via actions/cache keyed on pinned versions.
+    assert "actions/cache@v4" in text
+    assert "reld-linker-cache" in text
+    assert "key: linkers-${{ runner.os }}-mold${{ env.MOLD_VERSION }}" in text
+
+    # The heavy download work is delegated to the Python cache-gated script.
+    assert "python3 ci/linker_setup.py" in text
+    assert "--cache-dir" in text
+    assert "--install-debs" in text
+    assert "--link-clang" in text
+
+
+def test_ci_cross_compiles_release_on_linux_with_soldr():
+    text = WORKFLOW.read_text()
+
+    assert "cross-release:" in text
+    assert "zackees/setup-soldr@v0" in text
+    assert "soldr cargo build --release" in text
+    assert "x86_64-pc-windows-gnu" in text
+    assert "gcc-mingw-w64-x86-64" in text

--- a/ci/tests/test_linker_setup.py
+++ b/ci/tests/test_linker_setup.py
@@ -1,0 +1,162 @@
+import hashlib
+import io
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from ci.linker_setup import (
+    Artifact,
+    _append_github_path,
+    _extract_member,
+    _member_matches,
+    _url_suffix,
+    download_path,
+    is_satisfied,
+    needs_download,
+    provision,
+    resolve_artifacts,
+    sha256_file,
+)
+
+
+ENV = {
+    "MOLD_VERSION": "2.41.0",
+    "WILD_VERSION": "0.9.0",
+    "LIBTINFO5_VERSION": "6.3-2ubuntu0.2",
+}
+
+
+def test_resolve_artifacts_uses_env_versions() -> None:
+    by_name = {a.name: a for a in resolve_artifacts(ENV)}
+    assert set(by_name) == {"mold", "wild", "libtinfo5"}
+    assert "v2.41.0/mold-2.41.0-x86_64-linux.tar.gz" in by_name["mold"].url
+    assert "wild/releases/download/0.9.0/" in by_name["wild"].url
+    assert "libtinfo5_6.3-2ubuntu0.2_amd64.deb" in by_name["libtinfo5"].url
+    assert by_name["mold"].dest_name == "mold"
+    assert by_name["wild"].dest_name == "ld.wild"
+
+
+def test_url_suffix() -> None:
+    assert _url_suffix("https://x/y/mold-1.tar.gz") == ".tar.gz"
+    assert _url_suffix("https://x/y/libtinfo5_1_amd64.deb") == ".deb"
+    assert _url_suffix("https://x/y/thing") == ""
+
+
+def test_sha256_file(tmp_path: Path) -> None:
+    blob = tmp_path / "blob"
+    blob.write_bytes(b"hello")
+    assert sha256_file(blob) == hashlib.sha256(b"hello").hexdigest()
+
+
+def _deb_artifact(sha: str) -> Artifact:
+    return Artifact(name="libtinfo5", url="https://x/y/libtinfo5_1_amd64.deb", sha256=sha, kind="deb")
+
+
+def test_needs_download_true_when_missing(tmp_path: Path) -> None:
+    art = _deb_artifact("0" * 64)
+    assert needs_download(art, tmp_path) is True
+
+
+def test_needs_download_false_when_present_and_valid(tmp_path: Path) -> None:
+    art = _deb_artifact(hashlib.sha256(b"payload").hexdigest())
+    cached = download_path(art, tmp_path)
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"payload")
+    assert needs_download(art, tmp_path) is False
+
+
+def test_needs_download_true_when_sha_mismatch(tmp_path: Path) -> None:
+    art = _deb_artifact("0" * 64)
+    cached = download_path(art, tmp_path)
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"payload")
+    assert needs_download(art, tmp_path) is True
+
+
+def test_is_satisfied_tarball(tmp_path: Path) -> None:
+    art = Artifact(
+        name="mold",
+        url="https://x/y/mold-1.tar.gz",
+        sha256="0" * 64,
+        kind="tarball",
+        dest_name="mold",
+        member_suffix="/bin/mold",
+    )
+    assert is_satisfied(art, tmp_path) is False
+    binary = tmp_path / "bin" / "mold"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"\x7fELF")
+    assert is_satisfied(art, tmp_path) is True
+
+
+def test_is_satisfied_deb(tmp_path: Path) -> None:
+    art = _deb_artifact("0" * 64)
+    assert is_satisfied(art, tmp_path) is False
+    cached = download_path(art, tmp_path)
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"deb")
+    assert is_satisfied(art, tmp_path) is True
+
+
+def test_provision_hit_is_a_noop(tmp_path: Path) -> None:
+    """A satisfied tarball must not touch the network — provision returns 'hit'."""
+    art = Artifact(
+        name="mold",
+        url="https://invalid.invalid/should-not-be-fetched.tar.gz",
+        sha256="0" * 64,
+        kind="tarball",
+        dest_name="mold",
+        member_suffix="/bin/mold",
+    )
+    binary = tmp_path / "bin" / "mold"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"\x7fELF")
+    assert provision(art, tmp_path) == "hit"
+
+
+def test_unknown_kind_raises(tmp_path: Path) -> None:
+    art = Artifact(name="x", url="https://x/y/z", sha256="0" * 64, kind="bogus")
+    with pytest.raises(ValueError):
+        is_satisfied(art, tmp_path)
+
+
+def test_member_matches() -> None:
+    assert _member_matches("wild", "wild") is True
+    assert _member_matches("wild-linker-0.9.0/wild", "wild") is True
+    assert _member_matches("mold-2.41.0-x86_64-linux/bin/mold", "bin/mold") is True
+    assert _member_matches("something/mywild", "wild") is False
+    assert _member_matches("wild-linker/notes.txt", "wild") is False
+
+
+def _make_tarball(path: Path, members: dict[str, bytes]) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+
+
+def test_extract_member_toplevel_and_nested(tmp_path: Path) -> None:
+    tarball = tmp_path / "wild.tar.gz"
+    _make_tarball(tarball, {"wild-linker-0.9.0/wild": b"WILDBIN", "wild-linker-0.9.0/README": b"x"})
+    dest = tmp_path / "bin" / "ld.wild"
+    _extract_member(tarball, "wild", dest)
+    assert dest.read_bytes() == b"WILDBIN"
+    if os.name == "posix":
+        assert dest.stat().st_mode & 0o111  # executable bit set on the linker binary
+
+
+def test_extract_member_missing_raises(tmp_path: Path) -> None:
+    tarball = tmp_path / "empty.tar.gz"
+    _make_tarball(tarball, {"dir/other": b"x"})
+    with pytest.raises(SystemExit):
+        _extract_member(tarball, "wild", tmp_path / "out")
+
+
+def test_append_github_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path_file = tmp_path / "gh_path"
+    monkeypatch.setenv("GITHUB_PATH", str(path_file))
+    _append_github_path(tmp_path / "bin")
+    assert path_file.read_text().strip() == str(tmp_path / "bin")


### PR DESCRIPTION
Closes #50.

Implements the CI improvements from #50, grounded in the current `ci.yml` (which had no build caching and re-downloaded every system linker on every run).

## 1. Cache-gated Python linker setup (`ci/linker_setup.py`)

The mold/wild release tarballs and the `libtinfo5` `.deb` are the heavy, pinned downloads paid on every Linux run. They are now provisioned by a Python script that:

- **No-ops on a cache hit** — if the artifacts are already present in the cache dir (restored by `actions/cache`), nothing is downloaded or extracted.
- **Downloads + SHA-256 verifies only on a miss**, then materialises the binaries into the cache dir.
- **Fails loudly on a digest mismatch** rather than serving a wrong linker.

`ci.yml` wraps the cache dir in `actions/cache@v4` keyed on the pinned versions (`MOLD_VERSION` / `WILD_VERSION` / `LIBTINFO5_VERSION`). The `clang-22` apt toolchain install and the existing **version-drift smoke step** are unchanged — the smoke step is the correctness gate on both hit and miss paths.

**Validated in CI:** the first run populated the cache (miss); the follow-up run restored it and `Phase 1 / linux-gnu` passed with the script no-op'ing on the hit — the miss→hit transition is confirmed across two consecutive Actions runs.

## 2. Cross-compile release on parallel Linux runners

New `cross-release` job builds `reld` in `--release` for `x86_64-pc-windows-gnu` on `ubuntu-24.04` using the mingw-w64 cross toolchain, and uploads the artifact. This exploits cheap, plentiful Linux capacity for the compile+link phases. (The target already builds natively on the `windows-gnu` matrix leg, so the code is known-good for it.)

## On soldr (deferred, with upstream issues filed)

#50 also called for adopting `zackees/setup-soldr` for build caching. Implementing it surfaced two real blockers in soldr's current cross-compile path, so soldr is **not** wired into this PR yet:

- Its zccache builds the `cc`-crate C deps (zstd, blake3) with the **host** compiler → host ELF objects → the mingw PE/COFF link fails with undefined `ZSTD_*`/`blake3_*` references. Filed: **zackees/soldr#2334**.
- On a cache-hit run its toolchain cache doesn't rehydrate the target's rust-std → `error[E0463]: can't find crate for std`.

The proper fix is a first-class, published cross toolchain (`soldr cc --target x86_64-linux-gnu.2.17`, zig-style, with a glibc 2.17 floor) — filed as **zackees/soldr#2335** (+ C++ side #1591). A companion glob-filtered side-cache request for setup-soldr is **zackees/setup-soldr#463**, and simplifying reld's linker cache onto it is tracked in **#52**. Once the published soldr toolchain lands, `cross-release` should switch to it and drop the mingw `CC/CXX/AR` wiring (see the job comment).

## Tests

- `ci/tests/test_linker_setup.py` — cache hit/miss logic, checksum verification, tarball member extraction (top-level + nested), GITHUB_PATH append.
- `ci/tests/test_ci_workflow.py` — asserts the workflow wiring (cache step, script invocation, cross-release job).

`pytest ci/tests` green locally and in the `Python` CI job (31 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
