### PR TITLE
Validate linker modes across Linux, Windows, and macOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.extern-repos
+.bosn-state
+.pytest_cache
+target
+bench.log
+rr.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,9 @@ jobs:
             malfunction-elf-relocation-target-plus-one \
             --test-threads=1 2>&1 | tee malfunction-tests.log
 
-      - name: Linux LTO fixture compatibility
+      # Reld's routed LTO modes are exercised by linker-modes.yml. These native acceptance
+      # fixtures retain coverage for the pinned reference linker and its compiler plugin.
+      - name: Linux LTO reference fixture compatibility
         if: matrix.kind == 'linux-gnu'
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,18 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          # GitHub's Azure mirror can accept the connection and then stall
+          # indefinitely while fetching package indexes. Use Ubuntu's HTTPS
+          # archive directly and keep network failures bounded.
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|https://archive.ubuntu.com/ubuntu/|' /etc/apt/sources.list.d/ubuntu.sources
+          APT_OPTIONS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=30)
           curl -fsSL -o "${RUNNER_TEMP}/llvm-snapshot.gpg.key" https://apt.llvm.org/llvm-snapshot.gpg.key
           echo '8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0b8c75d  '${RUNNER_TEMP}'/llvm-snapshot.gpg.key' | sha256sum --check
           gpg --dearmor < "${RUNNER_TEMP}/llvm-snapshot.gpg.key" > "${RUNNER_TEMP}/llvm-snapshot.gpg"
           sudo install -m 644 "${RUNNER_TEMP}/llvm-snapshot.gpg" /usr/share/keyrings/llvm-snapshot.gpg
           echo 'deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' | sudo tee /etc/apt/sources.list.d/llvm-22.list
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get "${APT_OPTIONS[@]}" update
+          sudo apt-get "${APT_OPTIONS[@]}" install -y \
             "clang-22=${CLANG_PACKAGE_VERSION}" \
             "llvm-22-linker-tools=${CLANG_PACKAGE_VERSION}"
 
@@ -552,8 +557,11 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
+          # Avoid indefinite hangs from GitHub's Azure Ubuntu mirror.
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|https://archive.ubuntu.com/ubuntu/|' /etc/apt/sources.list.d/ubuntu.sources
+          APT_OPTIONS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=30)
+          sudo apt-get "${APT_OPTIONS[@]}" update
+          sudo apt-get "${APT_OPTIONS[@]}" install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
 
       - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:

--- a/.github/workflows/linker-modes.yml
+++ b/.github/workflows/linker-modes.yml
@@ -1,0 +1,56 @@
+name: Linker modes
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linker-modes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  exercise:
+    name: ${{ matrix.platform }} / fast + ThinLTO + LTO
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            runner: ubuntu-24.04
+            install_llvm: true
+          - platform: windows
+            runner: windows-2022
+            install_llvm: true
+          - platform: macos
+            runner: macos-14
+            install_llvm: false
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - if: matrix.install_llvm
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
+        with:
+          version: 18.1.8
+      - name: Exercise every linker mode
+        run: >-
+          uv run --no-project python ci/linker_modes.py
+          --platform ${{ matrix.platform }}
+          --report linker-modes-${{ matrix.platform }}.json
+      - if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linker-modes-${{ matrix.platform }}
+          path: linker-modes-${{ matrix.platform }}.json
+          if-no-files-found: warn

--- a/.github/workflows/linker-modes.yml
+++ b/.github/workflows/linker-modes.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - platform: linux
             runner: ubuntu-24.04
-            install_llvm: true
+            install_llvm: false
           - platform: windows
             runner: windows-2022
             install_llvm: true
@@ -43,6 +43,12 @@ jobs:
         uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
         with:
           version: 18.1.8
+      - name: Install upstream clang for macOS LTO
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          brew install llvm@18
+          echo "$(brew --prefix llvm@18)/bin" >> "${GITHUB_PATH}"
       - name: Exercise every linker mode
         run: >-
           uv run --no-project python ci/linker_modes.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # Local scratch
 /.tmp/
 /dist/
+/.bosn-state/
+/linker-modes*.json
 
 # Editors
 .vscode/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,10 +7,10 @@
 > Mach-O codegen in reld's own engine is still future work. Every performance figure in this
 > document is a *target*, not a measurement, except the Linux `reld` column in the published
 > benchmark, which is now a real CI-generated measurement (§6). reld's bundling of multiple real
-> linkers per platform is the basis for the **polylinker** framing in §4.5 — a flag-aware router
-> that would pick the right bundled engine per requested link configuration (e.g. LTO). That
-> router is **design only** ([#30](https://github.com/zackees/reld/issues/30)); today's routing
-> is by platform/format alone.
+> linkers per platform is the basis for the **polylinker** framing in §4.5. Its initial ELF
+> implementation routes LTO, ICF, and compatibility-policy requests to a capable bundled engine;
+> see [#30](https://github.com/zackees/reld/issues/30). Native COFF/Mach-O engines and the broader
+> capability matrix remain future work.
 
 ## 1. Position
 
@@ -99,15 +99,15 @@ linker across all target platforms, because a fast non-LTO linker is what the in
 actually needs and because LTO interacts with almost every other subsystem — sequencing it
 early would slow down the thing the project exists to deliver.
 
-**[DESIGN] Routing framing (not yet implemented).** reld does not plan to implement LTO natively
+**[SHIPPED routing; native codegen remains future work.]** reld does not plan to implement LTO natively
 in its own engine as the primary path. Instead, per the polylinker model (§4.5) and
 [#30](https://github.com/zackees/reld/issues/30), an LTO-shaped link request
 (`-flto`, `--plugin`, `/LTCG`, `/GL`) is meant to be **routed to whichever bundled engine already
 has real LTO support** — today that would be the `lld` bridge (§4.4), which does. This makes LTO
 *delegated*, not rejected, at the product level, while reld's own engine still owns zero LTO
-codegen. **The flag-aware router that would make this real does not exist yet** — see §4.5 for
-status. Until it lands, current behavior stands: LTO flags are **rejected or ignored with a
-clear, specific diagnostic** — never silently mislinked. Note that `wild` already has a
+codegen. The flag-aware router implements this for ELF today; see §4.5 for the exact capability
+set. Forcing the native engine for an LTO request is a clear capability error, never a silent
+mislink. Note that `wild` already has a
 linker-plugin LTO implementation with known issues; the fork inherits it, so on ELF the starting
 position is "partially works", not "absent". Do not delete that code. See
 [D13](docs/plan/01-DECISIONS.md) for the locked-decision record of this reframing.
@@ -155,8 +155,9 @@ must be the multiplier on an already-good serial path, not a substitute for one.
 Native codegen for PE/COFF (§4.1, §2.1) and Mach-O is not yet built. In the meantime, reld
 **bridges** Windows and macOS links by delegating to `lld` — `lld-link` for COFF, `ld64.lld` for
 Mach-O — both drivers built into the `rust-lld` binary that ships with every Rust toolchain.
-reld discovers the linker, execs it with the original argv, and propagates its exit code and
-diagnostics verbatim; the bridge does no parsing or layout of its own. This is proven by CI
+reld discovers the linker, classifies argv for routing, execs it with the compatible linker
+arguments, and propagates its exit code and diagnostics verbatim; the bridge does no layout of
+its own. This is proven by CI
 end-to-end builds on the windows-msvc and macos-arm64 runners that link and run a real
 multi-crate program with a C dependency (`rusqlite` bundled/SQLite).
 
@@ -169,14 +170,14 @@ fidelity). See [issue #17](https://github.com/zackees/reld/issues/17) for the ph
 
 ### 4.5 Polylinker: flag-aware routing over bundled engines
 
-**[DESIGN — not yet implemented.]** §4.4 establishes that reld already bundles more than one
+**[INITIAL IMPLEMENTATION SHIPPED.]** §4.4 establishes that reld bundles more than one
 real linker per platform (native engine + lld bridge) and already routes between them — but only
 on the platform/format axis, decided once at dispatch. [#30](https://github.com/zackees/reld/issues/30)
 proposes generalizing that into a **polylinker**: a router that also inspects the *requested
 configuration* (argv flags, env) and picks the bundled engine whose capabilities cover it. This
-section specifies that design so it can be implemented against (B8 in
-[#17](https://github.com/zackees/reld/issues/17), and the daemon router in
-[#19](https://github.com/zackees/reld/issues/19)); none of it is built yet.
+section specifies the policy implemented by the initial ELF router (B8 in
+[#17](https://github.com/zackees/reld/issues/17)) and to be extended by the daemon router in
+[#19](https://github.com/zackees/reld/issues/19).
 
 **Capability model.** Each bundled engine declares, in a static table (plus a cheap runtime
 probe where useful), which configurations it supports: LTO/ThinLTO, plugin interface,
@@ -196,8 +197,8 @@ Engine::LldBridge{ formats: [Coff, MachO, Elf],    lto: true,  incremental: fals
 3. Escalate to a more capable bundled engine when the requested configuration demands it (e.g.
    `-flto` on a platform where the native engine exists but doesn't support LTO → route to the
    lld bridge instead).
-4. `--engine=<name>` / `RELD_ENGINE` forces a specific bundled engine, bypassing routing
-   entirely — for benchmarking and as an escape hatch.
+4. `--engine=<name>` / `RELD_ENGINE` bypasses automatic engine selection for benchmarking and
+   as an escape hatch; the requested engine is still format- and capability-validated.
 
 **Fallback ordering.** If the default (fastest) engine can't satisfy a requested capability, fall
 back to a capable bundled engine rather than failing outright, ordered by (capability match, then
@@ -228,11 +229,11 @@ not by forking a new routing path per engine; see
 |---|---|
 | Multiple real linkers bundled per platform | Shipped (§4.4) |
 | Routing by platform/format at dispatch | Shipped (§4.4) |
-| Capability table | Design only |
-| Flag/config classification + routing | Design only |
-| Fallback-on-missing-capability | Design only |
-| `--engine=` / `RELD_ENGINE` override | Design only |
-| Per-decision routing log | Design only |
+| Capability table | Shipped: initial ELF/LTO/ICF and compatibility-policy set |
+| Flag/config classification + routing | Shipped for ELF, including nested response-file plugin detection |
+| Fallback-on-missing-capability | Shipped: native ELF → ELF `lld` |
+| `--engine=` / `RELD_ENGINE` override | Shipped |
+| Per-decision routing log | Shipped |
 
 ## 5. Honest risks
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -210,7 +210,9 @@ correctness-affecting flag or produce a silent mislink.
 spirit as the bridge's existing `reld: delegating to <linker> (bridge mode)` line (§4.4, B5):
 `reld: engine=<name> (reason: default|flag:-flto|fallback:<cap>|override)`. The benchmark harness
 already records *which* engine produced a number (§6, the `mode`/`engine` field) — routing
-generalizes that same discipline to ordinary links, not just benchmarks.
+generalizes that same discipline to ordinary links, not just benchmarks. The line is enabled by
+setting `RELD_LOG_ENGINE`; normal linker invocations keep stderr clean for compiler-driver and
+build-system compatibility.
 
 **Interaction with incremental linking.** LTO and the incremental daemon path (§4.2) are mutually
 exclusive on a given link (same as gold and MSVC). The router must select one engine and must not

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 Linux, and macOS as co-equal targets, incremental linking as the architecture, and a mandate to
 beat `wild` in every measured category.
 
-`reld` is a **polylinker**: it bundles multiple real linkers per platform (today: its own native
-engine plus an `lld` bridge) behind a single dispatch point, so it can run everywhere *and*,
-eventually, satisfy every requested link configuration by routing to whichever bundled engine
-supports it — fast by default, escalating only when the flags demand it. See
+`reld` is a **polylinker**: it puts multiple real linker engines behind a single dispatch point,
+so it can run everywhere and route a request to whichever engine supports it — fast by default,
+escalating only when the flags demand it. See
 ["Polylinker" below](#polylinker-runs-everywhere-supports-everything-by-routing) for what that
 means concretely, and what part of it is shipped vs. designed.
 
@@ -17,10 +16,10 @@ means concretely, and what part of it is shipped vs. designed.
 > (inherited from wild). Windows/COFF and macOS/Mach-O link via a **bridge** to `lld` (the
 > `rust-lld` that ships with every Rust toolchain) — proven by CI end-to-end builds on the
 > windows-msvc and macos-arm64 runners. Native COFF/Mach-O codegen in reld's own engine is still
-> **future work**. This bridge is today's *only* routing: it dispatches by platform/format, not
-> by requested flags. The flag-aware router described below (LTO/optimized links → a capable
-> bundled engine) is **design, not yet implemented** — see
-> [#30](https://github.com/zackees/reld/issues/30). Every performance number below remains a
+> **future work**. Linux also routes LTO/plugin, ICF, and several compatibility-policy flags to
+> the ELF `lld` bridge when the native engine cannot honor them. Every decision is logged with
+> the selected engine and reason. See [#30](https://github.com/zackees/reld/issues/30) and
+> decision B8 in [#17](https://github.com/zackees/reld/issues/17). Every performance number below remains a
 > **target**, not a measurement, except where noted. See [DESIGN.md](DESIGN.md) and
 > [#17](https://github.com/zackees/reld/issues/17) for the phase history.
 
@@ -99,14 +98,14 @@ Concretely (per [#30](https://github.com/zackees/reld/issues/30)):
 |---|---|
 | Bundling multiple real linkers per platform | **Shipped** — native ELF engine + lld bridge, see "Bridge status" above |
 | Routing by platform/format (dispatch to native vs. bridge) | **Shipped** |
-| Routing by requested *flags/config* (e.g. `-flto` → capable engine) | **Design only** — not implemented. Tracked by [#30](https://github.com/zackees/reld/issues/30), decision **B8** in [#17](https://github.com/zackees/reld/issues/17), and the daemon router in [#19](https://github.com/zackees/reld/issues/19) |
-| Capability table per bundled engine | **Design only** |
-| Fallback ordering when the fast engine lacks a capability | **Design only** |
-| `--engine=` / `RELD_ENGINE` override | **Design only** |
-| Per-decision routing log line | **Design only** |
+| Routing by requested *flags/config* | **Shipped for ELF** — LTO/plugin, ICF, discard-all, warning/color policy, version-script policy, and Cortex-A53 erratum 843419 route to `lld` |
+| Capability table per bundled engine | **Shipped, initial set** — extended as more native gaps are identified |
+| Fallback ordering when the fast engine lacks a capability | **Shipped** — native ELF first, capable ELF `lld` fallback |
+| `--engine=` / `RELD_ENGINE` override | **Shipped** — `reld` or `lld` on ELF; format-specific lld drivers elsewhere |
+| Per-decision routing log line | **Shipped** |
 
-Today, an `-flto` link is **not** automatically routed anywhere — see the Stretch goals section
-below for the current, honest state of LTO handling. See [DESIGN.md](DESIGN.md) for the full
+An ELF LTO link is automatically routed to `lld` when reld sees `-flto` or a linker plugin
+request, including plugin options found in response files. See [DESIGN.md](DESIGN.md) for the full
 routing design and [`agents/docs/polylinker.md`](agents/docs/polylinker.md) for the contributor-
 facing summary.
 
@@ -114,7 +113,7 @@ facing summary.
 
 1. **Runs and targets everywhere** — Windows, Linux, macOS. Not "Linux plus ports." The
    polylinker framing extends this claim toward "and supports every requested link
-   configuration," via routing — see above; that extension is design-stage, not shipped.
+   configuration," via routing — see above for the capability set shipped today.
 2. **Incremental** — a one-object change reflows the image instead of rebuilding it.
    Target: **warm relink in low single-digit milliseconds**, largely independent of binary size.
 3. **Faster than `wild` in every category** — cold link, warm full link, warm incremental,
@@ -156,14 +155,11 @@ day, not the one that goes to customers.
 on all three platforms. The inner loop is the priority; LTO touches nearly every subsystem and
 would slow down the thing this project exists to deliver.
 
-The framing for *how* LTO gets supported has changed: rather than reld ever implementing LTO
-natively in its own engine, `-flto`/`--plugin`/`/LTCG` links are meant to be **routed to a
-bundled engine that already does LTO** (the polylinker model above) — strictly better for the
-user than rejection, and still zero LTO codegen owned by reld. **That flag-aware router is
-design-stage, not implemented** ([#30](https://github.com/zackees/reld/issues/30), decision B8
-in [#17](https://github.com/zackees/reld/issues/17)); until it lands, LTO flags are rejected or
-ignored with a clear diagnostic rather than silently mislinked, per
-[D13](docs/plan/01-DECISIONS.md).
+The product-level LTO path is shipped: `-flto`/`--plugin`/`/LTCG` requests select a bundled
+`lld` driver with real LTO support (the polylinker model above), while reld's native engine owns
+zero LTO codegen. Implementing native LTO remains the stretch goal. An explicit
+`--engine=reld` on an LTO request fails with a capability-specific diagnostic rather than
+silently mislinking; see [D13](docs/plan/01-DECISIONS.md).
 
 ## Honest risks
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ means concretely, and what part of it is shipped vs. designed.
 > `rust-lld` that ships with every Rust toolchain) — proven by CI end-to-end builds on the
 > windows-msvc and macos-arm64 runners. Native COFF/Mach-O codegen in reld's own engine is still
 > **future work**. Linux also routes LTO/plugin, ICF, and several compatibility-policy flags to
-> the ELF `lld` bridge when the native engine cannot honor them. Every decision is logged with
-> the selected engine and reason. See [#30](https://github.com/zackees/reld/issues/30) and
+> the ELF `lld` bridge when the native engine cannot honor them. Set `RELD_LOG_ENGINE=1` to log
+> each selected engine and reason. See [#30](https://github.com/zackees/reld/issues/30) and
 > decision B8 in [#17](https://github.com/zackees/reld/issues/17). Every performance number below remains a
 > **target**, not a measurement, except where noted. See [DESIGN.md](DESIGN.md) and
 > [#17](https://github.com/zackees/reld/issues/17) for the phase history.
@@ -89,8 +89,9 @@ Concretely (per [#30](https://github.com/zackees/reld/issues/30)):
   back to a capable bundled engine. If *no* bundled engine supports the configuration, that's a
   loud, specific error — never a silent mislink.
 - **Explicit override.** `--engine=<name>` / `RELD_ENGINE` will force a specific bundled engine.
-- **Always observable.** Every routing decision is meant to be logged, so a user can always tell
-  which real linker ran and why.
+- **Observable on demand.** Set `RELD_LOG_ENGINE=1` to log each routing decision, so diagnostics
+  and benchmark harnesses can tell which real linker ran and why without polluting normal linker
+  stderr.
 
 **What's shipped today vs. designed:**
 
@@ -102,7 +103,7 @@ Concretely (per [#30](https://github.com/zackees/reld/issues/30)):
 | Capability table per bundled engine | **Shipped, initial set** — extended as more native gaps are identified |
 | Fallback ordering when the fast engine lacks a capability | **Shipped** — native ELF first, capable ELF `lld` fallback |
 | `--engine=` / `RELD_ENGINE` override | **Shipped** — `reld` or `lld` on ELF; format-specific lld drivers elsewhere |
-| Per-decision routing log line | **Shipped** |
+| Per-decision routing log line | **Shipped** — opt in with `RELD_LOG_ENGINE=1` |
 
 An ELF LTO link is automatically routed to `lld` when reld sees `-flto` or a linker plugin
 request, including plugin options found in response files. See [DESIGN.md](DESIGN.md) for the full

--- a/agents/docs/polylinker.md
+++ b/agents/docs/polylinker.md
@@ -31,7 +31,7 @@ an LTO-capable link.
 | Flag-aware router | **Shipped for ELF.** Direct argv and nested response-file flags are classified before native parsing. |
 | Fallback ordering when the default engine lacks a capability | **Shipped.** Native ELF is fastest/default; ELF `lld` is the capable fallback. |
 | `--engine=` / `RELD_ENGINE` explicit override | **Shipped.** A forced engine is still capability-validated. |
-| Per-decision routing log line (`reld: engine=<name> (reason=...)`) | **Shipped.** |
+| Per-decision routing log line (`reld: engine=<name> (reason=...)`) | **Shipped.** Set `RELD_LOG_ENGINE=1` to enable it without changing normal linker stderr. |
 | LTO delegated to a capable engine on request | **Shipped for ELF.** `-flto` and linker-plugin requests select `lld`; compiler-only `-flto` is not forwarded because raw `ld.lld` rejects it and consumes bitcode directly. |
 
 If you're extending B8/#19, keep the table and classifier centralized in `bridge.rs`; do not

--- a/agents/docs/polylinker.md
+++ b/agents/docs/polylinker.md
@@ -26,16 +26,16 @@ an LTO-capable link.
 | Layer | Status |
 |---|---|
 | Bundling more than one real linker engine per platform | **Shipped.** Native engine (Linux) + lld bridge (Windows, macOS). |
-| Routing by platform/format, decided once at dispatch | **Shipped.** This is today's entire routing logic — it is not flag-aware. |
-| Capability table (per-engine declared support for LTO, GC-sections, ICF, PDB/DWARF, incremental, formats, ...) | **Design only.** No such table exists in code yet. |
-| Flag-aware router (inspect argv/env, classify requested config, pick engine) | **Design only.** Not implemented. Tracked as B8 (#17) / #30 / #19. |
-| Fallback ordering when the default engine lacks a capability | **Design only.** |
-| `--engine=` / `RELD_ENGINE` explicit override | **Design only.** |
-| Per-decision routing log line (`reld: engine=<name> (reason: ...)`) | **Design only.** The bridge does log a `reld: delegating to <linker> (bridge mode)` note today (§4.4) — that's the shipped precedent the design generalizes, not the routing log itself. |
-| LTO delegated to a capable engine on request | **Design only.** Today, LTO flags are rejected/ignored with a diagnostic (D13); they are not routed anywhere yet. |
+| Routing by platform/format, decided once at dispatch | **Shipped.** |
+| Capability table | **Shipped, initial set.** ELF native-vs-lld capabilities cover LTO, ICF, discard-all, warning/color policy, version-script policy, and Cortex-A53 erratum 843419. Extend this table as new native gaps are routed. |
+| Flag-aware router | **Shipped for ELF.** Direct argv and nested response-file flags are classified before native parsing. |
+| Fallback ordering when the default engine lacks a capability | **Shipped.** Native ELF is fastest/default; ELF `lld` is the capable fallback. |
+| `--engine=` / `RELD_ENGINE` explicit override | **Shipped.** A forced engine is still capability-validated. |
+| Per-decision routing log line (`reld: engine=<name> (reason=...)`) | **Shipped.** |
+| LTO delegated to a capable engine on request | **Shipped for ELF.** `-flto` and linker-plugin requests select `lld`; compiler-only `-flto` is not forwarded because raw `ld.lld` rejects it and consumes bitcode directly. |
 
-If you're implementing B8/#19: this table is your scope. If you're just reading the docs to
-understand what reld does *today*, only the first two rows are real.
+If you're extending B8/#19, keep the table and classifier centralized in `bridge.rs`; do not
+recreate capability decisions in individual drivers.
 
 ## The rule for new backends
 

--- a/bosn.toml
+++ b/bosn.toml
@@ -1,0 +1,20 @@
+[stack.linux]
+dockerfile = "docker/bosn.Dockerfile"
+family = "rust"
+default = true
+
+[stack.linux.volumes]
+target = { scope = "stack" }
+cargo-home = { scope = "machine" }
+
+[task.route]
+stack = "linux"
+cmd = "cargo test -p reld-core bridge::tests --no-default-features"
+
+[task.smoke]
+stack = "linux"
+cmd = "python3 ci/linker_modes.py --platform linux --cargo-command cargo --report /tmp/linker-modes-linux.json"
+
+[task.test]
+stack = "linux"
+cmd = "RELD_TEST_CONFIG=/reld/test-config-ci.toml cargo test --workspace"

--- a/ci/linker_modes.py
+++ b/ci/linker_modes.py
@@ -15,9 +15,9 @@ import shlex
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -119,8 +119,7 @@ def run_checked(
         cwd=cwd,
         env=None if env is None else dict(env),
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         errors="replace",
         check=False,
     )
@@ -244,7 +243,7 @@ def write_fixture(directory: Path) -> tuple[Path, Path]:
         encoding="utf-8",
     )
     main.write_text(
-        "#include <stdio.h>\n" "int linker_mode_value(void);\n" "int main(void) {\n" "  if (linker_mode_value() != 42) return 1;\n" '  puts("reld-link-mode-ok");\n' "  return 0;\n" "}\n",
+        '#include <stdio.h>\nint linker_mode_value(void);\nint main(void) {\n  if (linker_mode_value() != 42) return 1;\n  puts("reld-link-mode-ok");\n  return 0;\n}\n',
         encoding="utf-8",
     )
     return main, value
@@ -262,6 +261,7 @@ def exercise_mode(
     mode_dir = root / mode.name
     mode_dir.mkdir(parents=True)
     command_env = dict(env)
+    command_env["RELD_LOG_ENGINE"] = "1"
     if host.name == "windows":
         command_env["PATH"] = os.pathsep.join([str(linker.parent), command_env.get("PATH", "")])
     sources = write_fixture(mode_dir)
@@ -312,7 +312,7 @@ def publish_summary(results: Sequence[ModeResult]) -> None:
         "| Platform | Mode | Engine | Route | Reason |",
         "|---|---|---|---|---|",
     ]
-    rows.extend(f"| {result.platform} | {result.mode} | {result.engine} | " f"{result.route_kind} | `{result.reason}` |" for result in results)
+    rows.extend(f"| {result.platform} | {result.mode} | {result.engine} | {result.route_kind} | `{result.reason}` |" for result in results)
     summary = "\n".join(rows) + "\n"
     print(summary)
     if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/ci/linker_modes.py
+++ b/ci/linker_modes.py
@@ -1,0 +1,371 @@
+"""Exercise every shipped reld link mode on the current host.
+
+The GitHub Actions workflow is intentionally a thin tool installer and invokes this file with
+``uv run``.  All mode selection, fixture construction, compiler/linker invocation, routing-log
+validation, executable validation, and reporting live here so the pipeline is testable as Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODE_NAMES = ("fast", "thin-lto", "full-lto")
+LLVM_BITCODE_MAGICS = (b"BC\xc0\xde", b"\xde\xc0\x17\x0b")
+ROUTE_PATTERN = re.compile(r"reld: engine=(?P<engine>\S+) " r"\((?P<kind>native|bridge), reason=(?P<reason>[^)]+)\)")
+
+
+class PipelineError(RuntimeError):
+    """A linker-mode contract was not satisfied."""
+
+
+@dataclass(frozen=True)
+class Mode:
+    name: str
+    clang_flags: tuple[str, ...]
+    expects_bitcode: bool
+
+
+@dataclass(frozen=True)
+class Host:
+    name: str
+    linker_binary: str
+    executable_suffix: str
+    object_suffix: str
+
+    def expected_engine(self, mode: Mode) -> tuple[str, str]:
+        if self.name == "linux":
+            return ("reld", "native") if mode.name == "fast" else ("lld", "bridge")
+        if self.name == "windows":
+            return "lld-link", "bridge"
+        return "ld64.lld", "bridge"
+
+
+@dataclass(frozen=True)
+class ModeResult:
+    platform: str
+    mode: str
+    engine: str
+    route_kind: str
+    reason: str
+    executable: str
+
+
+MODES = {
+    "fast": Mode("fast", (), False),
+    "thin-lto": Mode("thin-lto", ("-flto=thin",), True),
+    "full-lto": Mode("full-lto", ("-flto=full",), True),
+}
+
+HOSTS = {
+    "linux": Host("linux", "reld", "", ".o"),
+    "windows": Host("windows", "reld-link.exe", ".exe", ".obj"),
+    "macos": Host("macos", "reld", "", ".o"),
+}
+
+
+def detect_platform(value: str = "auto") -> Host:
+    if value != "auto":
+        try:
+            return HOSTS[value]
+        except KeyError as error:
+            raise PipelineError(f"unsupported platform {value!r}") from error
+    if sys.platform.startswith("linux"):
+        return HOSTS["linux"]
+    if sys.platform == "win32":
+        return HOSTS["windows"]
+    if sys.platform == "darwin":
+        return HOSTS["macos"]
+    raise PipelineError(f"unsupported host platform {sys.platform!r}")
+
+
+def select_modes(names: Iterable[str]) -> list[Mode]:
+    requested = list(names)
+    if not requested:
+        requested = list(MODE_NAMES)
+    unknown = [name for name in requested if name not in MODES]
+    if unknown:
+        raise PipelineError(f"unknown link mode(s): {', '.join(unknown)}")
+    if len(set(requested)) != len(requested):
+        raise PipelineError("link modes must not be repeated")
+    return [MODES[name] for name in requested]
+
+
+def command_text(argv: Sequence[os.PathLike[str] | str]) -> str:
+    return subprocess.list2cmdline([os.fspath(arg) for arg in argv])
+
+
+def run_checked(
+    argv: Sequence[os.PathLike[str] | str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = [os.fspath(arg) for arg in argv]
+    print(f"+ {command_text(command)}", flush=True)
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=None if env is None else dict(env),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        errors="replace",
+        check=False,
+    )
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
+    if result.returncode != 0:
+        raise PipelineError(f"command exited with {result.returncode}: {command_text(command)}")
+    return result
+
+
+def cargo_argv(value: str) -> list[str]:
+    argv = shlex.split(value, posix=os.name != "nt")
+    if not argv:
+        raise PipelineError("cargo command must not be empty")
+    return argv
+
+
+def executable_from_cargo_output(output: str, binary_name: str) -> Path | None:
+    for line in output.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") == "compiler-artifact" and message.get("target", {}).get("name") == binary_name and message.get("executable"):
+            return Path(message["executable"])
+    return None
+
+
+def build_linker(
+    host: Host,
+    *,
+    repo_root: Path,
+    cargo: Sequence[str],
+    env: Mapping[str, str],
+) -> Path:
+    binary_name = Path(host.linker_binary).stem
+    built = run_checked(
+        [
+            *cargo,
+            "build",
+            "--locked",
+            "--package",
+            "reld",
+            "--bin",
+            binary_name,
+            "--message-format=json-render-diagnostics",
+        ],
+        cwd=repo_root,
+        env=env,
+    )
+    linker = executable_from_cargo_output(built.stdout, binary_name)
+    if linker is None:
+        raise PipelineError(f"cargo did not report an executable for {binary_name}")
+    if not linker.is_file():
+        raise PipelineError(f"built linker not found at {linker}")
+    return linker.resolve()
+
+
+def compile_command(
+    compiler: str,
+    source: Path,
+    output: Path,
+    mode: Mode,
+) -> list[str]:
+    return [compiler, "-c", source, "-o", output, "-O2", *mode.clang_flags]
+
+
+def link_command(
+    compiler: str,
+    objects: Sequence[Path],
+    output: Path,
+    linker: Path,
+    mode: Mode,
+    host: Host,
+) -> list[str]:
+    linker_selector = "reld-link" if host.name == "windows" else str(linker)
+    return [
+        compiler,
+        *objects,
+        "-o",
+        output,
+        f"-fuse-ld={linker_selector}",
+        *mode.clang_flags,
+    ]
+
+
+def is_llvm_bitcode(path: Path) -> bool:
+    return path.read_bytes()[:4] in LLVM_BITCODE_MAGICS
+
+
+def validate_object(path: Path, mode: Mode) -> None:
+    actual = is_llvm_bitcode(path)
+    if actual != mode.expects_bitcode:
+        expected = "LLVM bitcode" if mode.expects_bitcode else "a native object"
+        raise PipelineError(f"{path} is not {expected}")
+
+
+def parse_route(output: str, host: Host, mode: Mode) -> tuple[str, str, str]:
+    routes = [match.groupdict() for match in ROUTE_PATTERN.finditer(output)]
+    if not routes:
+        raise PipelineError(f"{mode.name}: reld emitted no routing decision")
+    expected_engine, expected_kind = host.expected_engine(mode)
+    matching = [route for route in routes if route["engine"] == expected_engine and route["kind"] == expected_kind]
+    if not matching:
+        rendered = ", ".join(f"{r['engine']}/{r['kind']}" for r in routes)
+        raise PipelineError(f"{host.name}/{mode.name}: expected {expected_engine}/{expected_kind}, got {rendered}")
+    engines = {(route["engine"], route["kind"]) for route in routes}
+    if engines != {(expected_engine, expected_kind)}:
+        raise PipelineError(f"{host.name}/{mode.name}: inconsistent routes: {sorted(engines)}")
+    route = matching[0]
+    return route["engine"], route["kind"], route["reason"]
+
+
+def write_fixture(directory: Path) -> tuple[Path, Path]:
+    value = directory / "value.c"
+    main = directory / "main.c"
+    value.write_text(
+        "int linker_mode_value(void) { return 42; }\n",
+        encoding="utf-8",
+    )
+    main.write_text(
+        "#include <stdio.h>\n" "int linker_mode_value(void);\n" "int main(void) {\n" "  if (linker_mode_value() != 42) return 1;\n" '  puts("reld-link-mode-ok");\n' "  return 0;\n" "}\n",
+        encoding="utf-8",
+    )
+    return main, value
+
+
+def exercise_mode(
+    host: Host,
+    mode: Mode,
+    *,
+    compiler: str,
+    linker: Path,
+    root: Path,
+    env: Mapping[str, str],
+) -> ModeResult:
+    mode_dir = root / mode.name
+    mode_dir.mkdir(parents=True)
+    command_env = dict(env)
+    if host.name == "windows":
+        command_env["PATH"] = os.pathsep.join([str(linker.parent), command_env.get("PATH", "")])
+    sources = write_fixture(mode_dir)
+    objects: list[Path] = []
+    for source in sources:
+        output = mode_dir / f"{source.stem}{host.object_suffix}"
+        run_checked(
+            compile_command(compiler, source, output, mode),
+            cwd=mode_dir,
+            env=command_env,
+        )
+        validate_object(output, mode)
+        objects.append(output)
+
+    executable = mode_dir / f"fixture-{mode.name}{host.executable_suffix}"
+    linked = run_checked(
+        link_command(compiler, objects, executable, linker, mode, host),
+        cwd=mode_dir,
+        env=command_env,
+    )
+    engine, route_kind, reason = parse_route(linked.stdout + linked.stderr, host, mode)
+    executed = run_checked([executable], cwd=mode_dir, env=command_env)
+    if "reld-link-mode-ok" not in executed.stdout:
+        raise PipelineError(f"{host.name}/{mode.name}: executable output marker missing")
+    return ModeResult(
+        platform=host.name,
+        mode=mode.name,
+        engine=engine,
+        route_kind=route_kind,
+        reason=reason,
+        executable=str(executable),
+    )
+
+
+def write_report(path: Path, results: Sequence[ModeResult]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": 1,
+        "results": [asdict(result) for result in results],
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def publish_summary(results: Sequence[ModeResult]) -> None:
+    rows = [
+        "### Reld linker modes",
+        "",
+        "| Platform | Mode | Engine | Route | Reason |",
+        "|---|---|---|---|---|",
+    ]
+    rows.extend(f"| {result.platform} | {result.mode} | {result.engine} | " f"{result.route_kind} | `{result.reason}` |" for result in results)
+    summary = "\n".join(rows) + "\n"
+    print(summary)
+    if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(summary)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", choices=("auto", *HOSTS), default="auto")
+    parser.add_argument("--mode", action="append", choices=MODE_NAMES, default=[])
+    parser.add_argument("--compiler", default=os.environ.get("CLANG", "clang"))
+    parser.add_argument("--cargo-command", default=os.environ.get("CARGO_COMMAND", "cargo"))
+    parser.add_argument("--reld", type=Path, help="use a prebuilt linker and skip cargo build")
+    parser.add_argument("--report", type=Path, default=Path("linker-modes.json"))
+    args = parser.parse_args(argv)
+
+    host = detect_platform(args.platform)
+    modes = select_modes(args.mode)
+    env = dict(os.environ)
+    linker = (
+        args.reld.resolve()
+        if args.reld
+        else build_linker(
+            host,
+            repo_root=REPO_ROOT,
+            cargo=cargo_argv(args.cargo_command),
+            env=env,
+        )
+    )
+    if not linker.is_file():
+        raise PipelineError(f"linker not found at {linker}")
+
+    with tempfile.TemporaryDirectory(prefix="reld-linker-modes-") as temporary:
+        results = [
+            exercise_mode(
+                host,
+                mode,
+                compiler=args.compiler,
+                linker=linker,
+                root=Path(temporary),
+                env=env,
+            )
+            for mode in modes
+        ]
+    write_report(args.report, results)
+    publish_summary(results)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PipelineError as error:
+        print(f"linker-modes: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/ci/linker_setup.py
+++ b/ci/linker_setup.py
@@ -27,11 +27,9 @@ import os
 import shutil
 import subprocess
 import tarfile
-import tempfile
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-
 
 CHUNK = 1 << 20
 
@@ -143,7 +141,8 @@ def needs_download(artifact: Artifact, cache_dir: Path) -> bool:
 
 def _download(url: str, dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(url) as response, dest.open("wb") as handle:  # noqa: S310
+    request = urllib.request.Request(url, headers={"User-Agent": "reld-ci/1.0"})
+    with urllib.request.urlopen(request) as response, dest.open("wb") as handle:
         shutil.copyfileobj(response, handle)
 
 

--- a/ci/tests/test_linker_modes.py
+++ b/ci/tests/test_linker_modes.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import pytest
+
+from ci.linker_modes import (
+    HOSTS,
+    MODES,
+    PipelineError,
+    compile_command,
+    detect_platform,
+    executable_from_cargo_output,
+    is_llvm_bitcode,
+    link_command,
+    parse_route,
+    select_modes,
+    write_report,
+)
+
+
+def test_default_modes_cover_fast_thin_and_full_lto() -> None:
+    assert [mode.name for mode in select_modes([])] == ["fast", "thin-lto", "full-lto"]
+
+
+def test_repeated_modes_are_rejected() -> None:
+    with pytest.raises(PipelineError, match="must not be repeated"):
+        select_modes(["fast", "fast"])
+
+
+@pytest.mark.parametrize(
+    ("platform", "mode", "engine", "kind"),
+    [
+        ("linux", "fast", "reld", "native"),
+        ("linux", "thin-lto", "lld", "bridge"),
+        ("linux", "full-lto", "lld", "bridge"),
+        ("windows", "fast", "lld-link", "bridge"),
+        ("windows", "thin-lto", "lld-link", "bridge"),
+        ("windows", "full-lto", "lld-link", "bridge"),
+        ("macos", "fast", "ld64.lld", "bridge"),
+        ("macos", "thin-lto", "ld64.lld", "bridge"),
+        ("macos", "full-lto", "ld64.lld", "bridge"),
+    ],
+)
+def test_expected_engine_matrix(platform: str, mode: str, engine: str, kind: str) -> None:
+    assert HOSTS[platform].expected_engine(MODES[mode]) == (engine, kind)
+
+
+def test_explicit_platform_detection() -> None:
+    assert detect_platform("windows") is HOSTS["windows"]
+    with pytest.raises(PipelineError, match="unsupported platform"):
+        detect_platform("plan9")
+
+
+def test_compile_and_link_commands_own_lto_selection(tmp_path: Path) -> None:
+    mode = MODES["thin-lto"]
+    source = tmp_path / "main.c"
+    obj = tmp_path / "main.o"
+    linker = tmp_path / "reld"
+    executable = tmp_path / "fixture"
+
+    compile = compile_command("clang", source, obj, mode)
+    link = link_command("clang", [obj], executable, linker, mode, HOSTS["linux"])
+
+    assert "-flto=thin" in compile
+    assert "-flto=thin" in link
+    assert f"-fuse-ld={linker}" in link
+
+
+def test_windows_link_command_uses_path_resolvable_driver_name(tmp_path: Path) -> None:
+    linker = tmp_path / "reld-link.exe"
+    command = link_command(
+        "clang",
+        [tmp_path / "main.obj"],
+        tmp_path / "fixture.exe",
+        linker,
+        MODES["fast"],
+        HOSTS["windows"],
+    )
+    assert "-fuse-ld=reld-link" in command
+    assert all(str(linker) not in str(arg) for arg in command)
+
+
+def test_cargo_json_selects_exact_binary_path() -> None:
+    output = "\n".join(
+        [
+            "soldr: wrapper note",
+            '{"reason":"compiler-artifact","target":{"name":"other"},"executable":"/x/other"}',
+            '{"reason":"compiler-artifact","target":{"name":"reld-link"},' '"executable":"C:/target/x86_64-pc-windows-msvc/debug/reld-link.exe"}',
+        ]
+    )
+    assert executable_from_cargo_output(output, "reld-link") == Path("C:/target/x86_64-pc-windows-msvc/debug/reld-link.exe")
+
+
+@pytest.mark.parametrize("magic", [b"BC\xc0\xde", b"\xde\xc0\x17\x0b"])
+def test_bitcode_magic_detection(tmp_path: Path, magic: bytes) -> None:
+    obj = tmp_path / "input.o"
+    obj.write_bytes(magic + b"payload")
+    assert is_llvm_bitcode(obj)
+
+
+def test_native_object_is_not_bitcode(tmp_path: Path) -> None:
+    obj = tmp_path / "input.o"
+    obj.write_bytes(b"\x7fELFpayload")
+    assert not is_llvm_bitcode(obj)
+
+
+def test_route_parser_requires_expected_engine() -> None:
+    engine, kind, reason = parse_route(
+        "reld: engine=lld (bridge, reason=flag:--plugin) -> /tool/rust-lld\n",
+        HOSTS["linux"],
+        MODES["thin-lto"],
+    )
+    assert (engine, kind, reason) == ("lld", "bridge", "flag:--plugin")
+
+    with pytest.raises(PipelineError, match="expected reld/native"):
+        parse_route(
+            "reld: engine=lld (bridge, reason=default) -> /tool/rust-lld\n",
+            HOSTS["linux"],
+            MODES["fast"],
+        )
+
+
+def test_report_is_machine_readable(tmp_path: Path) -> None:
+    from ci.linker_modes import ModeResult
+
+    report = tmp_path / "report.json"
+    write_report(
+        report,
+        [ModeResult("linux", "fast", "reld", "native", "default", "/tmp/fixture")],
+    )
+    text = report.read_text(encoding="utf-8")
+    assert '"schema": 1' in text
+    assert '"mode": "fast"' in text

--- a/ci/tests/test_linker_modes_workflow.py
+++ b/ci/tests/test_linker_modes_workflow.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "linker-modes.yml"
+
+
+def test_workflow_covers_all_native_hosts() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "runner: ubuntu-24.04" in text
+    assert "runner: windows-2022" in text
+    assert "runner: macos-14" in text
+    for platform in ("linux", "windows", "macos"):
+        assert f"platform: {platform}" in text
+
+
+def test_workflow_is_a_thin_uv_invoker() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "astral-sh/setup-uv@" in text
+    assert "uv run --no-project python ci/linker_modes.py" in text
+    assert text.count("uv run") == 1
+
+    # Compilation, LTO selection, execution, and route assertions belong to Python.
+    assert "cargo build" not in text
+    assert "-flto" not in text
+    assert "fuse-ld" not in text
+    assert "reld: engine=" not in text
+
+
+def test_python_pipeline_owns_every_required_mode() -> None:
+    pipeline = (Path(__file__).parents[1] / "linker_modes.py").read_text(encoding="utf-8")
+    for mode in ("fast", "thin-lto", "full-lto"):
+        assert f'"{mode}"' in pipeline

--- a/ci/tests/test_linker_modes_workflow.py
+++ b/ci/tests/test_linker_modes_workflow.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "linker-modes.yml"
 
 
@@ -24,6 +23,16 @@ def test_workflow_is_a_thin_uv_invoker() -> None:
     assert "-flto" not in text
     assert "fuse-ld" not in text
     assert "reld: engine=" not in text
+
+
+def test_workflow_uses_compatible_platform_clang_toolchains() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    linux = text.index("platform: linux")
+    windows = text.index("platform: windows")
+    macos = text.index("platform: macos")
+    assert "install_llvm: false" in text[linux:windows]
+    assert "install_llvm: true" in text[windows:macos]
+    assert "brew install llvm@18" in text
 
 
 def test_python_pipeline_owns_every_required_mode() -> None:

--- a/ci/tests/test_linker_setup.py
+++ b/ci/tests/test_linker_setup.py
@@ -9,6 +9,7 @@ import pytest
 from ci.linker_setup import (
     Artifact,
     _append_github_path,
+    _download,
     _extract_member,
     _member_matches,
     _url_suffix,
@@ -19,7 +20,6 @@ from ci.linker_setup import (
     resolve_artifacts,
     sha256_file,
 )
-
 
 ENV = {
     "MOLD_VERSION": "2.41.0",
@@ -48,6 +48,20 @@ def test_sha256_file(tmp_path: Path) -> None:
     blob = tmp_path / "blob"
     blob.write_bytes(b"hello")
     assert sha256_file(blob) == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_download_sends_a_user_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str | None] = {}
+
+    def fake_urlopen(request):
+        seen["user_agent"] = request.get_header("User-agent")
+        return io.BytesIO(b"payload")
+
+    monkeypatch.setattr("ci.linker_setup.urllib.request.urlopen", fake_urlopen)
+    destination = tmp_path / "download"
+    _download("https://example.invalid/artifact", destination)
+    assert seen["user_agent"] == "reld-ci/1.0"
+    assert destination.read_bytes() == b"payload"
 
 
 def _deb_artifact(sha: str) -> Artifact:

--- a/crates/reld-core/src/args.rs
+++ b/crates/reld-core/src/args.rs
@@ -230,6 +230,15 @@ impl Args {
         }
     }
 
+    /// Returns the object format selected by argv[0], `-flavor`, or the host default.
+    pub fn link_target(&self) -> crate::bridge::BridgeTarget {
+        match self {
+            Args::Elf(_) => crate::bridge::BridgeTarget::Elf,
+            Args::Coff(_) => crate::bridge::BridgeTarget::Coff,
+            Args::MachO(_) => crate::bridge::BridgeTarget::MachO,
+        }
+    }
+
     pub(crate) fn print_emulation_info(&self, stdout: &mut dyn Write) -> Result<()> {
         match self {
             Args::Elf(_) => {
@@ -1365,6 +1374,14 @@ impl std::str::FromStr for CounterKind {
 }
 
 fn declare_common_args<T: platform::Args>(parser: &mut ArgumentParser<T>) {
+    // Routing consumes this option before native argument parsing. Declaring it here prevents a
+    // forced native route (`--engine=reld`) from being reported as an unknown linker option.
+    parser
+        .declare_with_param()
+        .long("engine")
+        .help("Force a bundled linker engine")
+        .execute(|_args, _modifier_stack, _value| Ok(()));
+
     parser
         .declare()
         .long("write-layout")
@@ -1517,6 +1534,11 @@ mod tests {
 
         let args = Args::new(|| ["reld", "-flavor", "link"].into_iter()).unwrap();
         assert!(matches!(args, Args::Coff(_)));
+
+        let mut args = Args::new(|| ["ld.reld", "--engine=reld"].into_iter()).unwrap();
+        args.parse(|| ["ld.reld", "--engine=reld"].into_iter())
+            .unwrap();
+        assert!(args.common().unrecognized_options.is_empty());
 
         // -flavor has priority
         let args = Args::new(|| ["ld.reld", "-flavor", "darwin"].into_iter()).unwrap();

--- a/crates/reld-core/src/bridge.rs
+++ b/crates/reld-core/src/bridge.rs
@@ -205,6 +205,13 @@ const ENGINE_FLAG_PREFIX: &str = "--engine=";
 /// argv token is present.
 pub const RELD_ENGINE_ENV: &str = "RELD_ENGINE";
 
+/// Enables one routing-decision line on stderr when present in the environment.
+pub const RELD_LOG_ENGINE_ENV: &str = "RELD_LOG_ENGINE";
+
+fn route_logging_enabled() -> bool {
+    std::env::var_os(RELD_LOG_ENGINE_ENV).is_some()
+}
+
 /// The selected engine and the reason it was selected for one link request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Route {
@@ -222,6 +229,9 @@ impl Route {
     /// Emits the observable routing decision for a native link.
     pub fn log_native(self) {
         debug_assert!(self.engine.native);
+        if !route_logging_enabled() {
+            return;
+        }
         eprintln!(
             "reld: engine={} (native, reason={})",
             self.engine.name,
@@ -709,12 +719,14 @@ pub fn run_bridge<I: IntoIterator<Item = OsString>>(argv: I, route: Route) -> Re
     let forwarded = forwarded_args_for_engine(argv, engine)?;
     let child_args = child_command_line(&linker, engine, forwarded);
 
-    eprintln!(
-        "reld: engine={} (bridge, reason={}) -> {}",
-        engine.name,
-        route.reason.label(),
-        linker.display()
-    );
+    if route_logging_enabled() {
+        eprintln!(
+            "reld: engine={} (bridge, reason={}) -> {}",
+            engine.name,
+            route.reason.label(),
+            linker.display()
+        );
+    }
 
     let mut command = std::process::Command::new(&linker);
     command.args(child_args);

--- a/crates/reld-core/src/bridge.rs
+++ b/crates/reld-core/src/bridge.rs
@@ -181,6 +181,7 @@ struct Requirement {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SelectionReason {
     Default,
+    SaveOnly,
     OverrideFlag,
     OverrideEnv,
     Capability(&'static str),
@@ -190,6 +191,7 @@ impl SelectionReason {
     fn label(self) -> &'static str {
         match self {
             SelectionReason::Default => "default",
+            SelectionReason::SaveOnly => "save-only(RELD_SAVE_SKIP_LINKING)",
             SelectionReason::OverrideFlag => "override(--engine)",
             SelectionReason::OverrideEnv => "override(RELD_ENGINE)",
             SelectionReason::Capability(trigger) => trigger,
@@ -461,9 +463,32 @@ fn select_route_with_env(
     Ok(Route { engine, reason })
 }
 
+fn select_route_with_context(
+    argv: &[OsString],
+    target: BridgeTarget,
+    env_override: Option<&str>,
+    capture_only: bool,
+) -> Result<Route> {
+    // Save-dir capture must parse the original invocation and write its native replay artifact.
+    // Capability routing is irrelevant because RELD_SAVE_SKIP_LINKING exits before the final link.
+    if capture_only && target == BridgeTarget::Elf {
+        return Ok(Route {
+            engine: &NATIVE_RELD_ENGINE,
+            reason: SelectionReason::SaveOnly,
+        });
+    }
+
+    select_route_with_env(argv, target, env_override)
+}
+
 /// Selects the engine for one raw linker invocation.
 pub fn select_route(argv: &[OsString], target: BridgeTarget) -> Result<Route> {
-    select_route_with_env(argv, target, std::env::var(RELD_ENGINE_ENV).ok().as_deref())
+    select_route_with_context(
+        argv,
+        target,
+        std::env::var(RELD_ENGINE_ENV).ok().as_deref(),
+        crate::save_dir::capture_only_requested(),
+    )
 }
 
 /// Locates the linker binary that the bridge should delegate to for the given engine.
@@ -1102,6 +1127,24 @@ mod tests {
         assert_eq!(route.engine.name, "reld");
         assert!(!route.is_bridge());
         assert_eq!(route.reason, SelectionReason::Default);
+    }
+
+    #[test]
+    fn elf_capture_only_lto_stays_native_for_save_dir_replay() {
+        let route = select_route_with_context(
+            &[
+                OsString::from("ld.reld"),
+                OsString::from("-flto"),
+                OsString::from("foo.o"),
+            ],
+            BridgeTarget::Elf,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(route.engine.name, "reld");
+        assert!(!route.is_bridge());
+        assert_eq!(route.reason, SelectionReason::SaveOnly);
     }
 
     #[test]

--- a/crates/reld-core/src/bridge.rs
+++ b/crates/reld-core/src/bridge.rs
@@ -1,4 +1,4 @@
-//! Windows/COFF and macOS/Mach-O bridges (issue #17; BR-1 for COFF, BR-3 for Mach-O).
+//! Polylinker routing and subprocess bridges (issue #17).
 //!
 //! `Args::new` reuses the ELF/GNU parser for `Args::Coff` because reld doesn't yet have a native
 //! COFF backend. Rather than feeding MSVC-style link arguments (`/OUT:`, `/DEFAULTLIB:`, …) into
@@ -9,6 +9,10 @@
 //! BR-3 (issue #29) generalizes this module to also bridge Mach-O links to `ld64.lld` (the
 //! Mach-O driver in `rust-lld`), following the exact same discovery + flavor-prefix strategy,
 //! selected by the `BridgeTarget` passed into `run_bridge`/`discover_linker`.
+//!
+//! BR-6 adds capability-based ELF routing. Ordinary ELF links stay in reld's native engine, while
+//! requests that need a capability the native engine does not implement are delegated to the ELF
+//! driver in `lld`.
 //!
 //! This module intentionally never falls back to the closed-source MSVC `link.exe` (or to Apple's
 //! `ld64`) -- silently doing so would poison benchmark comparability and mask discovery bugs
@@ -29,6 +33,8 @@ pub const RELD_BRIDGE_LINKER_ENV: &str = "RELD_BRIDGE_LINKER";
 /// Which object format the bridge should delegate links for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BridgeTarget {
+    /// Linux ELF, normally linked natively and bridged to `ld.lld` when capabilities require it.
+    Elf,
     /// Windows PE/COFF, bridged to `lld-link`.
     Coff,
     /// macOS Mach-O, bridged to `ld64.lld`.
@@ -39,18 +45,14 @@ impl BridgeTarget {
     /// The human-readable format label used in error messages.
     fn format_label(self) -> &'static str {
         match self {
+            BridgeTarget::Elf => "ELF",
             BridgeTarget::Coff => "COFF",
             BridgeTarget::MachO => "Mach-O",
         }
     }
 }
 
-/// A bundled bridge engine: a name, the object format it links, and how to invoke it.
-///
-/// This is a minimal capability seed (issue #34 / B8a) -- just enough to let `select_engine`
-/// validate an explicit override against the format it's being asked to link. It is deliberately
-/// not an elaborate capability matrix (LTO/GC-sections/etc.); that's later-slice scope per
-/// `agents/docs/polylinker.md`.
+/// A bundled linker engine: its public name, object format, invocation, and capabilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Engine {
     /// The engine name, as accepted by `--engine=<name>` / `RELD_ENGINE`.
@@ -62,22 +64,89 @@ pub struct Engine {
     /// The `-flavor` value to pass to the multi-flavor `rust-lld` dispatcher to select this
     /// engine's driver.
     rust_lld_flavor: &'static str,
+    /// Whether this engine runs in-process rather than through the subprocess bridge.
+    native: bool,
+    /// Link configurations this engine can satisfy without silently dropping their semantics.
+    capabilities: &'static [Capability],
 }
 
-/// The bundled bridge engines. `lld-link` bridges COFF; `ld64.lld` bridges Mach-O.
+/// Capabilities that affect engine selection rather than merely argument spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Capability {
+    Lto,
+    Icf,
+    DiscardAll,
+    FatalWarnings,
+    ColorDiagnostics,
+    VersionScriptPolicy,
+    CortexA53Erratum,
+}
+
+impl Capability {
+    fn label(self) -> &'static str {
+        match self {
+            Capability::Lto => "LTO",
+            Capability::Icf => "identical code folding",
+            Capability::DiscardAll => "discarding local symbols",
+            Capability::FatalWarnings => "fatal linker warnings",
+            Capability::ColorDiagnostics => "diagnostic color policy",
+            Capability::VersionScriptPolicy => "version-script undefined-symbol policy",
+            Capability::CortexA53Erratum => "Cortex-A53 erratum 843419 fixups",
+        }
+    }
+}
+
+const NO_CAPABILITIES: &[Capability] = &[];
+const LLD_CAPABILITIES: &[Capability] = &[
+    Capability::Lto,
+    Capability::Icf,
+    Capability::DiscardAll,
+    Capability::FatalWarnings,
+    Capability::ColorDiagnostics,
+    Capability::VersionScriptPolicy,
+    Capability::CortexA53Erratum,
+];
+
+const NATIVE_RELD_ENGINE: Engine = Engine {
+    name: "reld",
+    format: BridgeTarget::Elf,
+    linker_basename: "",
+    rust_lld_flavor: "",
+    native: true,
+    capabilities: NO_CAPABILITIES,
+};
+const ELF_LLD_ENGINE: Engine = Engine {
+    name: "lld",
+    format: BridgeTarget::Elf,
+    linker_basename: "ld.lld",
+    rust_lld_flavor: "gnu",
+    native: false,
+    capabilities: LLD_CAPABILITIES,
+};
+const COFF_LLD_ENGINE: Engine = Engine {
+    name: "lld-link",
+    format: BridgeTarget::Coff,
+    linker_basename: "lld-link",
+    rust_lld_flavor: "link",
+    native: false,
+    capabilities: LLD_CAPABILITIES,
+};
+const MACHO_LLD_ENGINE: Engine = Engine {
+    name: "ld64.lld",
+    format: BridgeTarget::MachO,
+    linker_basename: "ld64.lld",
+    rust_lld_flavor: "darwin",
+    native: false,
+    capabilities: LLD_CAPABILITIES,
+};
+
+/// The available engines and their capabilities. Ordering defines the default (fastest) engine
+/// for each format: native reld for ELF, and the appropriate lld driver for COFF/Mach-O.
 const ENGINES: &[Engine] = &[
-    Engine {
-        name: "lld-link",
-        format: BridgeTarget::Coff,
-        linker_basename: "lld-link",
-        rust_lld_flavor: "link",
-    },
-    Engine {
-        name: "ld64.lld",
-        format: BridgeTarget::MachO,
-        linker_basename: "ld64.lld",
-        rust_lld_flavor: "darwin",
-    },
+    NATIVE_RELD_ENGINE,
+    ELF_LLD_ENGINE,
+    COFF_LLD_ENGINE,
+    MACHO_LLD_ENGINE,
 ];
 
 impl Engine {
@@ -88,11 +157,24 @@ impl Engine {
 
     /// The default engine for a given target format (today's fixed platform->engine mapping).
     fn default_for(target: BridgeTarget) -> &'static Engine {
-        ENGINES
-            .iter()
-            .find(|engine| engine.format == target)
-            .expect("every BridgeTarget has a default engine in ENGINES")
+        match target {
+            BridgeTarget::Elf => &NATIVE_RELD_ENGINE,
+            BridgeTarget::Coff => &COFF_LLD_ENGINE,
+            BridgeTarget::MachO => &MACHO_LLD_ENGINE,
+        }
     }
+
+    fn supports(self, requirements: &[Requirement]) -> bool {
+        requirements
+            .iter()
+            .all(|requirement| self.capabilities.contains(&requirement.capability))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Requirement {
+    capability: Capability,
+    trigger: &'static str,
 }
 
 /// Where an engine selection came from, for the observable routing note.
@@ -101,6 +183,7 @@ enum SelectionReason {
     Default,
     OverrideFlag,
     OverrideEnv,
+    Capability(&'static str),
 }
 
 impl SelectionReason {
@@ -109,6 +192,7 @@ impl SelectionReason {
             SelectionReason::Default => "default",
             SelectionReason::OverrideFlag => "override(--engine)",
             SelectionReason::OverrideEnv => "override(RELD_ENGINE)",
+            SelectionReason::Capability(trigger) => trigger,
         }
     }
 }
@@ -121,36 +205,255 @@ const ENGINE_FLAG_PREFIX: &str = "--engine=";
 /// argv token is present.
 pub const RELD_ENGINE_ENV: &str = "RELD_ENGINE";
 
+/// The selected engine and the reason it was selected for one link request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Route {
+    engine: &'static Engine,
+    reason: SelectionReason,
+}
+
+impl Route {
+    /// Whether the selected engine must be invoked through the subprocess bridge.
+    #[must_use]
+    pub fn is_bridge(self) -> bool {
+        !self.engine.native
+    }
+
+    /// Emits the observable routing decision for a native link.
+    pub fn log_native(self) {
+        debug_assert!(self.engine.native);
+        eprintln!(
+            "reld: engine={} (native, reason={})",
+            self.engine.name,
+            self.reason.label()
+        );
+    }
+}
+
 /// Selects the bridge engine to use for `target`, honoring an explicit override name if given.
 ///
 /// - `override_name` is `None`: returns the target's default engine (today's behavior).
 /// - `override_name` is `Some(name)`: looks the engine up by name. An unknown name is a hard
 ///   error listing the valid engine names; a known engine whose format doesn't match `target` is
 ///   a hard error naming both the engine and the requested format.
-fn select_engine(target: BridgeTarget, override_name: Option<&str>) -> Result<&'static Engine> {
-    let Some(name) = override_name else {
-        return Ok(Engine::default_for(target));
-    };
+fn select_engine(
+    target: BridgeTarget,
+    override_name: Option<&str>,
+    requirements: &[Requirement],
+) -> Result<&'static Engine> {
+    if let Some(name) = override_name {
+        let Some(engine) = Engine::find(name) else {
+            let valid = ENGINES
+                .iter()
+                .map(|engine| engine.name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("Unknown engine `{name}`. Valid engines: {valid}.");
+        };
 
-    let Some(engine) = Engine::find(name) else {
-        let valid = ENGINES
+        if engine.format != target {
+            bail!(
+                "Engine `{name}` links {} but this link is for {}. Choose an engine that supports {}.",
+                engine.format.format_label(),
+                target.format_label(),
+                target.format_label(),
+            );
+        }
+
+        if let Some(requirement) = requirements
             .iter()
-            .map(|engine| engine.name)
-            .collect::<Vec<_>>()
-            .join(", ");
-        bail!("Unknown engine `{name}`. Valid engines: {valid}.");
-    };
+            .find(|requirement| !engine.capabilities.contains(&requirement.capability))
+        {
+            bail!(
+                "Engine `{name}` does not support {} requested by `{}`.",
+                requirement.capability.label(),
+                requirement.trigger,
+            );
+        }
 
-    if engine.format != target {
-        bail!(
-            "Engine `{name}` links {} but this link is for {}. Choose an engine that supports {}.",
-            engine.format.format_label(),
-            target.format_label(),
-            target.format_label(),
-        );
+        return Ok(engine);
     }
 
-    Ok(engine)
+    let default = Engine::default_for(target);
+    if default.supports(requirements) {
+        return Ok(default);
+    }
+
+    if let Some(engine) = ENGINES
+        .iter()
+        .find(|engine| engine.format == target && engine.supports(requirements))
+    {
+        return Ok(engine);
+    }
+
+    let Some(requirement) = requirements
+        .iter()
+        .find(|requirement| !default.capabilities.contains(&requirement.capability))
+    else {
+        bail!("Internal error: capability fallback failed without an unmet requirement");
+    };
+    bail!(
+        "No bundled {} engine supports {} requested by `{}`.",
+        target.format_label(),
+        requirement.capability.label(),
+        requirement.trigger,
+    );
+}
+
+fn collect_requested_capabilities(
+    args: impl IntoIterator<Item = OsString>,
+    requirements: &mut Vec<Requirement>,
+    response_depth: usize,
+) -> Result<()> {
+    for arg in args {
+        let Some(arg) = arg.to_str() else {
+            continue;
+        };
+        if let Some(path) = arg.strip_prefix('@') {
+            if response_depth >= 16 {
+                bail!("Linker response-file nesting exceeds 16 levels at `{path}`");
+            }
+            let nested = crate::args::read_args_from_file(Path::new(path))?
+                .into_iter()
+                .map(OsString::from);
+            collect_requested_capabilities(nested, requirements, response_depth + 1)?;
+            continue;
+        }
+
+        let lower = arg.to_ascii_lowercase();
+        let requirement = if is_driver_lto_flag(&lower) {
+            Some(Requirement {
+                capability: Capability::Lto,
+                trigger: "flag:-flto",
+            })
+        } else if lower == "-plugin"
+            || lower == "--plugin"
+            || lower.starts_with("-plugin=")
+            || lower.starts_with("--plugin=")
+        {
+            Some(Requirement {
+                capability: Capability::Lto,
+                trigger: "flag:--plugin",
+            })
+        } else if lower == "/ltcg"
+            || lower.starts_with("/ltcg:")
+            || lower == "/gl"
+            || lower.starts_with("/gl:")
+        {
+            Some(Requirement {
+                capability: Capability::Lto,
+                trigger: "flag:/LTCG",
+            })
+        } else if lower == "--icf=all"
+            || lower == "--icf=safe"
+            || lower == "-icf=all"
+            || lower == "-icf=safe"
+        {
+            Some(Requirement {
+                capability: Capability::Icf,
+                trigger: "flag:--icf",
+            })
+        } else if lower == "--discard-all" || lower == "-discard-all" || lower == "-x" {
+            Some(Requirement {
+                capability: Capability::DiscardAll,
+                trigger: "flag:--discard-all",
+            })
+        } else if lower == "--fatal-warnings" || lower == "-fatal-warnings" {
+            Some(Requirement {
+                capability: Capability::FatalWarnings,
+                trigger: "flag:--fatal-warnings",
+            })
+        } else if lower == "--color-diagnostics"
+            || lower.starts_with("--color-diagnostics=")
+            || lower == "--no-color-diagnostics"
+        {
+            Some(Requirement {
+                capability: Capability::ColorDiagnostics,
+                trigger: "flag:--color-diagnostics",
+            })
+        } else if lower == "--no-undefined-version"
+            || lower == "-no-undefined-version"
+            || lower == "--undefined-version"
+            || lower == "-undefined-version"
+        {
+            Some(Requirement {
+                capability: Capability::VersionScriptPolicy,
+                trigger: "flag:--no-undefined-version",
+            })
+        } else if lower == "--fix-cortex-a53-843419" || lower == "-fix-cortex-a53-843419" {
+            Some(Requirement {
+                capability: Capability::CortexA53Erratum,
+                trigger: "flag:--fix-cortex-a53-843419",
+            })
+        } else {
+            None
+        };
+
+        if let Some(requirement) = requirement
+            && !requirements
+                .iter()
+                .any(|existing: &Requirement| existing.capability == requirement.capability)
+        {
+            requirements.push(requirement);
+        }
+    }
+
+    Ok(())
+}
+
+fn requested_capabilities(argv: &[OsString]) -> Result<Vec<Requirement>> {
+    let mut requirements = Vec::new();
+    collect_requested_capabilities(argv.iter().skip(1).cloned(), &mut requirements, 0)?;
+    Ok(requirements)
+}
+
+fn override_from_request(
+    argv: &[OsString],
+    env_override: Option<&str>,
+) -> (Option<String>, SelectionReason) {
+    match engine_override_from_argv(argv) {
+        Some(name) => (Some(name), SelectionReason::OverrideFlag),
+        None => match env_override {
+            Some(name) => (Some(name.to_owned()), SelectionReason::OverrideEnv),
+            None => (None, SelectionReason::Default),
+        },
+    }
+}
+
+fn select_route_with_env(
+    argv: &[OsString],
+    target: BridgeTarget,
+    env_override: Option<&str>,
+) -> Result<Route> {
+    // COFF and Mach-O each have a single bundled engine today, so parsing their response files
+    // cannot affect selection. More importantly, their response grammars and encodings differ
+    // from ELF/GNU (MSVC commonly emits UTF-16). Leave them byte-for-byte for the destination
+    // driver instead of eagerly feeding them through reld's UTF-8 GNU response parser.
+    let requirements = if target == BridgeTarget::Elf {
+        requested_capabilities(argv)?
+    } else {
+        Vec::new()
+    };
+    let (override_name, override_reason) = override_from_request(argv, env_override);
+    let engine = select_engine(target, override_name.as_deref(), &requirements)?;
+    let default = Engine::default_for(target);
+    let reason = if override_name.is_some() {
+        override_reason
+    } else if engine != default {
+        let Some(requirement) = requirements.first() else {
+            bail!("Internal error: non-default route selected without a capability requirement");
+        };
+        SelectionReason::Capability(requirement.trigger)
+    } else {
+        SelectionReason::Default
+    };
+
+    Ok(Route { engine, reason })
+}
+
+/// Selects the engine for one raw linker invocation.
+pub fn select_route(argv: &[OsString], target: BridgeTarget) -> Result<Route> {
+    select_route_with_env(argv, target, std::env::var(RELD_ENGINE_ENV).ok().as_deref())
 }
 
 /// Locates the linker binary that the bridge should delegate to for the given engine.
@@ -160,7 +463,8 @@ fn select_engine(target: BridgeTarget, override_name: Option<&str>) -> Result<&'
 /// 2. `rust-lld` next to the active toolchain (`rustc --print sysroot`).
 /// 3. `gcc-ld/<basename>` under that same rustlib bin dir, then `<basename>` on `PATH`.
 /// 4. Otherwise, a hard error naming `RELD_BRIDGE_LINKER` and what to install.
-pub fn discover_linker(engine: &Engine) -> Result<PathBuf> {
+fn discover_linker(engine: &Engine) -> Result<PathBuf> {
+    debug_assert!(!engine.native);
     if let Ok(value) = std::env::var(RELD_BRIDGE_LINKER_ENV) {
         let path = PathBuf::from(value);
         if !path.exists() {
@@ -318,6 +622,53 @@ fn forwarded_args<I: IntoIterator<Item = OsString>>(argv: I) -> Vec<OsString> {
     rest
 }
 
+/// Removes compiler-driver-only LTO switches after they have served their routing purpose. LLD
+/// consumes LLVM bitcode directly and rejects `-flto` itself; plugin switches are real linker
+/// options and remain untouched.
+fn forwarded_args_for_engine<I: IntoIterator<Item = OsString>>(
+    argv: I,
+    engine: &Engine,
+) -> Result<Vec<OsString>> {
+    let forwarded = forwarded_args(argv);
+    if engine.name == "lld" {
+        return expand_and_strip_driver_lto(forwarded, 0);
+    }
+    Ok(forwarded)
+}
+
+fn is_driver_lto_flag(arg: &str) -> bool {
+    arg.eq_ignore_ascii_case("-flto")
+        || arg.eq_ignore_ascii_case("--flto")
+        || arg.to_ascii_lowercase().starts_with("-flto=")
+        || arg.to_ascii_lowercase().starts_with("--flto=")
+}
+
+fn expand_and_strip_driver_lto(
+    args: impl IntoIterator<Item = OsString>,
+    response_depth: usize,
+) -> Result<Vec<OsString>> {
+    let mut forwarded = Vec::new();
+    for arg in args {
+        if let Some(arg) = arg.to_str() {
+            if is_driver_lto_flag(arg) {
+                continue;
+            }
+            if let Some(path) = arg.strip_prefix('@') {
+                if response_depth >= 16 {
+                    bail!("Linker response-file nesting exceeds 16 levels at `{path}`");
+                }
+                let nested = crate::args::read_args_from_file(Path::new(path))?
+                    .into_iter()
+                    .map(OsString::from);
+                forwarded.extend(expand_and_strip_driver_lto(nested, response_depth + 1)?);
+                continue;
+            }
+        }
+        forwarded.push(arg);
+    }
+    Ok(forwarded)
+}
+
 /// Extracts the `--engine=<name>` override from the process argv, if present. Skips `argv[0]`
 /// (the program path) to mirror `forwarded_args`, so a program invoked from a path that happens
 /// to start with `--engine=` can never be misread as an override.
@@ -347,27 +698,21 @@ fn child_command_line(linker: &Path, engine: &Engine, forwarded: Vec<OsString>) 
 /// `argv` is the full process argv, including `argv[0]`; `argv[0]` is dropped and the rest is
 /// forwarded as the linker's command line (with `-flavor <target>` prepended if the discovered
 /// linker needs it).
-pub fn run_bridge<I: IntoIterator<Item = OsString>>(argv: I, target: BridgeTarget) -> Result<()> {
+pub fn run_bridge<I: IntoIterator<Item = OsString>>(argv: I, route: Route) -> Result<()> {
     let argv: Vec<OsString> = argv.into_iter().collect();
-
-    let (override_name, reason) = match engine_override_from_argv(&argv) {
-        Some(name) => (Some(name), SelectionReason::OverrideFlag),
-        None => match std::env::var(RELD_ENGINE_ENV) {
-            Ok(name) => (Some(name), SelectionReason::OverrideEnv),
-            Err(_) => (None, SelectionReason::Default),
-        },
-    };
-
-    let engine = select_engine(target, override_name.as_deref())?;
+    if !route.is_bridge() {
+        bail!("Internal error: native engine passed to the subprocess bridge");
+    }
+    let engine = route.engine;
     let linker = discover_linker(engine)?;
 
-    let forwarded = forwarded_args(argv);
+    let forwarded = forwarded_args_for_engine(argv, engine)?;
     let child_args = child_command_line(&linker, engine, forwarded);
 
     eprintln!(
         "reld: engine={} (bridge, reason={}) -> {}",
         engine.name,
-        reason.label(),
+        route.reason.label(),
         linker.display()
     );
 
@@ -441,8 +786,12 @@ mod tests {
 
     impl TempFile {
         fn create(name: &str) -> Self {
+            Self::create_with_contents(name, b"")
+        }
+
+        fn create_with_contents(name: &str, contents: &[u8]) -> Self {
             let path = unique_temp_path(name);
-            std::fs::write(&path, b"").unwrap();
+            std::fs::write(&path, contents).unwrap();
             Self(path)
         }
 
@@ -467,6 +816,9 @@ mod tests {
         assert_eq!(discovered, fake_linker.path());
 
         let discovered = discover_linker(Engine::default_for(BridgeTarget::MachO)).unwrap();
+        assert_eq!(discovered, fake_linker.path());
+
+        let discovered = discover_linker(Engine::find("lld").unwrap()).unwrap();
         assert_eq!(discovered, fake_linker.path());
     }
 
@@ -514,8 +866,12 @@ mod tests {
     fn not_found_message_names_env_var() {
         // The "no linker discoverable" error must always tell the user about the override knob,
         // for both bridge targets.
-        for target in [BridgeTarget::Coff, BridgeTarget::MachO] {
-            let message = not_found_message(Engine::default_for(target));
+        for engine in [
+            Engine::find("lld").unwrap(),
+            Engine::default_for(BridgeTarget::Coff),
+            Engine::default_for(BridgeTarget::MachO),
+        ] {
+            let message = not_found_message(engine);
             assert!(
                 message.contains(RELD_BRIDGE_LINKER_ENV),
                 "unexpected error message: {message}"
@@ -629,6 +985,18 @@ mod tests {
     }
 
     #[test]
+    fn elf_flavor_prefix_is_gnu() {
+        let forwarded = vec![OsString::from("-o"), OsString::from("a.out")];
+        let child = child_command_line(
+            Path::new("/tc/rust-lld"),
+            Engine::find("lld").unwrap(),
+            forwarded,
+        );
+        assert_eq!(child[0], OsString::from("-flavor"));
+        assert_eq!(child[1], OsString::from("gnu"));
+    }
+
+    #[test]
     fn lld_link_route_has_no_flavor_prefix() {
         let forwarded = vec![OsString::from("/OUT:a.exe"), OsString::from("foo.obj")];
         let expected = forwarded.clone();
@@ -654,30 +1022,30 @@ mod tests {
 
     #[test]
     fn select_engine_default_for_coff_is_lld_link() {
-        let engine = select_engine(BridgeTarget::Coff, None).unwrap();
+        let engine = select_engine(BridgeTarget::Coff, None, &[]).unwrap();
         assert_eq!(engine.name, "lld-link");
         assert_eq!(engine.format, BridgeTarget::Coff);
     }
 
     #[test]
     fn select_engine_default_for_macho_is_ld64_lld() {
-        let engine = select_engine(BridgeTarget::MachO, None).unwrap();
+        let engine = select_engine(BridgeTarget::MachO, None, &[]).unwrap();
         assert_eq!(engine.name, "ld64.lld");
         assert_eq!(engine.format, BridgeTarget::MachO);
     }
 
     #[test]
     fn select_engine_valid_override_matches_target() {
-        let engine = select_engine(BridgeTarget::Coff, Some("lld-link")).unwrap();
+        let engine = select_engine(BridgeTarget::Coff, Some("lld-link"), &[]).unwrap();
         assert_eq!(engine.name, "lld-link");
 
-        let engine = select_engine(BridgeTarget::MachO, Some("ld64.lld")).unwrap();
+        let engine = select_engine(BridgeTarget::MachO, Some("ld64.lld"), &[]).unwrap();
         assert_eq!(engine.name, "ld64.lld");
     }
 
     #[test]
     fn select_engine_unknown_name_errors_listing_valid_engines() {
-        let err = select_engine(BridgeTarget::Coff, Some("bogus")).unwrap_err();
+        let err = select_engine(BridgeTarget::Coff, Some("bogus"), &[]).unwrap_err();
         let message = err.to_string();
         assert!(message.contains("bogus"), "unexpected message: {message}");
         assert!(
@@ -693,7 +1061,7 @@ mod tests {
     #[test]
     fn select_engine_format_mismatch_errors() {
         // ld64.lld links Mach-O; requesting it for a COFF link is a format mismatch.
-        let err = select_engine(BridgeTarget::Coff, Some("ld64.lld")).unwrap_err();
+        let err = select_engine(BridgeTarget::Coff, Some("ld64.lld"), &[]).unwrap_err();
         let message = err.to_string();
         assert!(
             message.contains("ld64.lld"),
@@ -702,13 +1070,220 @@ mod tests {
         assert!(message.contains("COFF"), "unexpected message: {message}");
 
         // Symmetric direction: lld-link links COFF; requesting it for a Mach-O link mismatches.
-        let err = select_engine(BridgeTarget::MachO, Some("lld-link")).unwrap_err();
+        let err = select_engine(BridgeTarget::MachO, Some("lld-link"), &[]).unwrap_err();
         let message = err.to_string();
         assert!(
             message.contains("lld-link"),
             "unexpected message: {message}"
         );
         assert!(message.contains("Mach-O"), "unexpected message: {message}");
+    }
+
+    #[test]
+    fn elf_defaults_to_native_reld() {
+        let route = select_route_with_env(
+            &[OsString::from("ld.reld"), OsString::from("foo.o")],
+            BridgeTarget::Elf,
+            None,
+        )
+        .unwrap();
+        assert_eq!(route.engine.name, "reld");
+        assert!(!route.is_bridge());
+        assert_eq!(route.reason, SelectionReason::Default);
+    }
+
+    #[test]
+    fn elf_lto_spellings_route_to_lld() {
+        for flag in [
+            "-flto",
+            "-flto=thin",
+            "--flto=full",
+            "--plugin=/tool/LLVMgold.so",
+            "-plugin",
+        ] {
+            let route = select_route_with_env(
+                &[
+                    OsString::from("ld.reld"),
+                    OsString::from(flag),
+                    OsString::from("foo.o"),
+                ],
+                BridgeTarget::Elf,
+                None,
+            )
+            .unwrap();
+            assert_eq!(route.engine.name, "lld", "flag {flag}");
+            assert!(route.is_bridge(), "flag {flag}");
+            assert!(matches!(route.reason, SelectionReason::Capability(_)));
+        }
+    }
+
+    #[test]
+    fn elf_icf_routes_to_lld_but_disabled_icf_stays_native() {
+        for flag in ["--icf=all", "--icf=safe"] {
+            let route = select_route_with_env(
+                &[OsString::from("ld.reld"), OsString::from(flag)],
+                BridgeTarget::Elf,
+                None,
+            )
+            .unwrap();
+            assert_eq!(route.engine.name, "lld", "flag {flag}");
+        }
+
+        let native = select_route_with_env(
+            &[OsString::from("ld.reld"), OsString::from("--icf=none")],
+            BridgeTarget::Elf,
+            None,
+        )
+        .unwrap();
+        assert_eq!(native.engine.name, "reld");
+    }
+
+    #[test]
+    fn unsupported_native_semantics_route_to_lld() {
+        for flag in [
+            "--discard-all",
+            "-x",
+            "--fatal-warnings",
+            "--color-diagnostics=always",
+            "--no-color-diagnostics",
+            "--no-undefined-version",
+            "--undefined-version",
+            "--fix-cortex-a53-843419",
+        ] {
+            let route = select_route_with_env(
+                &[OsString::from("ld.reld"), OsString::from(flag)],
+                BridgeTarget::Elf,
+                None,
+            )
+            .unwrap();
+            assert_eq!(route.engine.name, "lld", "flag {flag}");
+        }
+    }
+
+    #[test]
+    fn linker_plugin_inside_response_file_routes_to_lld() {
+        let response =
+            TempFile::create_with_contents("lto-response", b"--plugin=/tool/LLVMgold.so foo.o");
+        let route = select_route_with_env(
+            &[
+                OsString::from("ld.reld"),
+                OsString::from(format!("@{}", response.path().display())),
+            ],
+            BridgeTarget::Elf,
+            None,
+        )
+        .unwrap();
+        assert_eq!(route.engine.name, "lld");
+        assert_eq!(route.reason, SelectionReason::Capability("flag:--plugin"));
+    }
+
+    #[test]
+    fn non_elf_response_files_are_forwarded_without_gnu_or_utf8_parsing() {
+        // UTF-16LE response data with Windows quoting. This must remain opaque to the router;
+        // lld-link/ld64.lld own their response-file grammar and encoding.
+        let response = TempFile::create_with_contents(
+            "windows-utf16-response",
+            &[
+                0xff, 0xfe, b'/', 0, b'O', 0, b'U', 0, b'T', 0, b':', 0, b'"', 0, b'a', 0, b' ', 0,
+                b'b', 0, b'.', 0, b'e', 0, b'x', 0, b'e', 0, b'"', 0,
+            ],
+        );
+        let response_arg = OsString::from(format!("@{}", response.path().display()));
+
+        for target in [BridgeTarget::Coff, BridgeTarget::MachO] {
+            let argv = [OsString::from("reld"), response_arg.clone()];
+            let route = select_route_with_env(&argv, target, None).unwrap();
+            assert_eq!(route.engine, Engine::default_for(target));
+            assert_eq!(
+                forwarded_args_for_engine(argv, route.engine).unwrap(),
+                vec![response_arg.clone()]
+            );
+        }
+    }
+
+    #[test]
+    fn elf_lld_strips_driver_lto_flag_but_keeps_plugin_flag() {
+        let argv = [
+            OsString::from("ld.reld"),
+            OsString::from("--engine=lld"),
+            OsString::from("-flto=thin"),
+            OsString::from("--plugin=/tool/LLVMgold.so"),
+            OsString::from("foo.o"),
+        ];
+        assert_eq!(
+            forwarded_args_for_engine(argv, Engine::find("lld").unwrap()).unwrap(),
+            vec![
+                OsString::from("--plugin=/tool/LLVMgold.so"),
+                OsString::from("foo.o"),
+            ]
+        );
+    }
+
+    #[test]
+    fn elf_lld_expands_response_files_and_strips_nested_driver_lto_flag() {
+        let nested = TempFile::create_with_contents(
+            "nested-lto-response",
+            b"-flto=thin --build-id=sha1 nested.o",
+        );
+        let nested_path = nested.path().to_string_lossy().replace('\\', "/");
+        let outer = TempFile::create_with_contents(
+            "outer-lto-response",
+            format!("@{nested_path} outer.o").as_bytes(),
+        );
+        let argv = [
+            OsString::from("ld.reld"),
+            OsString::from(format!("@{}", outer.path().display())),
+        ];
+
+        let route = select_route_with_env(&argv, BridgeTarget::Elf, None).unwrap();
+        assert_eq!(route.engine.name, "lld");
+        assert_eq!(
+            forwarded_args_for_engine(argv, route.engine).unwrap(),
+            vec![
+                OsString::from("--build-id=sha1"),
+                OsString::from("nested.o"),
+                OsString::from("outer.o"),
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_engine_flag_takes_precedence_over_environment() {
+        let route = select_route_with_env(
+            &[OsString::from("ld.reld"), OsString::from("--engine=lld")],
+            BridgeTarget::Elf,
+            Some("reld"),
+        )
+        .unwrap();
+        assert_eq!(route.engine.name, "lld");
+        assert_eq!(route.reason, SelectionReason::OverrideFlag);
+    }
+
+    #[test]
+    fn environment_can_force_elf_lld() {
+        let route =
+            select_route_with_env(&[OsString::from("ld.reld")], BridgeTarget::Elf, Some("lld"))
+                .unwrap();
+        assert_eq!(route.engine.name, "lld");
+        assert_eq!(route.reason, SelectionReason::OverrideEnv);
+    }
+
+    #[test]
+    fn forcing_native_reld_for_lto_is_a_clear_error() {
+        let error = select_route_with_env(
+            &[
+                OsString::from("ld.reld"),
+                OsString::from("--engine=reld"),
+                OsString::from("-flto"),
+            ],
+            BridgeTarget::Elf,
+            None,
+        )
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("reld"), "unexpected message: {message}");
+        assert!(message.contains("LTO"), "unexpected message: {message}");
+        assert!(message.contains("-flto"), "unexpected message: {message}");
     }
 
     #[test]

--- a/crates/reld-core/src/bridge.rs
+++ b/crates/reld-core/src/bridge.rs
@@ -73,6 +73,7 @@ pub struct Engine {
 /// Capabilities that affect engine selection rather than merely argument spelling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Capability {
+    NativeControl,
     Lto,
     Icf,
     DiscardAll,
@@ -85,6 +86,7 @@ enum Capability {
 impl Capability {
     fn label(self) -> &'static str {
         match self {
+            Capability::NativeControl => "reld-only validation or diagnostic output",
             Capability::Lto => "LTO",
             Capability::Icf => "identical code folding",
             Capability::DiscardAll => "discarding local symbols",
@@ -96,7 +98,7 @@ impl Capability {
     }
 }
 
-const NO_CAPABILITIES: &[Capability] = &[];
+const NATIVE_RELD_CAPABILITIES: &[Capability] = &[Capability::NativeControl];
 const LLD_CAPABILITIES: &[Capability] = &[
     Capability::Lto,
     Capability::Icf,
@@ -113,7 +115,7 @@ const NATIVE_RELD_ENGINE: Engine = Engine {
     linker_basename: "",
     rust_lld_flavor: "",
     native: true,
-    capabilities: NO_CAPABILITIES,
+    capabilities: NATIVE_RELD_CAPABILITIES,
 };
 const ELF_LLD_ENGINE: Engine = Engine {
     name: "lld",
@@ -181,7 +183,6 @@ struct Requirement {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SelectionReason {
     Default,
-    SaveOnly,
     OverrideFlag,
     OverrideEnv,
     Capability(&'static str),
@@ -191,7 +192,6 @@ impl SelectionReason {
     fn label(self) -> &'static str {
         match self {
             SelectionReason::Default => "default",
-            SelectionReason::SaveOnly => "save-only(RELD_SAVE_SKIP_LINKING)",
             SelectionReason::OverrideFlag => "override(--engine)",
             SelectionReason::OverrideEnv => "override(RELD_ENGINE)",
             SelectionReason::Capability(trigger) => trigger,
@@ -333,7 +333,15 @@ fn collect_requested_capabilities(
         }
 
         let lower = arg.to_ascii_lowercase();
-        let requirement = if is_driver_lto_flag(&lower) {
+        let requirement = if matches!(
+            lower.as_str(),
+            "--validate-output" | "--write-layout" | "--write-trace"
+        ) {
+            Some(Requirement {
+                capability: Capability::NativeControl,
+                trigger: "flag:reld-only-control",
+            })
+        } else if is_driver_lto_flag(&lower) {
             Some(Requirement {
                 capability: Capability::Lto,
                 trigger: "flag:-flto",
@@ -432,22 +440,41 @@ fn override_from_request(
     }
 }
 
-fn select_route_with_env(
+fn select_route_with_policy(
     argv: &[OsString],
     target: BridgeTarget,
     env_override: Option<&str>,
+    allow_unsupported_native: bool,
+    native_control_env: bool,
 ) -> Result<Route> {
     // COFF and Mach-O each have a single bundled engine today, so parsing their response files
     // cannot affect selection. More importantly, their response grammars and encodings differ
     // from ELF/GNU (MSVC commonly emits UTF-16). Leave them byte-for-byte for the destination
     // driver instead of eagerly feeding them through reld's UTF-8 GNU response parser.
-    let requirements = if target == BridgeTarget::Elf {
+    let mut requirements = if target == BridgeTarget::Elf {
         requested_capabilities(argv)?
     } else {
         Vec::new()
     };
+    if target == BridgeTarget::Elf
+        && native_control_env
+        && !requirements
+            .iter()
+            .any(|requirement| requirement.capability == Capability::NativeControl)
+    {
+        requirements.push(Requirement {
+            capability: Capability::NativeControl,
+            trigger: "environment:reld-only-control",
+        });
+    }
     let (override_name, override_reason) = override_from_request(argv, env_override);
-    let engine = select_engine(target, override_name.as_deref(), &requirements)?;
+    let checked_requirements =
+        if allow_unsupported_native && override_name.as_deref() == Some(NATIVE_RELD_ENGINE.name) {
+            &[][..]
+        } else {
+            requirements.as_slice()
+        };
+    let engine = select_engine(target, override_name.as_deref(), checked_requirements)?;
     let default = Engine::default_for(target);
     let reason = if override_name.is_some() {
         override_reason
@@ -463,31 +490,35 @@ fn select_route_with_env(
     Ok(Route { engine, reason })
 }
 
-fn select_route_with_context(
+#[cfg(test)]
+fn select_route_with_env(
     argv: &[OsString],
     target: BridgeTarget,
     env_override: Option<&str>,
-    capture_only: bool,
 ) -> Result<Route> {
-    // Save-dir capture must parse the original invocation and write its native replay artifact.
-    // Capability routing is irrelevant because RELD_SAVE_SKIP_LINKING exits before the final link.
-    if capture_only && target == BridgeTarget::Elf {
-        return Ok(Route {
-            engine: &NATIVE_RELD_ENGINE,
-            reason: SelectionReason::SaveOnly,
-        });
-    }
-
-    select_route_with_env(argv, target, env_override)
+    select_route_with_policy(argv, target, env_override, false, false)
 }
 
 /// Selects the engine for one raw linker invocation.
 pub fn select_route(argv: &[OsString], target: BridgeTarget) -> Result<Route> {
-    select_route_with_context(
+    let native_control_env = [
+        crate::args::VALIDATE_ENV,
+        crate::args::WRITE_LAYOUT_ENV,
+        crate::args::WRITE_TRACE_ENV,
+    ]
+    .iter()
+    .any(|name| std::env::var_os(name).is_some());
+    let allow_unsupported_native = std::env::var(crate::args::RELD_UNSUPPORTED_ENV)
+        .ok()
+        .as_deref()
+        == Some("ignore");
+
+    select_route_with_policy(
         argv,
         target,
         std::env::var(RELD_ENGINE_ENV).ok().as_deref(),
-        crate::save_dir::capture_only_requested(),
+        allow_unsupported_native,
+        native_control_env,
     )
 }
 
@@ -1130,21 +1161,51 @@ mod tests {
     }
 
     #[test]
-    fn elf_capture_only_lto_stays_native_for_save_dir_replay() {
-        let route = select_route_with_context(
+    fn explicit_native_override_can_accept_capabilities_with_ignore_policy() {
+        let route = select_route_with_policy(
             &[
                 OsString::from("ld.reld"),
                 OsString::from("-flto"),
                 OsString::from("foo.o"),
             ],
             BridgeTarget::Elf,
-            None,
+            Some("reld"),
             true,
+            false,
         )
         .unwrap();
         assert_eq!(route.engine.name, "reld");
         assert!(!route.is_bridge());
-        assert_eq!(route.reason, SelectionReason::SaveOnly);
+        assert_eq!(route.reason, SelectionReason::OverrideEnv);
+    }
+
+    #[test]
+    fn ignore_policy_does_not_suppress_conflicting_lld_override() {
+        let error = select_route_with_policy(
+            &[
+                OsString::from("ld.reld"),
+                OsString::from("--validate-output"),
+            ],
+            BridgeTarget::Elf,
+            Some("lld"),
+            true,
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("reld-only validation"));
+    }
+
+    #[test]
+    fn ignore_policy_does_not_suppress_unknown_override() {
+        let error = select_route_with_policy(
+            &[OsString::from("ld.reld"), OsString::from("foo.o")],
+            BridgeTarget::Elf,
+            Some("bogus"),
+            true,
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Unknown engine `bogus`"));
     }
 
     #[test]

--- a/crates/reld-core/src/lib.rs
+++ b/crates/reld-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod args;
 pub mod bridge;
 pub use bridge::BridgeTarget;
 pub use bridge::run_bridge;
+pub use bridge::select_route;
 pub(crate) mod compression;
 pub(crate) mod debug_trace;
 pub(crate) mod diagnostics;

--- a/crates/reld-core/src/save_dir.rs
+++ b/crates/reld-core/src/save_dir.rs
@@ -29,12 +29,6 @@ const SKIP_LINKING_ENV: &str = "RELD_SAVE_SKIP_LINKING";
 
 const PRELUDE: &str = include_str!("save-dir-prelude.sh");
 
-/// Whether this invocation exists only to capture a replayable native-link command.
-pub(crate) fn capture_only_requested() -> bool {
-    std::env::var_os(SKIP_LINKING_ENV).is_some()
-        && (std::env::var_os(SAVE_DIR_ENV).is_some() || std::env::var_os(SAVE_BASE_ENV).is_some())
-}
-
 #[derive(Debug)]
 struct SaveDirState {
     dir: PathBuf,

--- a/crates/reld-core/src/save_dir.rs
+++ b/crates/reld-core/src/save_dir.rs
@@ -29,6 +29,12 @@ const SKIP_LINKING_ENV: &str = "RELD_SAVE_SKIP_LINKING";
 
 const PRELUDE: &str = include_str!("save-dir-prelude.sh");
 
+/// Whether this invocation exists only to capture a replayable native-link command.
+pub(crate) fn capture_only_requested() -> bool {
+    std::env::var_os(SKIP_LINKING_ENV).is_some()
+        && (std::env::var_os(SAVE_DIR_ENV).is_some() || std::env::var_os(SAVE_BASE_ENV).is_some())
+}
+
 #[derive(Debug)]
 struct SaveDirState {
     dir: PathBuf,

--- a/crates/reld/src/main.rs
+++ b/crates/reld/src/main.rs
@@ -21,11 +21,14 @@ fn run() -> reld_core::error::Result {
 
     reld_core::init_timing()?;
 
+    let raw_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
     let mut args = reld_core::Args::new(std::env::args)?;
+    let route = reld_core::select_route(&raw_args, args.link_target())?;
 
-    if let Some(target) = args.bridge_target() {
-        return reld_core::run_bridge(std::env::args_os(), target);
+    if route.is_bridge() {
+        return reld_core::run_bridge(raw_args, route);
     }
+    route.log_native();
 
     args.set_version(VERSION);
     args.parse(std::env::args)?;

--- a/crates/reld/tests/acceptance.rs
+++ b/crates/reld/tests/acceptance.rs
@@ -3152,6 +3152,8 @@ fn build_obj(
 
             command
                 .env("RELD_SAVE_SKIP_LINKING", "1")
+                .env(reld_core::bridge::RELD_ENGINE_ENV, "reld")
+                .env(reld_core::args::RELD_UNSUPPORTED_ENV, "ignore")
                 .args(config.rustc_channel.as_arg())
                 .args(["-C", "linker=clang"])
                 .args(["-C", &format!("link-arg=--ld-path={reld}")]);
@@ -3808,6 +3810,8 @@ impl LinkCommand {
         }
 
         if linker.is_reld() {
+            command.env(reld_core::bridge::RELD_ENGINE_ENV, "reld");
+            command.env(reld_core::args::RELD_UNSUPPORTED_ENV, "ignore");
             if matches!(config.linker_driver, LinkerDriver::Direct(_)) {
                 command.arg("--validate-output");
                 // TODO: Add a flag or do something so that unsupported flags get ignored. i.e. the
@@ -3815,7 +3819,6 @@ impl LinkCommand {
                 // than printing warnings, reld_core should return them, then we as the caller can
                 // just choose to not print them.
             } else {
-                command.env(reld_core::args::RELD_UNSUPPORTED_ENV, "ignore");
                 command.env(reld_core::args::VALIDATE_ENV, "1");
             }
 

--- a/crates/reld/tests/acceptance.rs
+++ b/crates/reld/tests/acceptance.rs
@@ -1409,6 +1409,9 @@ impl Config {
     }
 
     fn is_linker_enabled(&self, linker: &Linker) -> bool {
+        if linker.is_reld() && self.uses_native_save_dir_incompatible_lto_route() {
+            return false;
+        }
         if let Some(references) = self.reference_linkers.as_ref() {
             if linker.is_reld() {
                 return true;
@@ -1424,6 +1427,19 @@ impl Config {
             return true;
         }
         linker.enabled_by_default()
+    }
+
+    /// These legacy configurations require reld's native save-dir replay script. Routed LTO
+    /// deliberately bypasses that native-only path; ci/linker_modes.py covers the routed engine
+    /// end to end on every host while these configurations continue testing their references.
+    fn uses_native_save_dir_incompatible_lto_route(&self) -> bool {
+        matches!(
+            (self.test_name.as_str(), self.config_name.as_str()),
+            ("wrap-lto", "clang")
+                | ("lto-integration", "clang")
+                | ("rust-integration-dynamic", "lto")
+                | ("rust-integration", "linker-plugin-lto")
+        )
     }
 
     /// Returns the configuration that should be used when building our dependencies. This is a copy

--- a/crates/reld/tests/external_tests/mold_tests.rs
+++ b/crates/reld/tests/external_tests/mold_tests.rs
@@ -50,11 +50,20 @@ fn run_mold_test(mold_test: &Path) -> Result<Output> {
         None
     };
 
-    let env_vars: Vec<(&str, &str)> = if let Some(ref triple_value) = triple {
+    let mut env_vars: Vec<(&str, &str)> = if let Some(ref triple_value) = triple {
         vec![("TRIPLE", triple_value.as_str())]
     } else {
         vec![]
     };
+
+    // This corpus measures reld's native ELF compatibility. Routed LLD coverage lives in the
+    // dedicated linker-mode matrix, so keep the native regression ratchet on the native engine.
+    if !using_third_party_linker() {
+        env_vars.extend([
+            (reld_core::bridge::RELD_ENGINE_ENV, "reld"),
+            (reld_core::args::RELD_UNSUPPORTED_ENV, "ignore"),
+        ]);
+    }
 
     run_external_test(mold_test, &env_vars)
 }

--- a/docker/bosn.Dockerfile
+++ b/docker/bosn.Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.94.1-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_HOME=/bosn/cargo-home \
+    CARGO_TARGET_DIR=/bosn/target
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        lld \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /reld
+COPY . .

--- a/docs/plan/01-DECISIONS.md
+++ b/docs/plan/01-DECISIONS.md
@@ -280,30 +280,27 @@ Once that's true, "reject LTO" is no longer the honest best available answer —
   linker across all three platforms — unchanged from the original rationale in `DESIGN.md` §3.1.
   The revision is about *how the user's LTO request is handled today*, not about reld growing
   native LTO sooner.
-- **The flag-aware router itself is not yet implemented.** This decision records the target
-  policy for B8/#17 and the daemon router (#19) to implement against; it does not claim the
-  routing exists. **Until the router lands, current behavior is unchanged from the original
-  text**: LTO flags are rejected or ignored with a specific diagnostic naming the feature — never
-  silently mislinked.
+- **The initial flag-aware router is implemented for ELF.** `-flto` and linker-plugin requests
+  route from the native engine to the ELF `lld` bridge. B8/#17 can extend the capability set and
+  the daemon router (#19) can reuse the same policy; native LTO remains future work.
 
 Consequences for every phase:
 
 - **Do not delete wild's linker-plugin LTO.** The fork inherits a working-with-known-issues
   implementation on ELF (`linker_plugins.rs`, ~1467 LOC, driven from `lib.rs:325` and
   `lib.rs:374`). P2 must not regress it; pin current behaviour with a smoke test.
-- **Until the flag-aware router (B8) is implemented, LTO flags are rejected or ignored with a
-  specific diagnostic naming the feature** — never silently mislinked. This matters most where
-  build systems pass the flag unconditionally: rustc passes `-plugin` on the MinGW gcc path
-  (unless `-fno-use-linker-plugin`), and MSBuild passes `/LTCG`. Once B8 lands, the same flags
-  route to a capable bundled engine instead of producing that diagnostic.
+- **LTO requests route to a capable bundled engine.** This matters most where build systems pass
+  the flag unconditionally: rustc passes `-plugin` on GNU linker paths (unless
+  `-fno-use-linker-plugin`), and MSBuild passes `/LTCG`. An explicit request for an incapable
+  engine is rejected with a feature-specific diagnostic.
 - When native LTO does land in reld's own engine it will still be **incompatible with the
   incremental path** — gold and MSVC both fall back to a full link for it — so trigger 13 in
   `09-INCREMENTAL.md` §I1 stays permanent. Routing an LTO link to the `lld` bridge is likewise
   incompatible with the incremental path, for the same reason.
 
 Do not treat "LTO is a non-goal" as current. Earlier drafts of `DESIGN.md` and `README.md` said
-that; both have been corrected. Do not treat "the flag-aware router routes LTO today" as current
-either — see `agents/docs/polylinker.md` for the shipped-vs-designed summary.
+that; both have been corrected. The product-level ELF LTO route is shipped; native LTO codegen is
+still future work. See `agents/docs/polylinker.md` for the current capability boundary.
 
 ## D12 — Test oracle. **Locked: semantic differential, not byte comparison.**
 


### PR DESCRIPTION
## Summary

- route ELF links through native reld when supported and bridge LTO/capability gaps through the bundled LLD
- route COFF and Mach-O links through their matching bundled LLD drivers
- add a Python integration runner that builds, links, executes, and verifies fast, ThinLTO, and full-LTO fixtures
- run the same Python meat from thin Linux, Windows, and macOS GitHub Actions jobs via `uv run --no-project`
- document engine selection and provide a reproducible Bosn Linux harness

## Validation

- `soldr cargo fmt --all -- --check`
- `soldr cargo clippy -p reld-core -p reld --all-targets --no-default-features -- -D warnings`
- 37 focused bridge tests
- 89 Python CI tests
- Ruff check and format checks
- Windows: fast, ThinLTO, and full LTO all linked through `lld-link` and executed successfully
- Linux/Bosn: fast linked natively; ThinLTO and full LTO bridged through LLD; all executables ran successfully
- `/clud-review`: clean, no remaining critical or high findings
