### PR TITLE
feat(bench): gate expected linker coverage; mark reld pending, not silent n/a (#63)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -25,10 +25,15 @@ jobs:
         include:
           - runner: ubuntu-24.04
             target: x86_64-linux
+          # reld is measured natively on Linux; on Windows/macOS it is pending-by-design (the
+          # rustc-based bridge measurement hasn't landed — see #17), so it renders an explicit
+          # `pending` rather than a silent `n/a` (#63).
           - runner: windows-2022
             target: x86_64-pc-windows-msvc
+            reld_pending: "reld bridge measurement pending (rustc-based); see #17"
           - runner: macos-14
             target: aarch64-apple-darwin
+            reld_pending: "reld bridge measurement pending (rustc-based); see #17"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     steps:
@@ -89,12 +94,34 @@ jobs:
         shell: bash
         env:
           TARGET: ${{ matrix.target }}
+          RELD_PENDING: ${{ matrix.reld_pending }}
         run: |
           set -euo pipefail
           mkdir -p benchmark-output
-          cargo run --release -p reld-testkit --bin reld-bench -- \
-            --target "$TARGET" --trials 5 --warmup 1 \
-            > "benchmark-output/benchmark.log" 2>&1
+          if [ -n "${RELD_PENDING:-}" ]; then
+            # Render reld's documented, unsupported-by-design gap as `pending`, never silent n/a.
+            cargo run --release -p reld-testkit --bin reld-bench -- \
+              --target "$TARGET" --trials 5 --warmup 1 --reld-pending "$RELD_PENDING" \
+              > "benchmark-output/benchmark.log" 2>&1
+          else
+            cargo run --release -p reld-testkit --bin reld-bench -- \
+              --target "$TARGET" --trials 5 --warmup 1 \
+              > "benchmark-output/benchmark.log" 2>&1
+          fi
+
+      - name: Assert benchmark coverage (no silent n/a for expected linkers)
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          # Fails the build if any expected linker for this platform reports n/a, or if a
+          # pending-by-design linker slipped to a bare n/a. Prints the expected-vs-measured
+          # table to the log and the job step summary (#63).
+          PY=python3
+          command -v "$PY" >/dev/null 2>&1 || PY=python
+          "$PY" -m ci.benchmark_coverage \
+            --input-log "benchmark-output/benchmark.log" --target "$TARGET"
 
       - name: Upload raw benchmark log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,12 +372,17 @@ jobs:
         if: matrix.kind == 'windows-msvc'
         shell: pwsh
         run: |
-          & $env:CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker lld --trials 2 --warmup 1 | Tee-Object benchmark-windows-msvc.md
+          # reld has no shim on this leg, so it is pending-by-design (bridge measurement pending,
+          # #17). Pass --reld-pending so it renders an explicit `pending` rather than a silent
+          # n/a (#63).
+          & $env:CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker lld --trials 2 --warmup 1 --reld-pending "reld bridge measurement pending (rustc-based); see #17" | Tee-Object benchmark-windows-msvc.md
           if ($LASTEXITCODE -ne 0) { throw "reld-bench exited with code $LASTEXITCODE" }
           if (-not (Test-Path benchmark-windows-msvc.md)) { throw "benchmark-windows-msvc.md not produced" }
           $table = Get-Content benchmark-windows-msvc.md -Raw
           if (-not ($table | Select-String -Pattern '## Link Benchmark:' -Quiet)) { throw "benchmark table missing '## Link Benchmark:' heading" }
           if (-not ($table | Select-String -Pattern '\| *reld *\|' -Quiet)) { throw "benchmark table missing reld column" }
+          # reld must be explicitly pending here, never a bare n/a (#63).
+          if (-not ($table | Select-String -Pattern 'pending' -Quiet)) { throw "reld must render 'pending', not a silent n/a" }
 
       - name: Upload Windows MSVC benchmark artifact
         if: always() && matrix.kind == 'windows-msvc'
@@ -441,13 +446,17 @@ jobs:
           set -euo pipefail
           # Exercise ld64.lld specifically: it was silently n/a because clang maps
           # -fuse-ld=ld64.lld to a nonexistent ld.ld64.lld (#60). This asserts it now links.
-          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker ld64.lld --trials 2 --warmup 1 | tee benchmark-macos-arm64.md
+          # reld has no shim here, so it is pending-by-design (#17): --reld-pending renders an
+          # explicit `pending` instead of a silent n/a (#63).
+          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker ld64.lld --trials 2 --warmup 1 --reld-pending "reld bridge measurement pending (rustc-based); see #17" | tee benchmark-macos-arm64.md
           grep -q '## Link Benchmark:' benchmark-macos-arm64.md || { echo "benchmark table missing '## Link Benchmark:' heading" >&2; exit 1; }
           grep -qE '\| *ld64.lld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing ld64.lld column" >&2; exit 1; }
           grep -qE '\| *reld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing reld column" >&2; exit 1; }
           # ld64.lld is the only linker requested (reld has no shim here), so a real timing proves
           # it actually linked rather than reporting n/a.
           grep -qE '[0-9]+\.[0-9]{4}' benchmark-macos-arm64.md || { echo "ld64.lld produced no timing (still n/a?)" >&2; exit 1; }
+          # reld must be explicitly pending here, never a bare n/a (#63).
+          grep -q 'pending' benchmark-macos-arm64.md || { echo "reld must render 'pending', not a silent n/a" >&2; exit 1; }
 
       - name: macOS self-host (link reld with reld)
         if: matrix.kind == 'macos-arm64'

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ means concretely, and what part of it is shipped vs. designed.
 *Auto-generated nightly by [`benchmark-stats.yml`](.github/workflows/benchmark-stats.yml) and
 published to the [`benchmark-stats` branch](https://github.com/zackees/reld/tree/benchmark-stats),
 with independent `latest.json` and `history.jsonl` per target. Linux measures reld's native
-engine; Windows and macOS currently report honest `n/a` for reld in this clang-based harness
-until the rustc-based bridge measurement lands. Every chart labels reference, native, and bridge
-series modes in its generated metadata.*
+engine; Windows and macOS mark reld **`pending`** (unsupported-by-design in this clang-based
+harness) until the rustc-based bridge measurement lands — an explicit, documented state that
+`latest.json` and the charts render distinctly from a failed `n/a`. Each platform gates its
+**expected** linkers in CI (Linux `bfd`/`lld`/`mold`/`wild`/`reld`, Windows `link.exe`/`lld`,
+macOS `ld`/`ld64.lld`): a missing timing for an expected linker fails the build, so coverage can
+never silently understate itself (see [#63](https://github.com/zackees/reld/issues/63)). Every
+chart labels reference, native, and bridge series modes in its generated metadata.*
 <!-- BENCHMARK:END -->
 
 ## What it is

--- a/ci/benchmark_coverage.py
+++ b/ci/benchmark_coverage.py
@@ -1,0 +1,214 @@
+"""Per-platform benchmark-coverage gate.
+
+Makes benchmark coverage *provable and honest* (issue #63): every linker we claim to measure on
+a platform must actually produce a real timing, and any remaining gap must be an explicit,
+documented **pending** state — never an accidental ``n/a``.
+
+Two policies, both keyed by the benchmark target label:
+
+* ``EXPECTED_LINKERS`` — linkers that MUST produce a real timing. A missing/failed/``pending``
+  timing for any of these fails the gate.
+* ``PENDING_LINKERS`` — series that are *unsupported-by-design* (documented) on that platform,
+  mapped to the reason. These must render as ``pending`` (or be measured); a bare ``n/a`` for one
+  of them is itself a failure, because a silent ``n/a`` is exactly what #63 forbids.
+
+Run as a gate::
+
+    python -m ci.benchmark_coverage --input-log path/to/benchmark.log --target x86_64-linux
+
+Exits non-zero (and prints the offending linkers) if coverage is not honest. Always prints a
+per-platform expected-vs-measured table to stdout and, when running under Actions, appends it to
+``$GITHUB_STEP_SUMMARY`` so a missing linker is loud in the run — not only discoverable by
+inspecting the published branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from ci.benchmark_stats import Report, parse_benchmark_log, target_os
+
+# Linkers that MUST produce a real timing on each platform. reld is expected on Linux (native
+# engine) but *pending* elsewhere until the bridge measurement lands — see PENDING_LINKERS.
+EXPECTED_LINKERS: dict[str, list[str]] = {
+    "x86_64-linux": ["bfd", "lld", "mold", "wild", "reld"],
+    "x86_64-pc-windows-msvc": ["link.exe", "lld"],
+    "aarch64-apple-darwin": ["ld", "ld64.lld"],
+}
+
+# Series that are unsupported-by-design (documented) on a platform, with the reason. They must
+# render as ``pending`` rather than a bare ``n/a``. Ties to the bridge status in the README and
+# issue #17.
+_RELD_BRIDGE_PENDING = "reld bridge measurement pending (rustc-based); see #17"
+PENDING_LINKERS: dict[str, dict[str, str]] = {
+    "x86_64-pc-windows-msvc": {"reld": _RELD_BRIDGE_PENDING},
+    "aarch64-apple-darwin": {"reld": _RELD_BRIDGE_PENDING},
+}
+
+# Fallback so an unrecognized/short target label still resolves to a policy via its OS.
+_OS_TO_TARGET = {
+    "Linux": "x86_64-linux",
+    "Windows": "x86_64-pc-windows-msvc",
+    "Darwin": "aarch64-apple-darwin",
+}
+
+
+def _canonical_target(target: str) -> str | None:
+    if target in EXPECTED_LINKERS:
+        return target
+    os_name = target_os(target)
+    return _OS_TO_TARGET.get(os_name or "")
+
+
+def expected_for(target: str) -> list[str]:
+    key = _canonical_target(target)
+    return list(EXPECTED_LINKERS.get(key or "", []))
+
+
+def pending_for(target: str) -> dict[str, str]:
+    key = _canonical_target(target)
+    return dict(PENDING_LINKERS.get(key or "", {}))
+
+
+class CoverageResult:
+    """Outcome of checking one platform's benchmark report against its policy."""
+
+    def __init__(self, target: str) -> None:
+        self.target = target
+        # series -> "measured" | "pending" | "na" (only for series we have a policy for)
+        self.statuses: dict[str, str] = {}
+        # (series, reason) tuples describing each violation.
+        self.violations: list[tuple[str, str]] = []
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+
+def check_coverage(report: Report, target: str) -> CoverageResult:
+    result = CoverageResult(target)
+    expected = expected_for(target)
+    pending = pending_for(target)
+
+    if not expected and not pending:
+        result.violations.append(
+            ("<policy>", f"no coverage policy defined for target {target!r}")
+        )
+        return result
+
+    for linker in expected:
+        status = report.series_status(linker)
+        result.statuses[linker] = status
+        if status != "measured":
+            detail = "reported n/a (failed/unavailable)" if status == "na" else f"reported {status}"
+            result.violations.append(
+                (linker, f"expected linker {linker!r} must be measured but {detail}")
+            )
+            continue
+        # Measured overall, but an expected linker must produce a real timing for *every*
+        # scenario — a partial n/a is a silent regression, exactly what #63 forbids.
+        missing = [r.scenario for r in report.rows if r.series == linker and r.seconds is None]
+        if missing:
+            result.violations.append(
+                (
+                    linker,
+                    f"expected linker {linker!r} has no timing for scenario(s): "
+                    f"{', '.join(missing)}",
+                )
+            )
+
+    for linker, reason in pending.items():
+        status = report.series_status(linker)
+        result.statuses.setdefault(linker, status)
+        # A pending-by-design series may be measured (bonus) or pending, but a bare n/a means the
+        # runner did not emit the deliberate pending marker — the silent gap #63 forbids.
+        if status == "na":
+            result.violations.append(
+                (
+                    linker,
+                    f"pending-by-design linker {linker!r} reported a bare n/a; it must be marked "
+                    f"pending ({reason})",
+                )
+            )
+
+    return result
+
+
+def render_summary(report: Report, result: CoverageResult) -> str:
+    expected = set(expected_for(result.target))
+    pending = pending_for(result.target)
+
+    def role(linker: str) -> str:
+        if linker in expected:
+            return "expected"
+        if linker in pending:
+            return "pending-by-design"
+        return "extra"
+
+    lines = [
+        f"### Benchmark coverage: {result.target}",
+        "",
+        "| Linker | Role | Status |",
+        "|:-------|:-----|:-------|",
+    ]
+    # Cover every series present plus every policy linker, in a stable order.
+    ordered = list(dict.fromkeys([*expected_for(result.target), *pending, *report.series]))
+    for linker in ordered:
+        status = result.statuses.get(linker) or report.series_status(linker)
+        # ASCII only: this string is also printed to stdout, which on the Windows CI leg is a
+        # redirected (non-tty) stream using the cp1252 locale encoding — emoji would raise
+        # UnicodeEncodeError and crash the gate even when coverage is healthy.
+        mark = {"measured": "OK measured", "pending": "-- pending", "na": "XX n/a"}.get(
+            status, status
+        )
+        lines.append(f"| {linker} | {role(linker)} | {mark} |")
+
+    lines.append("")
+    if result.ok:
+        lines.append("All expected linkers measured; no silent `n/a`.")
+    else:
+        lines.append("**Coverage gate failed:**")
+        for linker, reason in result.violations:
+            lines.append(f"- `{linker}`: {reason}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="ci.benchmark_coverage")
+    p.add_argument("--input-log", type=Path, required=True)
+    p.add_argument(
+        "--target",
+        default=None,
+        help="benchmark target label (e.g. x86_64-linux); falls back to the log heading",
+    )
+    args = p.parse_args(argv)
+
+    report = parse_benchmark_log(args.input_log.read_text(encoding="utf-8"))
+    # Prefer the explicit target; fall back to the label the runner stamped in the log.
+    target = args.target or report.label
+    if not target:
+        sys.stderr.write("no --target given and no benchmark heading found in the log\n")
+        return 1
+
+    result = check_coverage(report, target)
+    summary = render_summary(report, result)
+    print(summary)
+    if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(summary)
+
+    if not result.ok:
+        sys.stderr.write(
+            f"benchmark coverage gate failed for {target}: "
+            + "; ".join(reason for _, reason in result.violations)
+            + "\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 HISTORY_MAX_LINES = 1000
 IMAGE_NAME = "benchmark-link.jpg"
 HEADING_PREFIX = "## Link Benchmark:"
@@ -45,6 +45,9 @@ FG = (230, 237, 243)
 MUTED = (125, 133, 144)
 GRID = (48, 54, 61)
 NA = (70, 76, 86)
+# Pending (unsupported-by-design) reads as a deliberate, documented gap — amber, distinct from the
+# dim grey of a failed ``n/a`` so the chart never conflates the two.
+PENDING = (187, 128, 9)
 
 # Stable colour per linker so a series keeps its identity across runs.
 SERIES_COLORS = {
@@ -62,6 +65,15 @@ class Row:
     scenario: str
     series: str
     seconds: float | None
+    # A cell is *pending* when the linker is unsupported-by-design on this platform (documented,
+    # e.g. reld's bridge measurement on Windows/macOS) rather than *failed* (a real ``n/a``). The
+    # two are indistinguishable as bare ``n/a`` — this flag is what keeps them apart downstream.
+    pending: bool = False
+
+    def status(self) -> str:
+        if self.seconds is not None:
+            return "measured"
+        return "pending" if self.pending else "na"
 
 
 @dataclass
@@ -83,6 +95,23 @@ class Report:
                 return r.seconds
         return None
 
+    def is_pending(self, scenario: str, series: str) -> bool:
+        for r in self.rows:
+            if r.scenario == scenario and r.series == series:
+                return r.pending
+        return False
+
+    def series_status(self, series: str) -> str:
+        """Collapse a series' per-scenario cells into one status. A series counts as *measured*
+        if any scenario produced a real timing, *pending* if it was never measured but every
+        cell is a deliberate pending marker, otherwise *na* (failed)."""
+        cells = [r for r in self.rows if r.series == series]
+        if any(r.seconds is not None for r in cells):
+            return "measured"
+        if cells and all(r.pending for r in cells):
+            return "pending"
+        return "na"
+
 
 def _clean(cell: str) -> str:
     return cell.replace("**", "").replace("`", "").strip()
@@ -96,6 +125,20 @@ def _to_seconds(cell: str) -> float | None:
         return float(cell.rstrip("s"))
     except ValueError:
         return None
+
+
+# Cell tokens the runner uses to mark a linker it did not time on purpose, rather than one that
+# failed. Kept distinct from the ``n/a`` family in ``_to_seconds`` so pending never renders as a
+# silent failure.
+_PENDING_TOKENS = ("pending", "pending*", "todo")
+
+
+def _classify(cell: str) -> tuple[float | None, bool]:
+    """Return ``(seconds, pending)`` for a raw table cell. ``seconds`` is ``None`` for both
+    failed (``n/a``) and pending cells; ``pending`` is ``True`` only for the deliberate markers."""
+    if _clean(cell).lower() in _PENDING_TOKENS:
+        return None, True
+    return _to_seconds(cell), False
 
 
 def parse_benchmark_log(text: str) -> Report:
@@ -139,8 +182,10 @@ def parse_benchmark_log(text: str) -> Report:
         if not scenario:
             continue
         for idx, series in enumerate(report.series, start=1):
-            value = _to_seconds(cells[idx]) if idx < len(cells) else None
-            report.rows.append(Row(scenario=scenario, series=series, seconds=value))
+            value, pending = _classify(cells[idx]) if idx < len(cells) else (None, False)
+            report.rows.append(
+                Row(scenario=scenario, series=series, seconds=value, pending=pending)
+            )
 
     return report
 
@@ -272,12 +317,15 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
             d.text((34 * SCALE, (y + 5) * SCALE), s, font=f_meta, fill=MUTED)
 
             if v is None:
+                pending = report.is_pending(scenario, s)
+                edge = PENDING if pending else NA
+                label = "pending" if pending else "n/a"
                 d.rectangle(
                     [bar_x * SCALE, (y + 4) * SCALE, (bar_x + 60) * SCALE, (y + 18) * SCALE],
-                    outline=NA,
+                    outline=edge,
                     width=SCALE,
                 )
-                d.text(((bar_x + 70) * SCALE, (y + 5) * SCALE), "n/a", font=f_meta, fill=NA)
+                d.text(((bar_x + 70) * SCALE, (y + 5) * SCALE), label, font=f_meta, fill=edge)
             else:
                 w = max(2, int(bar_max * (v / peak))) if peak > 0 else 2
                 d.rectangle(
@@ -297,7 +345,8 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
 
     d.text(
         (20 * SCALE, (height - 24) * SCALE),
-        "lower is better  |  median of N trials, link step only  |  n/a = linker unavailable on runner",
+        "lower is better  |  median of N trials, link step only  |  "
+        "n/a = linker failed/unavailable  |  pending = unsupported-by-design (documented)",
         font=f_meta,
         fill=MUTED,
     )
@@ -313,7 +362,12 @@ def render_html(report: Report, meta: dict[str, Any]) -> str:
         cells = ""
         for s in report.series:
             v = report.value(sc, s)
-            cells += f"<td>{'n/a' if v is None else f'{v:.4f}s'}</td>"
+            if v is not None:
+                cells += f"<td>{v:.4f}s</td>"
+            elif report.is_pending(sc, s):
+                cells += '<td class="pending">pending</td>'
+            else:
+                cells += '<td class="na">n/a</td>'
         body += f"<tr><td>{sc}</td>{cells}</tr>"
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>reld benchmarks</title>
@@ -321,6 +375,7 @@ def render_html(report: Report, meta: dict[str, Any]) -> str:
 body{{background:#0d1117;color:#e6edf3;font:14px system-ui,sans-serif;margin:2rem auto;max-width:960px}}
 table{{border-collapse:collapse;width:100%}}th,td{{border:1px solid #30363d;padding:.4rem .6rem;text-align:right}}
 th:first-child,td:first-child{{text-align:left}}img{{max-width:100%}}a{{color:#58a6ff}}
+td.na{{color:#7d8590}}td.pending{{color:#bb8009}}
 </style></head><body>
 <h1>reld &mdash; link benchmark</h1>
 <p>{meta['generated_at']} &middot; {meta.get('target','')} &middot; {meta['runner']['platform']}</p>
@@ -347,6 +402,10 @@ def write_outputs(report: Report, meta: dict[str, Any], out_dir: Path) -> None:
                 "scenario": r.scenario,
                 "series": r.series,
                 "seconds": r.seconds,
+                # "measured" | "pending" | "na" — pending (unsupported-by-design, documented) is
+                # kept distinct from na (failed) so consumers never read a deliberate gap as a
+                # regression. See issue #63.
+                "status": r.status(),
                 "mode": series_mode(r.series, runner_os, meta.get("target", "")),
             }
             for r in report.rows

--- a/ci/tests/test_benchmark_coverage.py
+++ b/ci/tests/test_benchmark_coverage.py
@@ -1,0 +1,168 @@
+"""Per-platform benchmark-coverage gate tests (issue #63).
+
+These are the RED -> GREEN gate: a benchmark where an *expected* linker silently reports ``n/a``
+must fail the check, and a benchmark where reld is *explicitly pending* on Windows/macOS must
+pass. The same log that a pre-#63 pipeline published happily (expected linker as bare ``n/a``) is
+now rejected here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from ci.benchmark_coverage import (  # noqa: E402
+    check_coverage,
+    expected_for,
+    main,
+    pending_for,
+    render_summary,
+)
+from ci.benchmark_stats import parse_benchmark_log  # noqa: E402
+
+LINUX_FULL = """
+## Link Benchmark: x86_64-linux
+
+| Scenario | bfd | lld | mold | wild | reld |
+|:---------|----:|----:|-----:|-----:|----:|
+| small (16 units) | 0.0210 | 0.0081 | 0.0062 | 0.0044 | 0.0216 |
+| large (512 units) | 0.6120 | 0.1602 | 0.0904 | 0.0631 | 0.2100 |
+"""
+
+# The exact shape #63 forbids: an expected linker (reld on Linux) as a bare n/a.
+LINUX_RELD_NA = LINUX_FULL.replace("| 0.0216 |", "| n/a |").replace("| 0.2100 |", "| n/a |")
+
+# Another silent gap: wild (expected on Linux) drops to n/a.
+LINUX_WILD_NA = LINUX_FULL.replace("| 0.0044 |", "| n/a |").replace("| 0.0631 |", "| n/a |")
+
+MACOS_RELD_PENDING = """
+## Link Benchmark: aarch64-apple-darwin
+
+| Scenario | ld | ld64.lld | reld |
+|:---------|---:|---------:|----:|
+| small (16 units) | 0.0300 | 0.0120 | pending |
+| large (512 units) | 0.6000 | 0.1600 | pending |
+"""
+
+# reld on macOS as a bare n/a — it must be explicitly pending, not silently n/a.
+MACOS_RELD_NA = MACOS_RELD_PENDING.replace("| pending |", "| n/a |")
+
+# macOS with ld64.lld silently n/a — the #60 regression the gate must catch.
+MACOS_LD64_NA = MACOS_RELD_PENDING.replace("| 0.0120 |", "| n/a |").replace(
+    "| 0.1600 |", "| n/a |"
+)
+
+WINDOWS_OK = """
+## Link Benchmark: x86_64-pc-windows-msvc
+
+| Scenario | link.exe | lld | reld |
+|:---------|---------:|----:|----:|
+| small (16 units) | 0.0500 | 0.0200 | pending |
+"""
+
+
+def _check(log: str, target: str):
+    return check_coverage(parse_benchmark_log(log), target)
+
+
+def test_policy_matches_issue_63_expected_sets():
+    assert expected_for("x86_64-linux") == ["bfd", "lld", "mold", "wild", "reld"]
+    assert expected_for("x86_64-pc-windows-msvc") == ["link.exe", "lld"]
+    assert expected_for("aarch64-apple-darwin") == ["ld", "ld64.lld"]
+    # reld is pending-by-design on Windows/macOS, not on Linux.
+    assert "reld" in pending_for("x86_64-pc-windows-msvc")
+    assert "reld" in pending_for("aarch64-apple-darwin")
+    assert pending_for("x86_64-linux") == {}
+
+
+def test_full_linux_coverage_passes():
+    result = _check(LINUX_FULL, "x86_64-linux")
+    assert result.ok, result.violations
+    assert result.statuses["reld"] == "measured"
+
+
+def test_expected_linker_na_fails_the_gate():
+    # This is the RED -> GREEN heart: pre-#63 this log published fine; now it must fail.
+    result = _check(LINUX_RELD_NA, "x86_64-linux")
+    assert not result.ok
+    assert any(linker == "reld" for linker, _ in result.violations)
+
+
+def test_expected_reference_linker_na_fails_the_gate():
+    result = _check(LINUX_WILD_NA, "x86_64-linux")
+    assert not result.ok
+    assert any(linker == "wild" for linker, _ in result.violations)
+
+
+def test_partial_scenario_na_for_expected_linker_fails_the_gate():
+    # mold is measured for `small` but silently n/a for `large` — a partial regression that must
+    # not slip through just because the series has *some* timing.
+    partial = LINUX_FULL.replace("| 0.0904 |", "| n/a |")
+    result = _check(partial, "x86_64-linux")
+    assert not result.ok
+    violation = next((r for linker, r in result.violations if linker == "mold"), None)
+    assert violation is not None and "large (512 units)" in violation
+
+
+def test_render_summary_is_ascii_only():
+    # Printed to stdout on the Windows CI leg (cp1252, redirected) — non-ASCII would crash it.
+    report = parse_benchmark_log(LINUX_RELD_NA)
+    summary = render_summary(report, check_coverage(report, "x86_64-linux"))
+    summary.encode("ascii")  # raises UnicodeEncodeError if any emoji slipped back in
+
+
+def test_macos_ld64_na_fails_the_gate():
+    # #60's exact regression: ld64.lld silently n/a must now be loud.
+    result = _check(MACOS_LD64_NA, "aarch64-apple-darwin")
+    assert not result.ok
+    assert any(linker == "ld64.lld" for linker, _ in result.violations)
+
+
+def test_reld_pending_on_macos_passes():
+    result = _check(MACOS_RELD_PENDING, "aarch64-apple-darwin")
+    assert result.ok, result.violations
+    assert result.statuses["reld"] == "pending"
+
+
+def test_reld_bare_na_on_macos_fails():
+    # reld must be *explicitly* pending on macOS; a bare n/a is the silent gap #63 forbids.
+    result = _check(MACOS_RELD_NA, "aarch64-apple-darwin")
+    assert not result.ok
+    assert any(linker == "reld" for linker, _ in result.violations)
+
+
+def test_windows_pending_reld_passes():
+    result = _check(WINDOWS_OK, "x86_64-pc-windows-msvc")
+    assert result.ok, result.violations
+
+
+def test_target_resolves_via_os_when_label_is_short():
+    # A non-canonical label still resolves to a policy through its OS.
+    result = _check(LINUX_FULL.replace("x86_64-linux", "linux"), "linux")
+    assert result.ok, result.violations
+
+
+def test_render_summary_lists_roles_and_status():
+    report = parse_benchmark_log(MACOS_RELD_PENDING)
+    result = check_coverage(report, "aarch64-apple-darwin")
+    summary = render_summary(report, result)
+    assert "Benchmark coverage: aarch64-apple-darwin" in summary
+    assert "ld64.lld" in summary and "expected" in summary
+    assert "pending-by-design" in summary
+    assert "pending" in summary
+
+
+def test_main_exits_nonzero_on_silent_na(tmp_path):
+    log = tmp_path / "benchmark.log"
+    log.write_text(LINUX_RELD_NA, encoding="utf-8")
+    rc = main(["--input-log", str(log), "--target", "x86_64-linux"])
+    assert rc == 1
+
+
+def test_main_exits_zero_on_honest_coverage(tmp_path):
+    log = tmp_path / "benchmark.log"
+    log.write_text(LINUX_FULL, encoding="utf-8")
+    rc = main(["--input-log", str(log), "--target", "x86_64-linux"])
+    assert rc == 0

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -84,12 +84,17 @@ def test_write_outputs_produces_all_artifacts(tmp_path):
         assert (tmp_path / name).exists(), name
 
     payload = json.loads((tmp_path / "latest.json").read_text())
-    assert payload["schema_version"] == 2
+    assert payload["schema_version"] == 3
     assert len(payload["results"]) == 15
     for entry in payload["results"]:
         assert "mode" in entry
+        assert "status" in entry
         if entry["series"] in ("bfd", "lld"):
             assert entry["mode"] == "reference"
+            assert entry["status"] == "measured"
+        if entry["series"] == "reld":
+            # SAMPLE_LOG has reld as a bare n/a (not a pending marker), so it is a failure.
+            assert entry["status"] == "na"
 
 
 def test_series_mode():
@@ -122,3 +127,52 @@ def test_render_refuses_empty(tmp_path):
     r = parse_benchmark_log("nothing")
     with pytest.raises(SystemExit):
         write_outputs(r, collect_metadata(r), tmp_path)
+
+
+PENDING_LOG = """
+## Link Benchmark: aarch64-apple-darwin
+
+| Scenario | ld | ld64.lld | reld |
+|:---------|---:|---------:|----:|
+| small (16 units) | 0.0300 | 0.0120 | pending |
+| medium (128 units) | 0.1500 | 0.0400 | pending |
+| large (512 units) | 0.6000 | 0.1600 | pending |
+
+<!-- linker reld pending: reld bridge measurement pending (rustc-based); see #17 -->
+"""
+
+
+def test_pending_cells_parse_as_pending_not_na():
+    r = parse_benchmark_log(PENDING_LOG)
+    # A pending cell has no timing (like n/a) but is flagged distinctly.
+    assert r.value("small (16 units)", "reld") is None
+    assert r.is_pending("small (16 units)", "reld") is True
+    # A real n/a would not be flagged pending.
+    assert r.is_pending("small (16 units)", "ld") is False
+
+
+def test_series_status_distinguishes_pending_measured_and_na():
+    r = parse_benchmark_log(PENDING_LOG)
+    assert r.series_status("ld") == "measured"
+    assert r.series_status("ld64.lld") == "measured"
+    assert r.series_status("reld") == "pending"
+    # A series absent from the table is treated as na, never pending.
+    assert parse_benchmark_log(SAMPLE_LOG).series_status("reld") == "na"
+
+
+def test_latest_json_carries_pending_status(tmp_path):
+    r = parse_benchmark_log(PENDING_LOG)
+    write_outputs(r, collect_metadata(r), tmp_path)
+    payload = json.loads((tmp_path / "latest.json").read_text())
+    reld = [e for e in payload["results"] if e["series"] == "reld"]
+    assert reld and all(e["status"] == "pending" for e in reld)
+    assert all(e["seconds"] is None for e in reld)
+
+
+def test_html_marks_pending_distinctly():
+    from ci.benchmark_stats import render_html
+
+    report = parse_benchmark_log(PENDING_LOG)
+    html = render_html(report, collect_metadata(report))
+    assert 'class="pending">pending<' in html
+    assert "n/a" not in html  # every reld cell is pending here, no failed cells

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -17,3 +17,17 @@ def test_benchmark_workflow_publishes_one_directory_per_target():
     assert "needs: benchmark" in text
     assert 'benchmark-stats/$target' in text
     assert "github.event.repository.default_branch" in text
+
+
+def test_benchmark_workflow_gates_expected_linker_coverage():
+    text = WORKFLOW.read_text()
+
+    # The per-platform coverage gate must run on every leg (#63): a missing expected linker
+    # fails the build rather than shipping a silent n/a.
+    assert "ci.benchmark_coverage" in text
+    assert "Assert benchmark coverage" in text
+
+    # reld is pending-by-design on Windows/macOS, so those legs pass --reld-pending; Linux (where
+    # reld is expected/measured) must not.
+    assert "--reld-pending" in text
+    assert text.count("reld_pending:") == 2  # windows + macOS matrix entries only

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -30,3 +30,13 @@ def test_ci_cross_compiles_release_on_linux():
     assert "x86_64-pc-windows-gnu" in text
     assert "gcc-mingw-w64-x86-64" in text
     assert "CC_x86_64_pc_windows_gnu" in text
+
+
+def test_ci_marks_reld_pending_on_windows_and_macos_benchmarks():
+    text = WORKFLOW.read_text()
+
+    # reld has no shim on the Windows/macOS PR benchmark smokes, so it must render an explicit
+    # `pending` (with reason) rather than a silent n/a (#63). Both legs pass --reld-pending.
+    assert "--reld-pending" in text
+    # Both legs assert the pending marker actually appears in the table (windows + macOS).
+    assert text.count("reld must render 'pending'") == 2

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -56,6 +56,14 @@ struct Args {
     #[arg(long)]
     target: Option<String>,
 
+    /// Mark reld as *pending / unsupported-by-design* with this reason when it can't be measured
+    /// on this platform (e.g. the bridge measurement hasn't landed yet on Windows/macOS). The
+    /// reld cell then renders `pending` (carrying the reason as an HTML comment) instead of a bare
+    /// `n/a`, so the chart and `latest.json` can tell a documented gap apart from a real failure
+    /// (#63). Ignored when a working `ld.reld` shim is discovered — real data always wins.
+    #[arg(long)]
+    reld_pending: Option<String>,
+
     /// Replay a frozen link corpus instead of generating synthetic workloads: this directory
     /// must contain `corpus.json` plus the referenced object files (as produced by the
     /// benchmark-assets pipeline and fetched via `ci/benchmark_assets.py`). Times only the link
@@ -238,6 +246,15 @@ fn main() -> Result<()> {
         reld_unavailable_reason
     };
 
+    let reld_measured = reld_shim_str.is_some() && reld_ok;
+    // When reld can't be measured but the caller declared it pending-by-design, render `pending`
+    // (carrying the reason) instead of a silent `n/a`. A working shim always wins over the flag.
+    let reld_pending = if reld_measured {
+        None
+    } else {
+        args.reld_pending.clone()
+    };
+
     let target = args.target.clone().unwrap_or_else(target_triple);
     println!("## Link Benchmark: {target}");
     println!();
@@ -276,15 +293,21 @@ fn main() -> Result<()> {
                 }
             }
         }
-        match (&reld_shim_str, reld_ok) {
-            (Some(linker), true) => match time_link(&args, &dir, &objects, linker) {
+        if reld_measured {
+            let linker = reld_shim_str
+                .as_ref()
+                .expect("measured implies a shim path");
+            match time_link(&args, &dir, &objects, linker) {
                 Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
                 Err(e) => {
                     failures.push(("reld".to_string(), name.clone(), e.to_string()));
                     println!(" n/a |");
                 }
-            },
-            _ => println!(" n/a |"),
+            }
+        } else if reld_pending.is_some() {
+            println!(" pending |");
+        } else {
+            println!(" n/a |");
         }
     }
 
@@ -297,7 +320,9 @@ fn main() -> Result<()> {
             );
         }
     }
-    if let Some(reason) = reld_unavailable_reason {
+    if let Some(reason) = &reld_pending {
+        println!("{}", format_pending_comment("reld", reason));
+    } else if let Some(reason) = reld_unavailable_reason {
         println!("<!-- linker reld not available: {reason} -->");
     }
     for (linker, scenario, error) in &failures {
@@ -336,6 +361,25 @@ fn format_failure_comment(linker: &str, scenario: &str, error: &str) -> String {
         neutralized
     };
     format!("<!-- linker {linker} link failed ({scenario}): {truncated} -->")
+}
+
+/// Format reld's pending-by-design marker as a single-line HTML comment carrying the reason. Same
+/// one-line / `-->`-safe / length-capped guarantees as [`format_failure_comment`], so it is always
+/// safe to emit as one `<!-- ... -->` line.
+fn format_pending_comment(linker: &str, reason: &str) -> String {
+    let collapsed = reason.split_whitespace().collect::<Vec<_>>().join(" ");
+    let neutralized = collapsed.replace("-->", "- >");
+    let truncated: String = if neutralized.chars().count() > FAILURE_COMMENT_ERROR_LIMIT {
+        let mut s: String = neutralized
+            .chars()
+            .take(FAILURE_COMMENT_ERROR_LIMIT)
+            .collect();
+        s.push_str("...");
+        s
+    } else {
+        neutralized
+    };
+    format!("<!-- linker {linker} pending: {truncated} -->")
 }
 
 fn target_triple() -> String {
@@ -543,6 +587,12 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
         Some(linker) => probe_linker(&cc, linker, &root).unwrap_or(false),
         None => false,
     };
+    let reld_measured = reld_shim_str.is_some() && reld_ok;
+    let reld_pending = if reld_measured {
+        None
+    } else {
+        args.reld_pending.clone()
+    };
 
     let target = args.target.clone().unwrap_or_else(target_triple);
     let scenario = corpus
@@ -581,8 +631,11 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
             Err(_) => print!(" n/a |"),
         }
     }
-    match (&reld_shim_str, reld_ok) {
-        (Some(linker), true) => match time_link_replay(
+    if reld_measured {
+        let linker = reld_shim_str
+            .as_ref()
+            .expect("measured implies a shim path");
+        match time_link_replay(
             &cc,
             &objects,
             &corpus.extra_link_args,
@@ -593,10 +646,16 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
         ) {
             Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
             Err(_) => println!(" n/a |"),
-        },
-        _ => println!(" n/a |"),
+        }
+    } else if reld_pending.is_some() {
+        println!(" pending |");
+    } else {
+        println!(" n/a |");
     }
     println!();
+    if let Some(reason) = &reld_pending {
+        println!("{}", format_pending_comment("reld", reason));
+    }
     Ok(())
 }
 
@@ -640,6 +699,48 @@ mod tests {
     fn ld64_lld_token_falls_back_to_lld_when_not_found() {
         let resolved = resolve_fuse_ld("ld64.lld", |_| None);
         assert_eq!(resolved, "lld");
+    }
+
+    #[test]
+    fn expected_linker_tokens_never_resolve_to_a_bogus_ld_name() {
+        // Regression guard for #60/#63 across the full expected matrix: no expected linker may
+        // resolve to a bare `ld64.lld`, which clang would rewrite to a nonexistent `ld.ld64.lld`
+        // and link silently to n/a. Reference linkers pass through so clang forms the real
+        // `ld.bfd` / `ld.lld` / `ld.mold` / `ld.wild`; `ld64.lld` must be rewritten.
+        for token in ["bfd", "lld", "mold", "wild"] {
+            assert_eq!(
+                resolve_fuse_ld(token, |_| panic!("reference tokens need no PATH lookup")),
+                token,
+                "{token} must pass through so clang forms ld.{token}"
+            );
+        }
+        assert_eq!(
+            resolve_fuse_ld("ld64.lld", |_| Some(PathBuf::from("/usr/bin/ld64.lld"))),
+            "/usr/bin/ld64.lld"
+        );
+        let fallback = resolve_fuse_ld("ld64.lld", |_| None);
+        assert_ne!(
+            fallback, "ld64.lld",
+            "must never stay a bare ld64.lld token"
+        );
+        assert_eq!(fallback, "lld");
+    }
+
+    #[test]
+    fn format_pending_comment_is_single_line_and_safe() {
+        // The reason is caller-supplied, so it gets the same one-line / `-->`-safe treatment as a
+        // failure comment: no embedded newline, exactly one `-->` (the closing delimiter).
+        let comment =
+            format_pending_comment("reld", "bridge measurement pending\nsee --> issue #17");
+        assert!(
+            comment.starts_with("<!-- linker reld pending: "),
+            "{comment}"
+        );
+        assert!(comment.ends_with("-->"));
+        assert_eq!(comment.matches("-->").count(), 1, "{comment}");
+        assert!(!comment.contains('\n'), "{comment}");
+        assert!(comment.contains("bridge measurement pending"));
+        assert!(comment.contains("issue #17"));
     }
 
     #[test]


### PR DESCRIPTION
Resolves #63 — makes benchmark linker-coverage **provable and honest**: it is now structurally impossible for an *expected* linker to silently drop to `n/a`, and a documented gap (reld's bridge on Windows/macOS) is an explicit **pending** state distinct from a failed `n/a`.

## What changed

**`reld-bench` (`--reld-pending <reason>`)**
- When reld can't be measured but is declared pending-by-design, the reld cell renders `pending` (carrying the reason as an HTML comment) instead of a bare `n/a`. A working `ld.reld` shim always wins over the flag. Applies to both the synthetic and `--replay-corpus` paths.

**`ci/benchmark_stats.py`**
- Parses/renders `pending` distinctly (chart = amber outline+label, HTML = `pending` cell) and emits a new per-result `status` (`measured` | `pending` | `na`) in `latest.json`/`history.jsonl`. `schema_version` 2 to 3.

**`ci/benchmark_coverage.py` (new) — the gate**
- Per-platform expected sets (from #63): linux `{bfd, lld, mold, wild, reld}`, windows `{link.exe, lld}`, macOS `{ld, ld64.lld}`.
- Fails CI if any expected linker reports `n/a` — including a **partial per-scenario** `n/a` — or if a pending-by-design linker slips to a bare `n/a`.
- Prints expected-vs-measured coverage to the job log and `$GITHUB_STEP_SUMMARY` (ASCII-only, so the Windows leg's cp1252 stdout can't crash it).

**Workflows**
- `benchmark-stats.yml`: runs the gate on every platform leg; passes `--reld-pending` on Windows/macOS.
- `ci.yml`: the PR benchmark smokes now mark reld `pending` and assert it (PR-visible RED to GREEN).

**README**: documents the `pending` state and the per-platform gate.

## Acceptance criteria (#63)
- [x] CI fails if any platform's **expected** linker reports `n/a`.
- [x] `latest.json` / charts distinguish **pending** from failed `n/a`.
- [x] reld is explicitly **pending** on Windows/macOS (no bare `n/a`).
- [x] Per-platform expected-vs-measured coverage printed in the job.
- [x] RED to GREEN gate: `test_expected_linker_na_fails_the_gate` (and the macOS `ld64.lld` case from #60) fail with a silent `n/a` and pass once honest.

## Testing
- `pytest ci/tests` — 66 passed (coverage gate RED to GREEN, pending parse/render, workflow-lint wiring).
- reld-bench unit tests — 17 passed (adds `resolve_fuse_ld` regression matrix + pending-comment safety).
- rustfmt `--check` and clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
