### PR TITLE
feat(bench): frozen linker-object asset pipeline — manifest + replay (#57)

### DIFF
--- a/.github/workflows/benchmark-assets.yml
+++ b/.github/workflows/benchmark-assets.yml
@@ -1,0 +1,289 @@
+name: Benchmark Assets
+
+# Frozen linker-object benchmark corpora: build once per platform, pack, and publish to the
+# `benchmark-assets` branch alongside a single `manifest.json` index. The benchmark then fetches
+# a frozen corpus and replays only the link (`reld-bench --replay-corpus`) — zero compilation in
+# the loop. See ci/BENCHMARK_ASSETS.md.
+#
+# The `validate` job proves the whole pipeline end-to-end on every PR that touches it. The
+# `publish` job (default branch, dispatch/schedule only) regenerates the corpora + manifest and
+# force-pushes the `benchmark-assets` branch.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 9 * * *"
+  pull_request:
+    paths:
+      - ci/benchmark_assets.py
+      - ci/tests/test_benchmark_assets.py
+      - .github/workflows/benchmark-assets.yml
+      - crates/reld-testkit/src/bin/reld-bench.rs
+
+concurrency:
+  group: benchmark-assets-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  # End-to-end proof on PRs: build a small real corpus, pack it, index it in a manifest, then
+  # fetch + verify + replay the link through reld-bench with zero compilation in the loop.
+  validate:
+    name: Validate assets pipeline (linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install toolchain + linkers
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang lld mold zstd
+
+      - name: Build reld-bench
+        shell: bash
+        run: cargo build -p reld-testkit --bin reld-bench
+
+      - name: Build a demo corpus (compile once)
+        id: corpus
+        shell: bash
+        run: |
+          set -euxo pipefail
+          corpus="${RUNNER_TEMP}/corpus"
+          mkdir -p "${corpus}/objs"
+          # A handful of trivial translation units, compiled once. #55 replaces this with a
+          # frozen Bevy capture; the pipeline is identical.
+          objs=()
+          for i in 0 1 2 3; do
+            printf 'int unit_%d(void){return %d;}\n' "$i" "$i" > "${corpus}/objs/u${i}.c"
+            clang -c "${corpus}/objs/u${i}.c" -o "${corpus}/objs/u${i}.o" -O0 -fPIC
+            objs+=("\"objs/u${i}.o\"")
+          done
+          printf 'int main(void){return 0;}\n' > "${corpus}/objs/main.c"
+          clang -c "${corpus}/objs/main.c" -o "${corpus}/objs/main.o" -O0 -fPIC
+          objs+=("\"objs/main.o\"")
+          joined=$(IFS=,; echo "${objs[*]}")
+          cat > "${corpus}/corpus.json" <<EOF
+          {
+            "schema_version": 1,
+            "platform": "x86_64-linux",
+            "configuration": "quick",
+            "cc": "clang",
+            "objects": [${joined}],
+            "extra_link_args": [],
+            "output_name": "app"
+          }
+          EOF
+          echo "dir=${corpus}" >> "${GITHUB_OUTPUT}"
+
+      - name: Pack, index, fetch, and replay
+        shell: bash
+        run: |
+          set -euxo pipefail
+          assets="${RUNNER_TEMP}/benchmark-assets"
+          mkdir -p "${assets}/x86_64-linux/quick"
+          archive_rel="x86_64-linux/quick/corpus.tar.zst"
+
+          python ci/benchmark_assets.py pack \
+            --corpus-dir "${{ steps.corpus.outputs.dir }}" \
+            --out "${assets}/${archive_rel}"
+
+          python ci/benchmark_assets.py manifest \
+            --out "${assets}/manifest.json" \
+            --generated-at "ci" --corpus-version "demo-v1" \
+            --base-url "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/benchmark-assets" \
+            --asset "platform=x86_64-linux,configuration=quick,archive=${assets}/${archive_rel},archive_path=${archive_rel}"
+
+          python ci/benchmark_assets.py validate --manifest "${assets}/manifest.json"
+
+          extracted="${RUNNER_TEMP}/extracted"
+          python ci/benchmark_assets.py fetch \
+            --manifest "${assets}/manifest.json" \
+            --platform x86_64-linux --configuration quick \
+            --base "${assets}" --dest "${extracted}"
+
+          # The benchmark consumes the fetched corpus and links it repeatedly — no compilation.
+          ./target/debug/reld-bench --replay-corpus "${extracted}" --trials 2 --warmup 1 \
+            | tee "${RUNNER_TEMP}/replay.md"
+          grep -q '## Link Benchmark:' "${RUNNER_TEMP}/replay.md"
+          grep -q '| quick |' "${RUNNER_TEMP}/replay.md"
+
+  # Per-platform corpus build + pack. Runs on dispatch/schedule; feeds `publish`.
+  build:
+    name: Build corpus (${{ matrix.target }})
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-linux
+          - runner: windows-2022
+            target: x86_64-pc-windows-msvc
+          - runner: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install clang + zstd (linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang lld zstd
+
+      - name: Install clang + zstd (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          brew install zstd || true
+          command -v clang
+
+      - name: Install clang + zstd (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install llvm zstandard --no-progress --yes
+          "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Build a corpus and pack it
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euxo pipefail
+          corpus="${RUNNER_TEMP}/corpus"
+          mkdir -p "${corpus}/objs"
+          objs=()
+          for i in 0 1 2 3; do
+            printf 'int unit_%d(void){return %d;}\n' "$i" "$i" > "${corpus}/objs/u${i}.c"
+            clang -c "${corpus}/objs/u${i}.c" -o "${corpus}/objs/u${i}.o" -O0
+            objs+=("\"objs/u${i}.o\"")
+          done
+          printf 'int main(void){return 0;}\n' > "${corpus}/objs/main.c"
+          clang -c "${corpus}/objs/main.c" -o "${corpus}/objs/main.o" -O0
+          objs+=("\"objs/main.o\"")
+          joined=$(IFS=,; echo "${objs[*]}")
+          cat > "${corpus}/corpus.json" <<EOF
+          {
+            "schema_version": 1,
+            "platform": "${TARGET}",
+            "configuration": "quick",
+            "cc": "clang",
+            "objects": [${joined}],
+            "extra_link_args": [],
+            "output_name": "app"
+          }
+          EOF
+          out="${RUNNER_TEMP}/out/${TARGET}/quick"
+          mkdir -p "${out}"
+          python ci/benchmark_assets.py pack --corpus-dir "${corpus}" --out "${out}/corpus.tar.zst"
+
+      - name: Upload corpus artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: corpus-${{ matrix.target }}
+          path: ${{ runner.temp }}/out/${{ matrix.target }}/quick/corpus.tar.zst
+          if-no-files-found: error
+
+  # Assemble manifest.json and publish everything to the benchmark-assets branch.
+  publish:
+    name: Publish benchmark-assets branch
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - run: sudo apt-get update && sudo apt-get install -y zstd
+
+      - name: Download corpus artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: corpus-*
+          path: ${{ runner.temp }}/corpora
+
+      - name: Assemble benchmark-assets tree + manifest
+        id: assemble
+        shell: bash
+        run: |
+          set -euxo pipefail
+          assets="${RUNNER_TEMP}/benchmark-assets"
+          mkdir -p "${assets}"
+          base_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/benchmark-assets"
+          asset_args=()
+          for target in x86_64-linux x86_64-pc-windows-msvc aarch64-apple-darwin; do
+            src="${RUNNER_TEMP}/corpora/corpus-${target}/corpus.tar.zst"
+            if [[ ! -f "${src}" ]]; then
+              echo "::warning::no corpus artifact for ${target}; skipping"
+              continue
+            fi
+            rel="${target}/quick/corpus.tar.zst"
+            mkdir -p "${assets}/${target}/quick"
+            cp "${src}" "${assets}/${rel}"
+            asset_args+=(--asset "platform=${target},configuration=quick,archive=${assets}/${rel},archive_path=${rel}")
+          done
+          if [[ ${#asset_args[@]} -eq 0 ]]; then
+            echo "::error::no corpora to publish"; exit 1
+          fi
+          python ci/benchmark_assets.py manifest \
+            --out "${assets}/manifest.json" \
+            --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --corpus-version "demo-v1" \
+            --base-url "${base_url}" \
+            "${asset_args[@]}"
+          python ci/benchmark_assets.py validate --manifest "${assets}/manifest.json"
+          touch "${assets}/.nojekyll"
+          echo "dir=${assets}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish to benchmark-assets branch
+        if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          assets="${{ steps.assemble.outputs.dir }}"
+          echo "Publishing frozen linker-object corpora to the 'benchmark-assets' branch."
+          echo "This is a force-push of generated content (source sha ${GITHUB_SHA})."
+          echo "Contents:"
+          find "${assets}" -type f | sed "s#${assets}/#  #" | sort
+          publish_dir="$(mktemp -d)"
+          cp -a "${assets}/." "${publish_dir}/"
+          git -C "${publish_dir}" init -b benchmark-assets
+          git -C "${publish_dir}" config user.name "github-actions[bot]"
+          git -C "${publish_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${publish_dir}" add .
+          git -C "${publish_dir}" commit -m "chore: publish benchmark assets for ${GITHUB_SHA}"
+          git -C "${publish_dir}" remote add origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git -C "${publish_dir}" push --force origin benchmark-assets
+          count=$(find "${assets}" -name 'corpus.tar.zst' | wc -l)
+          echo "Published ${count} corpus archive(s) + manifest.json to benchmark-assets (https://github.com/${GITHUB_REPOSITORY}/tree/benchmark-assets)."
+
+      - name: Note when publish is skipped
+        if: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+        shell: bash
+        run: echo "Not on the default branch (${GITHUB_REF}); skipping publish of the benchmark-assets branch."

--- a/ci/BENCHMARK_ASSETS.md
+++ b/ci/BENCHMARK_ASSETS.md
@@ -1,0 +1,100 @@
+# Benchmark assets: frozen linker-object corpora
+
+Coordination layer for the "compile once, link every iteration" benchmark (meta issue #57,
+corpus #55, LTO sections #56). Linker corpora are built **once per platform per configuration**,
+frozen, and published so the benchmark only ever times the **link** — never compilation.
+
+## Flow
+
+```
+build once  ->  pack (zstd)  ->  manifest.json  ->  publish (benchmark-assets branch)
+                                       |
+consumer:                             v
+   resolve -> fetch (verify sha256) -> extract -> reld-bench --replay-corpus   (zero compile)
+```
+
+- `ci/benchmark_assets.py` — pack/extract archives, build/validate/resolve `manifest.json`,
+  and fetch+verify+extract a corpus. Pure logic is unit-tested in `ci/tests/test_benchmark_assets.py`.
+- `reld-bench --replay-corpus <dir>` — reads `<dir>/corpus.json` and times the link across every
+  linker (and reld's shim) against the frozen objects. No compilation happens in the loop.
+- `.github/workflows/benchmark-assets.yml` — `validate` proves the pipeline end-to-end on PRs;
+  `build` + `publish` regenerate corpora and push the `benchmark-assets` branch on the default
+  branch (dispatch/schedule).
+
+## Storage decision (adopted)
+
+**One orphan `benchmark-assets` branch** that doubles as the assets folder / static www site,
+with a single canonical `manifest.json` at its root and one archive per platform per
+configuration beneath it:
+
+```
+benchmark-assets/                 # orphan branch, .nojekyll
+  manifest.json                   # canonical index — single source of truth
+  x86_64-linux/quick/corpus.tar.zst
+  x86_64-pc-windows-msvc/quick/corpus.tar.zst
+  aarch64-apple-darwin/quick/corpus.tar.zst
+  # ... thin-lto / full-lto configurations added by #56
+```
+
+Canonical manifest URL:
+`https://raw.githubusercontent.com/zackees/reld/benchmark-assets/manifest.json`
+
+Chosen over per-platform `benchmark-assets-<platform>` branches for the simplest consumer story
+and a single www site. Escalate to per-platform branches only if blob size or force-push
+contention demands it (see #57).
+
+## `manifest.json` schema (v1)
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "<ISO8601>",
+  "corpus_version": "<e.g. bevy version or demo-v1>",
+  "assets": [
+    {
+      "platform": "x86_64-linux",
+      "configuration": "quick",              // quick | thin-lto | full-lto
+      "archive_path": "x86_64-linux/quick/corpus.tar.zst",
+      "archive_url": "https://raw.githubusercontent.com/zackees/reld/benchmark-assets/x86_64-linux/quick/corpus.tar.zst",
+      "sha256": "<64 hex>",
+      "bytes": 12345,
+      "corpus_json": "corpus.json",
+      "toolchain": {}
+    }
+  ]
+}
+```
+
+`manifest.json` is the single source of truth for consumers; archives are content-addressed by
+sha256 and keyed on `(platform, configuration)`. A checksum mismatch on fetch is a hard failure —
+the benchmark never links against a corrupt or wrong corpus.
+
+## `corpus.json` (inside each archive)
+
+```json
+{
+  "schema_version": 1,
+  "platform": "x86_64-linux",
+  "configuration": "quick",
+  "cc": "clang",
+  "objects": ["objs/u0.o", "objs/main.o"],
+  "extra_link_args": [],
+  "output_name": "app"
+}
+```
+
+`reld-bench --replay-corpus` links `objects` (relative to the extracted corpus dir) with `cc`,
+swapping `-fuse-ld=<linker>` per series. Extra linker inputs (native libs, `-l…`) go in
+`extra_link_args`. Unknown fields are ignored so the recipe can carry extra metadata.
+
+## Archive codec
+
+Codec is chosen by extension: `.tar.zst` (production, via the `zstd` CLI — fast, high ratio) and
+`.tar.gz` (stdlib, used by the hermetic tests). The manifest records each archive by filename +
+sha256 regardless of codec.
+
+## Scope note
+
+This layer is demonstrated end-to-end with a small synthetic corpus. The real Bevy corpus lands
+in #55 and the thin/full-LTO configurations in #56 — both drop straight into this manifest +
+publish + replay machinery unchanged.

--- a/ci/benchmark_assets.py
+++ b/ci/benchmark_assets.py
@@ -1,0 +1,373 @@
+"""Frozen linker-object benchmark assets: manifest, packing, and fetching.
+
+This is the coordination layer for the "compile once, link every iteration"
+benchmark (see the meta issue). Linker corpora (frozen object files + a
+``corpus.json`` recipe describing how to link them) are built once per platform
+per configuration, packed into an archive, and published to the
+``benchmark-assets`` branch alongside a single ``manifest.json`` index.
+
+``manifest.json`` is the single source of truth for consumers: it lists, per
+``(platform, configuration)``, the archive location, its SHA-256, size, and the
+toolchain/corpus metadata. The benchmark then:
+
+    resolve -> fetch (verify sha256) -> extract -> replay the link
+
+with **zero compilation in the loop** — the replay (``reld-bench
+--replay-corpus``) only re-runs the link step against the frozen objects.
+
+Archive codec is chosen by extension: ``.tar.gz`` uses the stdlib (portable,
+used by the hermetic tests); ``.tar.zst`` shells out to the ``zstd`` CLI (used
+in publishing, where zstd's fast high-ratio compression shrinks the blobs).
+
+The pure logic (manifest build/validate/resolve, checksum, codec dispatch) is
+kept free of network and toolchain calls so it is unit-testable without a
+compiler, a runner, or the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import tarfile
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+MANIFEST_SCHEMA_VERSION = 1
+CORPUS_JSON = "corpus.json"
+CHUNK = 1 << 20
+
+# The configurations coverage matrix (see the LTO benchmark issue).
+CONFIGURATIONS = ("quick", "thin-lto", "full-lto")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Archive codec (dispatched by extension)
+# --------------------------------------------------------------------------- #
+
+
+def _is_zst(path: Path) -> bool:
+    return path.name.endswith(".tar.zst")
+
+
+def _is_targz(path: Path) -> bool:
+    return path.name.endswith((".tar.gz", ".tgz"))
+
+
+def pack_dir(corpus_dir: Path, out_archive: Path) -> None:
+    """Pack a corpus directory into ``out_archive`` (codec by extension).
+
+    The archive stores paths relative to ``corpus_dir`` so extraction restores
+    the corpus (including ``corpus.json``) directly into the target directory.
+    """
+    if not (corpus_dir / CORPUS_JSON).is_file():
+        raise SystemExit(f"{corpus_dir} has no {CORPUS_JSON}; refusing to pack an invalid corpus")
+    out_archive.parent.mkdir(parents=True, exist_ok=True)
+    if _is_targz(out_archive):
+        with tarfile.open(out_archive, "w:gz") as tar:
+            tar.add(corpus_dir, arcname=".")
+    elif _is_zst(out_archive):
+        # tar (stdlib) has no zstd; stream a plain tar into the zstd CLI.
+        tar_path = out_archive.with_suffix("")  # drop .zst -> .tar
+        try:
+            with tarfile.open(tar_path, "w") as tar:
+                tar.add(corpus_dir, arcname=".")
+            subprocess.run(
+                ["zstd", "-19", "-q", "-f", "-o", str(out_archive), str(tar_path)],
+                check=True,
+            )
+        finally:
+            tar_path.unlink(missing_ok=True)
+    else:
+        raise SystemExit(f"unsupported archive extension: {out_archive.name}")
+
+
+def extract_archive(archive: Path, dest: Path) -> None:
+    """Extract ``archive`` into ``dest`` (codec by extension)."""
+    dest.mkdir(parents=True, exist_ok=True)
+    if _is_targz(archive):
+        with tarfile.open(archive, "r:gz") as tar:
+            _safe_extractall(tar, dest)
+    elif _is_zst(archive):
+        tar_path = dest / archive.with_suffix("").name  # e.g. corpus.tar
+        try:
+            subprocess.run(
+                ["zstd", "-d", "-q", "-f", "-o", str(tar_path), str(archive)],
+                check=True,
+            )
+            with tarfile.open(tar_path, "r:") as tar:
+                _safe_extractall(tar, dest)
+        finally:
+            tar_path.unlink(missing_ok=True)
+    else:
+        raise SystemExit(f"unsupported archive extension: {archive.name}")
+
+
+def _safe_extractall(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract, rejecting members that escape ``dest`` (path traversal)."""
+    dest = dest.resolve()
+    for member in tar.getmembers():
+        target = (dest / member.name).resolve()
+        if dest != target and dest not in target.parents:
+            raise SystemExit(f"unsafe path in archive: {member.name}")
+    # `data` filter (Python 3.12+) blocks absolute paths, traversal, and unsafe
+    # members; the explicit check above is belt-and-suspenders.
+    tar.extractall(dest, filter="data")  # noqa: S202 - members validated + data filter
+
+
+# --------------------------------------------------------------------------- #
+# Manifest
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AssetEntry:
+    platform: str
+    configuration: str
+    archive_path: str  # path within the benchmark-assets tree (and www site)
+    sha256: str
+    bytes: int
+    corpus_json: str = CORPUS_JSON  # path to the recipe inside the extracted archive
+    archive_url: str = ""  # canonical raw URL, filled by the publisher
+    toolchain: dict[str, Any] = field(default_factory=dict)
+
+    def key(self) -> tuple[str, str]:
+        return (self.platform, self.configuration)
+
+
+def entry_from_archive(
+    *,
+    platform: str,
+    configuration: str,
+    archive: Path,
+    archive_path: str,
+    base_url: str = "",
+    toolchain: dict[str, Any] | None = None,
+) -> AssetEntry:
+    """Build a manifest entry for an on-disk archive (computes sha256 + size)."""
+    if configuration not in CONFIGURATIONS:
+        raise SystemExit(
+            f"unknown configuration {configuration!r}; expected one of {CONFIGURATIONS}"
+        )
+    url = f"{base_url.rstrip('/')}/{archive_path.lstrip('/')}" if base_url else ""
+    return AssetEntry(
+        platform=platform,
+        configuration=configuration,
+        archive_path=archive_path,
+        sha256=sha256_file(archive),
+        bytes=archive.stat().st_size,
+        archive_url=url,
+        toolchain=dict(toolchain or {}),
+    )
+
+
+def build_manifest(entries: list[AssetEntry], *, generated_at: str, corpus_version: str) -> dict[str, Any]:
+    """Assemble the manifest dict. Rejects duplicate (platform, configuration)."""
+    seen: set[tuple[str, str]] = set()
+    for e in entries:
+        if e.key() in seen:
+            raise SystemExit(f"duplicate manifest entry for {e.key()}")
+        seen.add(e.key())
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "corpus_version": corpus_version,
+        "assets": [asdict(e) for e in sorted(entries, key=lambda e: e.key())],
+    }
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    """Raise SystemExit on any structural problem. Used before publishing."""
+    if manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise SystemExit(f"manifest schema_version must be {MANIFEST_SCHEMA_VERSION}")
+    for field_name in ("generated_at", "corpus_version", "assets"):
+        if field_name not in manifest:
+            raise SystemExit(f"manifest missing required field {field_name!r}")
+    seen: set[tuple[str, str]] = set()
+    for a in manifest["assets"]:
+        for field_name in ("platform", "configuration", "archive_path", "sha256", "bytes"):
+            if not a.get(field_name) and a.get(field_name) != 0:
+                raise SystemExit(f"asset missing required field {field_name!r}: {a}")
+        if a["configuration"] not in CONFIGURATIONS:
+            raise SystemExit(f"asset has unknown configuration {a['configuration']!r}")
+        if len(a["sha256"]) != 64:
+            raise SystemExit(f"asset sha256 not a hex digest: {a['sha256']!r}")
+        key = (a["platform"], a["configuration"])
+        if key in seen:
+            raise SystemExit(f"duplicate asset {key}")
+        seen.add(key)
+
+
+def resolve_entry(manifest: dict[str, Any], platform: str, configuration: str) -> dict[str, Any] | None:
+    """Find the asset for (platform, configuration), or None if not published."""
+    for a in manifest["assets"]:
+        if a["platform"] == platform and a["configuration"] == configuration:
+            return a
+    return None
+
+
+def write_manifest(manifest: dict[str, Any], path: Path) -> None:
+    validate_manifest(manifest)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    validate_manifest(manifest)
+    return manifest
+
+
+# --------------------------------------------------------------------------- #
+# Fetch: resolve -> download -> verify -> extract
+# --------------------------------------------------------------------------- #
+
+
+def _read_archive_bytes(entry: dict[str, Any], base: str) -> bytes:
+    """Read the archive from ``base`` (a local dir path or an http(s) URL)."""
+    if base.startswith(("http://", "https://")):
+        url = entry.get("archive_url") or f"{base.rstrip('/')}/{entry['archive_path']}"
+        with urllib.request.urlopen(url) as response:  # noqa: S310
+            return response.read()
+    return (Path(base) / entry["archive_path"]).read_bytes()
+
+
+def fetch_and_extract(
+    manifest: dict[str, Any],
+    platform: str,
+    configuration: str,
+    *,
+    base: str,
+    dest: Path,
+) -> Path:
+    """Fetch the (platform, configuration) archive from ``base``, verify, extract.
+
+    ``base`` is either a local directory (the benchmark-assets checkout) or the
+    canonical raw URL root. Returns the extracted corpus directory. A checksum
+    mismatch is a hard failure — never link against a corrupt/wrong corpus.
+    """
+    entry = resolve_entry(manifest, platform, configuration)
+    if entry is None:
+        raise SystemExit(
+            f"no published asset for platform={platform} configuration={configuration}"
+        )
+    data = _read_archive_bytes(entry, base)
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != entry["sha256"]:
+        raise SystemExit(
+            f"sha256 mismatch for {entry['archive_path']}: "
+            f"expected {entry['sha256']}, got {actual}"
+        )
+    dest.mkdir(parents=True, exist_ok=True)
+    archive_name = Path(entry["archive_path"]).name
+    tmp_archive = dest / archive_name
+    tmp_archive.write_bytes(data)
+    try:
+        extract_archive(tmp_archive, dest)
+    finally:
+        tmp_archive.unlink(missing_ok=True)
+    corpus = dest / entry.get("corpus_json", CORPUS_JSON)
+    if not corpus.is_file():
+        raise SystemExit(f"extracted corpus is missing {entry.get('corpus_json', CORPUS_JSON)}")
+    return dest
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _cmd_pack(args: argparse.Namespace) -> int:
+    pack_dir(args.corpus_dir, args.out)
+    print(f"packed {args.corpus_dir} -> {args.out} ({sha256_file(args.out)}, {args.out.stat().st_size} bytes)")
+    return 0
+
+
+def _cmd_manifest(args: argparse.Namespace) -> int:
+    entries: list[AssetEntry] = []
+    for spec in args.asset:
+        # spec form: platform=<p>,configuration=<c>,archive=<file>,archive_path=<rel>
+        fields = dict(kv.split("=", 1) for kv in spec.split(","))
+        entries.append(
+            entry_from_archive(
+                platform=fields["platform"],
+                configuration=fields["configuration"],
+                archive=Path(fields["archive"]),
+                archive_path=fields["archive_path"],
+                base_url=args.base_url,
+            )
+        )
+    manifest = build_manifest(
+        entries, generated_at=args.generated_at, corpus_version=args.corpus_version
+    )
+    write_manifest(manifest, args.out)
+    print(f"wrote {args.out} with {len(entries)} asset(s)")
+    return 0
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    load_manifest(args.manifest)
+    print(f"{args.manifest}: valid ({MANIFEST_SCHEMA_VERSION})")
+    return 0
+
+
+def _cmd_fetch(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    corpus = fetch_and_extract(
+        manifest, args.platform, args.configuration, base=args.base, dest=args.dest
+    )
+    print(f"fetched + verified corpus -> {corpus}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("pack", help="pack a corpus dir into an archive (.tar.gz or .tar.zst)")
+    p.add_argument("--corpus-dir", type=Path, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    p.set_defaults(func=_cmd_pack)
+
+    p = sub.add_parser("manifest", help="build manifest.json from packed archives")
+    p.add_argument("--out", type=Path, required=True)
+    p.add_argument("--generated-at", required=True)
+    p.add_argument("--corpus-version", required=True)
+    p.add_argument("--base-url", default="")
+    p.add_argument(
+        "--asset",
+        action="append",
+        default=[],
+        help="platform=<p>,configuration=<c>,archive=<file>,archive_path=<rel>",
+    )
+    p.set_defaults(func=_cmd_manifest)
+
+    p = sub.add_parser("validate", help="validate a manifest.json")
+    p.add_argument("--manifest", type=Path, required=True)
+    p.set_defaults(func=_cmd_validate)
+
+    p = sub.add_parser("fetch", help="fetch+verify+extract a corpus from a manifest")
+    p.add_argument("--manifest", type=Path, required=True)
+    p.add_argument("--platform", required=True)
+    p.add_argument("--configuration", required=True)
+    p.add_argument("--base", required=True, help="local dir or http(s) URL root")
+    p.add_argument("--dest", type=Path, required=True)
+    p.set_defaults(func=_cmd_fetch)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_benchmark_assets.py
+++ b/ci/tests/test_benchmark_assets.py
@@ -1,0 +1,205 @@
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from ci.benchmark_assets import (
+    CONFIGURATIONS,
+    AssetEntry,
+    build_manifest,
+    entry_from_archive,
+    extract_archive,
+    fetch_and_extract,
+    load_manifest,
+    pack_dir,
+    resolve_entry,
+    sha256_file,
+    validate_manifest,
+    write_manifest,
+)
+
+
+def _make_corpus(root: Path) -> Path:
+    corpus = root / "corpus"
+    (corpus / "objs").mkdir(parents=True)
+    (corpus / "objs" / "a.o").write_bytes(b"\x7fELF-a")
+    (corpus / "objs" / "b.o").write_bytes(b"\x7fELF-b")
+    (corpus / "corpus.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "platform": "x86_64-linux",
+                "configuration": "quick",
+                "cc": "clang",
+                "objects": ["objs/a.o", "objs/b.o"],
+                "output_name": "app",
+            }
+        )
+    )
+    return corpus
+
+
+def test_sha256_file(tmp_path: Path) -> None:
+    blob = tmp_path / "b"
+    blob.write_bytes(b"hello")
+    assert sha256_file(blob) == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_pack_extract_roundtrip_targz(tmp_path: Path) -> None:
+    corpus = _make_corpus(tmp_path)
+    archive = tmp_path / "corpus.tar.gz"
+    pack_dir(corpus, archive)
+    assert archive.is_file()
+    out = tmp_path / "extracted"
+    extract_archive(archive, out)
+    assert (out / "corpus.json").is_file()
+    assert (out / "objs" / "a.o").read_bytes() == b"\x7fELF-a"
+
+
+def test_pack_rejects_corpus_without_recipe(tmp_path: Path) -> None:
+    d = tmp_path / "bad"
+    d.mkdir()
+    (d / "stray.o").write_bytes(b"x")
+    with pytest.raises(SystemExit):
+        pack_dir(d, tmp_path / "out.tar.gz")
+
+
+def test_extract_rejects_path_traversal(tmp_path: Path) -> None:
+    evil = tmp_path / "evil.tar.gz"
+    with tarfile.open(evil, "w:gz") as tar:
+        data = b"pwned"
+        info = tarfile.TarInfo("../escape.txt")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    with pytest.raises(SystemExit):
+        extract_archive(evil, tmp_path / "dest")
+
+
+def test_entry_from_archive_computes_digest_and_url(tmp_path: Path) -> None:
+    corpus = _make_corpus(tmp_path)
+    archive = tmp_path / "c.tar.gz"
+    pack_dir(corpus, archive)
+    entry = entry_from_archive(
+        platform="x86_64-linux",
+        configuration="quick",
+        archive=archive,
+        archive_path="x86_64-linux/quick/c.tar.gz",
+        base_url="https://raw.example/base",
+    )
+    assert entry.sha256 == sha256_file(archive)
+    assert entry.bytes == archive.stat().st_size
+    assert entry.archive_url == "https://raw.example/base/x86_64-linux/quick/c.tar.gz"
+
+
+def test_entry_rejects_unknown_configuration(tmp_path: Path) -> None:
+    archive = tmp_path / "c.tar.gz"
+    pack_dir(_make_corpus(tmp_path), archive)
+    with pytest.raises(SystemExit):
+        entry_from_archive(
+            platform="x", configuration="bogus", archive=archive, archive_path="x/c.tar.gz"
+        )
+
+
+def _entry(platform: str, configuration: str) -> AssetEntry:
+    return AssetEntry(
+        platform=platform,
+        configuration=configuration,
+        archive_path=f"{platform}/{configuration}/c.tar.gz",
+        sha256="a" * 64,
+        bytes=10,
+    )
+
+
+def test_build_manifest_rejects_duplicates() -> None:
+    with pytest.raises(SystemExit):
+        build_manifest(
+            [_entry("linux", "quick"), _entry("linux", "quick")],
+            generated_at="t",
+            corpus_version="v1",
+        )
+
+
+def test_configurations_cover_quick_and_lto() -> None:
+    assert CONFIGURATIONS == ("quick", "thin-lto", "full-lto")
+
+
+def test_validate_manifest_good_and_bad() -> None:
+    good = build_manifest([_entry("linux", "quick")], generated_at="t", corpus_version="v1")
+    validate_manifest(good)  # no raise
+
+    bad_ver = dict(good)
+    bad_ver["schema_version"] = 999
+    with pytest.raises(SystemExit):
+        validate_manifest(bad_ver)
+
+    bad_digest = build_manifest([_entry("linux", "thin-lto")], generated_at="t", corpus_version="v1")
+    bad_digest["assets"][0]["sha256"] = "short"
+    with pytest.raises(SystemExit):
+        validate_manifest(bad_digest)
+
+
+def test_write_load_roundtrip(tmp_path: Path) -> None:
+    manifest = build_manifest(
+        [_entry("linux", "quick"), _entry("macos", "full-lto")],
+        generated_at="t",
+        corpus_version="v1",
+    )
+    path = tmp_path / "manifest.json"
+    write_manifest(manifest, path)
+    loaded = load_manifest(path)
+    assert len(loaded["assets"]) == 2
+    # sorted by (platform, configuration)
+    assert loaded["assets"][0]["platform"] == "linux"
+
+
+def test_resolve_entry() -> None:
+    manifest = build_manifest([_entry("linux", "quick")], generated_at="t", corpus_version="v1")
+    assert resolve_entry(manifest, "linux", "quick") is not None
+    assert resolve_entry(manifest, "linux", "thin-lto") is None
+
+
+def test_fetch_red_then_green(tmp_path: Path) -> None:
+    """RED: no published asset. GREEN: pack + manifest, then fetch+verify+extract."""
+    base = tmp_path / "benchmark-assets"
+    base.mkdir()
+
+    # RED — manifest has no matching asset yet.
+    empty = build_manifest([], generated_at="t", corpus_version="v1")
+    with pytest.raises(SystemExit):
+        fetch_and_extract(empty, "x86_64-linux", "quick", base=str(base), dest=tmp_path / "d0")
+
+    # Publish: pack the corpus into the assets tree, build the manifest.
+    corpus = _make_corpus(tmp_path)
+    archive_path = "x86_64-linux/quick/corpus.tar.gz"
+    archive = base / archive_path
+    pack_dir(corpus, archive)
+    entry = entry_from_archive(
+        platform="x86_64-linux",
+        configuration="quick",
+        archive=archive,
+        archive_path=archive_path,
+    )
+    manifest = build_manifest([entry], generated_at="t", corpus_version="v1")
+
+    # GREEN — fetch resolves, verifies sha256, extracts, and yields the recipe.
+    out = fetch_and_extract(manifest, "x86_64-linux", "quick", base=str(base), dest=tmp_path / "d1")
+    assert (out / "corpus.json").is_file()
+    assert (out / "objs" / "a.o").read_bytes() == b"\x7fELF-a"
+
+
+def test_fetch_detects_tampering(tmp_path: Path) -> None:
+    base = tmp_path / "assets"
+    archive_path = "x86_64-linux/quick/corpus.tar.gz"
+    archive = base / archive_path
+    pack_dir(_make_corpus(tmp_path), archive)
+    entry = entry_from_archive(
+        platform="x86_64-linux", configuration="quick", archive=archive, archive_path=archive_path
+    )
+    manifest = build_manifest([entry], generated_at="t", corpus_version="v1")
+    # Corrupt the published archive after the manifest recorded its digest.
+    archive.write_bytes(archive.read_bytes() + b"tampered")
+    with pytest.raises(SystemExit):
+        fetch_and_extract(manifest, "x86_64-linux", "quick", base=str(base), dest=tmp_path / "d")

--- a/ci/tests/test_benchmark_assets_workflow.py
+++ b/ci/tests/test_benchmark_assets_workflow.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "benchmark-assets.yml"
+DOCS = ROOT / "ci" / "BENCHMARK_ASSETS.md"
+
+
+def test_workflow_has_pr_validate_and_guarded_publish():
+    text = WORKFLOW.read_text()
+
+    # End-to-end validation runs on PRs.
+    assert "pull_request:" in text
+    assert "validate:" in text
+    assert "python ci/benchmark_assets.py pack" in text
+    assert "python ci/benchmark_assets.py manifest" in text
+    assert "python ci/benchmark_assets.py fetch" in text
+    assert "reld-bench --replay-corpus" in text
+
+    # Publish only on the default branch, and never on pull_request.
+    assert "publish:" in text
+    assert "if: github.event_name != 'pull_request'" in text
+    assert "github.event.repository.default_branch" in text
+    assert "push --force origin benchmark-assets" in text
+
+    # Verbose about populating the branch.
+    assert "force-push of generated content" in text
+    assert "skipping publish" in text
+
+
+def test_docs_record_storage_decision():
+    text = DOCS.read_text()
+    assert "benchmark-assets" in text
+    assert "manifest.json" in text
+    assert "single source of truth" in text

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -55,6 +55,31 @@ struct Args {
     /// Label written in the benchmark heading (for example, a Rust target triple).
     #[arg(long)]
     target: Option<String>,
+
+    /// Replay a frozen link corpus instead of generating synthetic workloads: this directory
+    /// must contain `corpus.json` plus the referenced object files (as produced by the
+    /// benchmark-assets pipeline and fetched via `ci/benchmark_assets.py`). Times only the link
+    /// step across every linker — zero compilation in the loop.
+    #[arg(long)]
+    replay_corpus: Option<PathBuf>,
+}
+
+/// Recipe for replaying a frozen link, read from `<corpus>/corpus.json`. Unknown fields are
+/// ignored so the JSON can carry extra metadata for other consumers. Only the fields needed to
+/// re-run the link are deserialized here.
+#[derive(serde::Deserialize)]
+struct Corpus {
+    /// C compiler / link driver to invoke. Falls back to `--cc` when absent.
+    #[serde(default)]
+    cc: Option<String>,
+    /// Object files (and other linker inputs) relative to the corpus directory.
+    objects: Vec<String>,
+    /// Extra arguments appended to the link (native libs, `-l…`, etc.).
+    #[serde(default)]
+    extra_link_args: Vec<String>,
+    /// Configuration label for the table row (e.g. `quick` / `thin-lto` / `full-lto`).
+    #[serde(default)]
+    configuration: Option<String>,
 }
 
 /// Workload sizes. Small is where incremental linking will eventually matter most; large is
@@ -138,6 +163,10 @@ fn discover_reld_in(explicit: &Option<PathBuf>, sibling_dir: Option<&Path>) -> O
 
 fn main() -> Result<()> {
     let args = Args::parse();
+
+    if let Some(dir) = args.replay_corpus.clone() {
+        return run_replay(&args, &dir);
+    }
 
     let root = match &args.workdir {
         Some(p) => p.clone(),
@@ -390,9 +419,190 @@ fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Resu
     Ok(samples[samples.len() / 2])
 }
 
+/// Link a frozen corpus once with `cc`, appending `extra` (native libs etc.) and selecting
+/// `linker` via `-fuse-ld=`. Mirrors [`link_once`] but takes the compiler and extra args
+/// explicitly so the corpus can carry its own toolchain, independent of `--cc`.
+fn link_once_replay(
+    cc: &str,
+    objects: &[PathBuf],
+    extra: &[String],
+    linker: &str,
+    out: &Path,
+) -> Result<()> {
+    let mut cmd = Command::new(cc);
+    cmd.args(objects).args(extra).arg("-o").arg(out);
+    if !linker.is_empty() {
+        cmd.arg(format!("-fuse-ld={linker}"));
+    }
+    let status = cmd
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .context("spawning linker")?;
+    if !status.status.success() {
+        bail!("link failed: {}", String::from_utf8_lossy(&status.stderr));
+    }
+    Ok(())
+}
+
+/// Warmup + timed median link of a frozen corpus. Compilation never happens here — the objects
+/// are already on disk — so this measures only the link step.
+fn time_link_replay(
+    cc: &str,
+    objects: &[PathBuf],
+    extra: &[String],
+    linker: &str,
+    out_dir: &Path,
+    warmup: usize,
+    trials: usize,
+) -> Result<Duration> {
+    let out = out_dir.join(bench_output_name(linker));
+    for _ in 0..warmup {
+        link_once_replay(cc, objects, extra, linker, &out)?;
+    }
+    let mut samples = Vec::with_capacity(trials);
+    for _ in 0..trials {
+        let _ = std::fs::remove_file(&out);
+        let t = Instant::now();
+        link_once_replay(cc, objects, extra, linker, &out)?;
+        samples.push(t.elapsed());
+    }
+    samples.sort();
+    Ok(samples[samples.len() / 2])
+}
+
+/// Replay a frozen link corpus: read `<dir>/corpus.json`, then time the link of its objects
+/// across every available linker (and reld's shim), emitting the same markdown table as the
+/// synthetic path. No compilation happens — only linking is measured.
+fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
+    let recipe = corpus_dir.join("corpus.json");
+    let text = std::fs::read_to_string(&recipe)
+        .with_context(|| format!("reading {}", recipe.display()))?;
+    let corpus: Corpus =
+        serde_json::from_str(&text).with_context(|| format!("parsing {}", recipe.display()))?;
+
+    let cc = corpus.cc.clone().unwrap_or_else(|| args.cc.clone());
+    let objects: Vec<PathBuf> = corpus.objects.iter().map(|o| corpus_dir.join(o)).collect();
+    for obj in &objects {
+        if !obj.exists() {
+            bail!("corpus object missing: {}", obj.display());
+        }
+    }
+
+    let root = args
+        .workdir
+        .clone()
+        .unwrap_or_else(|| std::env::temp_dir().join("reld-bench-replay"));
+    std::fs::create_dir_all(&root)?;
+
+    let requested: Vec<String> = if args.linkers.is_empty() {
+        default_linkers().into_iter().map(String::from).collect()
+    } else {
+        args.linkers.clone()
+    };
+    let mut available = Vec::new();
+    for l in &requested {
+        available.push((l.clone(), probe_linker(&cc, l, &root).unwrap_or(false)));
+    }
+
+    let reld_shim = discover_reld(&args.reld).and_then(|p| std::fs::canonicalize(&p).ok());
+    let reld_shim_str = reld_shim.as_ref().map(|p| p.to_string_lossy().into_owned());
+    let reld_ok = match &reld_shim_str {
+        Some(linker) => probe_linker(&cc, linker, &root).unwrap_or(false),
+        None => false,
+    };
+
+    let target = args.target.clone().unwrap_or_else(target_triple);
+    let scenario = corpus
+        .configuration
+        .clone()
+        .unwrap_or_else(|| "corpus".to_string());
+    println!("## Link Benchmark: {target}");
+    println!();
+    print!("| Scenario |");
+    for (l, _) in &available {
+        print!(" {} |", display_linker(l));
+    }
+    println!(" reld |");
+    print!("|:---------|");
+    for _ in &available {
+        print!("----:|");
+    }
+    println!("----:|");
+
+    print!("| {scenario} |");
+    for (linker, ok) in &available {
+        if !ok {
+            print!(" n/a |");
+            continue;
+        }
+        match time_link_replay(
+            &cc,
+            &objects,
+            &corpus.extra_link_args,
+            linker,
+            &root,
+            args.warmup,
+            args.trials,
+        ) {
+            Ok(d) => print!(" {:.4} |", d.as_secs_f64()),
+            Err(_) => print!(" n/a |"),
+        }
+    }
+    match (&reld_shim_str, reld_ok) {
+        (Some(linker), true) => match time_link_replay(
+            &cc,
+            &objects,
+            &corpus.extra_link_args,
+            linker,
+            &root,
+            args.warmup,
+            args.trials,
+        ) {
+            Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
+            Err(_) => println!(" n/a |"),
+        },
+        _ => println!(" n/a |"),
+    }
+    println!();
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_corpus_json_recipe() {
+        let json = r#"{
+            "schema_version": 1,
+            "platform": "x86_64-linux",
+            "configuration": "quick",
+            "cc": "clang",
+            "objects": ["objs/a.o", "objs/b.o"],
+            "extra_link_args": ["-lm"],
+            "output_name": "app"
+        }"#;
+        let corpus: Corpus = serde_json::from_str(json).unwrap();
+        assert_eq!(corpus.cc.as_deref(), Some("clang"));
+        assert_eq!(
+            corpus.objects,
+            vec!["objs/a.o".to_string(), "objs/b.o".to_string()]
+        );
+        assert_eq!(corpus.extra_link_args, vec!["-lm".to_string()]);
+        assert_eq!(corpus.configuration.as_deref(), Some("quick"));
+    }
+
+    #[test]
+    fn corpus_json_defaults_are_lenient() {
+        // Only `objects` is required; cc/extra/configuration default; unknown fields ignored.
+        let corpus: Corpus =
+            serde_json::from_str(r#"{"objects":["a.o"],"unknown":"ignored"}"#).unwrap();
+        assert!(corpus.cc.is_none());
+        assert!(corpus.extra_link_args.is_empty());
+        assert!(corpus.configuration.is_none());
+        assert_eq!(corpus.objects, vec!["a.o".to_string()]);
+    }
 
     /// Unique temp directory per test, so the (hermetic) discovery tests never touch the real
     /// executable directory or race each other.


### PR DESCRIPTION
Closes #57.

Implements the **frozen linker-object benchmark assets** coordination layer: build a linker corpus once per platform, freeze it, publish it with a canonical index, and **replay only the link** each benchmark iteration — zero compilation in the loop.

## What's here

### `ci/benchmark_assets.py` — the coordination layer
- Pack/extract corpus archives, codec by extension: `.tar.zst` (production, via the `zstd` CLI — fast, high ratio) and `.tar.gz` (stdlib, hermetic tests). Extraction is path-traversal-guarded (+ the `data` filter).
- `manifest.json`: build / validate / resolve. Single source of truth, entries keyed on `(platform, configuration)`, content-addressed by sha256.
- `fetch_and_extract`: resolve → download (local dir or raw URL) → **verify sha256** → extract. A checksum mismatch is a hard failure — never link a corrupt/wrong corpus.

### `reld-bench --replay-corpus <dir>` — the native consumer
Reads `<dir>/corpus.json` and times the link of the frozen objects across every linker (and reld's shim), emitting the same markdown table as the synthetic path. **No compilation happens in the loop** — only linking is measured.

### `.github/workflows/benchmark-assets.yml`
- **`validate`** (runs on PRs): builds a small real corpus, packs it, indexes it in a manifest, then `fetch`es + verifies + extracts and runs `reld-bench --replay-corpus` — the whole pipeline, end-to-end, green on every PR.
- **`build` + `publish`** (default branch, dispatch/schedule; skipped on PRs): regenerate per-platform corpora and force-push the orphan **`benchmark-assets`** branch with a regenerated `manifest.json`, logging the branch, that it's a force-push of generated content, the file list, and the source SHA (verbose); explicit "skipping publish" when off the default branch.

### `ci/BENCHMARK_ASSETS.md`
Records the **storage decision** (adopted): one orphan `benchmark-assets` branch that doubles as the assets/www site, with a canonical `manifest.json` at its root and one archive per platform per configuration beneath it — chosen over per-platform branches for the simplest consumer story. Documents the `manifest.json` (v1) and `corpus.json` schemas.

## Acceptance criteria (#57)

- [x] Single source-of-truth `manifest.json` at a canonical URL indexing every `(platform, configuration)` archive with URL, sha256, size, toolchain, and the in-archive `corpus.json` path.
- [x] Archives published to the chosen layout (single `benchmark-assets` branch) with zstd compression + checksums.
- [x] Publishing regenerates the manifest and logs branch + archives + source SHA (verbose); refresh explicit; explicit skip message off the default branch.
- [x] The benchmark consumes the manifest: `reld-bench --replay-corpus` links the fetched corpus repeatedly with zero in-loop compilation (exercised end-to-end in the `validate` job).
- [x] Storage decision recorded (`ci/BENCHMARK_ASSETS.md`) for #55/#56 to adopt.
- [x] RED → GREEN: `test_fetch_red_then_green` (no asset → SystemExit; then pack+manifest → fetch succeeds), plus the live `validate` job.

## Scope

This is the coordination layer (meta #57). It's proven end-to-end with a small **synthetic** corpus; the real **Bevy** corpus (#55) and the **thin/full-LTO** configurations (#56) drop into this manifest + publish + replay machinery unchanged.

## Validation

- `pytest ci/tests` — 46 tests green (locally + `Python` CI job), incl. pack/extract, manifest build/validate/resolve, fetch RED→GREEN, tamper detection, traversal guard.
- `reld-bench`: `cargo build` + `cargo clippy --all-targets -- -D warnings` + tests + `fmt --check` all green locally; the two new corpus-parsing unit tests run in the Phase 1 matrix.
- `benchmark-assets.yml` `validate` job exercises the full pipeline (pack → manifest → fetch → replay) on a real Linux runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
