### PR TITLE
fix(ci): restore trustworthy benchmark publishing

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -39,6 +39,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+
+      - name: Sync Python tooling
+        shell: bash
+        run: uv sync --extra dev
+
       - uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Install Linux linkers
@@ -59,7 +67,7 @@ jobs:
       - name: Install Windows linkers
         if: runner.os == 'Windows'
         shell: bash
-        run: python -m ci.windows_ci install-benchmark-linkers
+        run: uv run --no-sync python -m ci.windows_ci install-benchmark-linkers
 
       - name: Install macOS linkers
         if: runner.os == 'macOS'
@@ -92,7 +100,7 @@ jobs:
         shell: bash
         env:
           CARGO_COMMAND: cargo
-        run: python -m ci.windows_ci build-benchmark-driver
+        run: uv run --no-sync python -m ci.windows_ci build-benchmark-driver
 
       - name: Build macOS Mach-O reld front door
         if: runner.os == 'macOS'
@@ -132,9 +140,7 @@ jobs:
           # Fails the build if any expected linker for this platform reports n/a, or if a
           # pending-by-design linker slipped to a bare n/a. Prints the expected-vs-measured
           # table to the log and the job step summary (#63).
-          PY=python3
-          command -v "$PY" >/dev/null 2>&1 || PY=python
-          "$PY" -m ci.benchmark_coverage \
+          uv run --no-sync python -m ci.benchmark_coverage \
             --input-log "benchmark-output/benchmark.log" --target "$TARGET"
 
       - name: Report per-target timings and metadata
@@ -143,9 +149,7 @@ jobs:
         run: |
           set -euo pipefail
           test -f benchmark-output/benchmark.log
-          PY=python3
-          command -v "$PY" >/dev/null 2>&1 || PY=python
-          "$PY" -m ci.benchmark_stats \
+          uv run --no-sync python -m ci.benchmark_stats \
             --input-log benchmark-output/benchmark.log --summary-only \
             --publish-outcome "raw benchmark artifact uploaded; aggregation pending"
 
@@ -165,12 +169,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - name: Install renderer dependencies
-        run: python -m pip install --disable-pip-version-check pillow
+      - name: Sync Python tooling
+        shell: bash
+        run: uv sync --extra dev
 
       - name: Download benchmark logs
         uses: actions/download-artifact@v4
@@ -185,14 +194,14 @@ jobs:
           RELD_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/benchmark-stats
         run: |
           set -euo pipefail
-          mapfile -t targets < <(python -m ci.benchmark_stats --print-targets)
+          mapfile -t targets < <(uv run --no-sync python -m ci.benchmark_stats --print-targets)
           for target in "${targets[@]}"; do
             mkdir -p "benchmark-stats/$target"
             curl --fail --silent --location --max-time 30 \
               -o "benchmark-stats/$target/history.jsonl" \
               "$RELD_BENCHMARK_RAW_BASE_URL/$target/history.jsonl" \
               || : > "benchmark-stats/$target/history.jsonl"
-            python -m ci.benchmark_stats \
+            uv run --no-sync python -m ci.benchmark_stats \
               --input-log "benchmark-input/benchmark-log-$target/benchmark.log" \
               --output-dir "benchmark-stats/$target"
           done
@@ -201,8 +210,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m ci.benchmark_stats --check-readme README.md
-          python -m ci.benchmark_stats \
+          uv run --no-sync python -m ci.benchmark_stats --check-readme README.md
+          uv run --no-sync python -m ci.benchmark_stats \
             --verify-current-outputs benchmark-stats --expected-sha "$GITHUB_SHA" \
             --max-age-seconds 7200
 
@@ -272,16 +281,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: Sync Python tooling
+        shell: bash
+        run: uv sync --extra dev
 
       - name: Check published latest.json age and status
         env:
           RELD_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/benchmark-stats
         run: |
           set -euo pipefail
-          python -m ci.benchmark_stats \
+          uv run --no-sync python -m ci.benchmark_stats \
             --check-remote-freshness \
             --remote-base-url "$RELD_BENCHMARK_RAW_BASE_URL" \
             --expected-sha "$GITHUB_SHA" \

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -25,15 +25,15 @@ jobs:
         include:
           - runner: ubuntu-24.04
             target: x86_64-linux
-          # reld is measured natively on Linux; on Windows/macOS it is pending-by-design (the
-          # rustc-based bridge measurement hasn't landed — see #17), so it renders an explicit
-          # `pending` rather than a silent `n/a` (#63).
+            reld_driver: target/release/ld.reld
           - runner: windows-2022
             target: x86_64-pc-windows-msvc
-            reld_pending: "reld bridge measurement pending (rustc-based); see #17"
+            # COFF format selection is made from argv[0], not Linux's ld.reld shim name.
+            reld_driver: target/release/reld-link.exe
           - runner: macos-14
             target: aarch64-apple-darwin
-            reld_pending: "reld bridge measurement pending (rustc-based); see #17"
+            # Mach-O format selection is also made from argv[0].
+            reld_driver: target/release/ld64.reld
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     steps:
@@ -58,13 +58,8 @@ jobs:
 
       - name: Install Windows linkers
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install llvm --no-progress --yes
-          "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { throw "clang missing" }
-          if (-not (Get-Command lld-link -ErrorAction SilentlyContinue)) { throw "lld-link missing" }
-          if (-not (Get-Command link.exe -ErrorAction SilentlyContinue)) { throw "link.exe missing" }
+        shell: bash
+        run: python -m ci.windows_ci install-benchmark-linkers
 
       - name: Install macOS linkers
         if: runner.os == 'macOS'
@@ -82,32 +77,51 @@ jobs:
           command -v clang
           command -v ld64.lld
 
-      - name: Build native reld shim
+      - name: Build Linux native reld shim
         if: runner.os == 'Linux'
         shell: bash
+        env:
+          CARGO_COMMAND: cargo
         run: |
           set -euo pipefail
-          cargo build --release -p reld
+          $CARGO_COMMAND build --release -p reld
           bash ci/install-driver-shims.sh release
+
+      - name: Build Windows COFF reld front door
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          CARGO_COMMAND: cargo
+        run: python -m ci.windows_ci build-benchmark-driver
+
+      - name: Build macOS Mach-O reld front door
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          CARGO_COMMAND: cargo
+        run: |
+          set -euo pipefail
+          $CARGO_COMMAND build --release -p reld --bin reld
+          bash ci/install-driver-shims.sh release
+          test -x target/release/ld64.reld
+          echo "Using Mach-O bridge driver: target/release/ld64.reld"
 
       - name: Run benchmark
         shell: bash
         env:
           TARGET: ${{ matrix.target }}
-          RELD_PENDING: ${{ matrix.reld_pending }}
+          RELD_DRIVER: ${{ matrix.reld_driver }}
+          CARGO_COMMAND: cargo
         run: |
           set -euo pipefail
           mkdir -p benchmark-output
-          if [ -n "${RELD_PENDING:-}" ]; then
-            # Render reld's documented, unsupported-by-design gap as `pending`, never silent n/a.
-            cargo run --release -p reld-testkit --bin reld-bench -- \
-              --target "$TARGET" --trials 5 --warmup 1 --reld-pending "$RELD_PENDING" \
-              > "benchmark-output/benchmark.log" 2>&1
-          else
-            cargo run --release -p reld-testkit --bin reld-bench -- \
-              --target "$TARGET" --trials 5 --warmup 1 \
-              > "benchmark-output/benchmark.log" 2>&1
-          fi
+          test -f "$RELD_DRIVER"
+          # The harness compiles generated workloads once before `time_link`; every warm-up and
+          # trial is link-only. `--reld` supplies the target-correct bridge front door, so bridge
+          # timing is real data rather than the former permanent pending marker.
+          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- \
+            --target "$TARGET" --trials 5 --warmup 1 --reld "$RELD_DRIVER" \
+            > "benchmark-output/benchmark.log" 2>&1
 
       - name: Assert benchmark coverage (no silent n/a for expected linkers)
         shell: bash
@@ -122,6 +136,18 @@ jobs:
           command -v "$PY" >/dev/null 2>&1 || PY=python
           "$PY" -m ci.benchmark_coverage \
             --input-log "benchmark-output/benchmark.log" --target "$TARGET"
+
+      - name: Report per-target timings and metadata
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f benchmark-output/benchmark.log
+          PY=python3
+          command -v "$PY" >/dev/null 2>&1 || PY=python
+          "$PY" -m ci.benchmark_stats \
+            --input-log benchmark-output/benchmark.log --summary-only \
+            --publish-outcome "raw benchmark artifact uploaded; aggregation pending"
 
       - name: Upload raw benchmark log
         if: always()
@@ -159,7 +185,7 @@ jobs:
           RELD_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/benchmark-stats
         run: |
           set -euo pipefail
-          targets=(x86_64-linux x86_64-pc-windows-msvc aarch64-apple-darwin)
+          mapfile -t targets < <(python -m ci.benchmark_stats --print-targets)
           for target in "${targets[@]}"; do
             mkdir -p "benchmark-stats/$target"
             curl --fail --silent --location --max-time 30 \
@@ -171,6 +197,15 @@ jobs:
               --output-dir "benchmark-stats/$target"
           done
 
+      - name: Assert generated README block and artifact freshness
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ci.benchmark_stats --check-readme README.md
+          python -m ci.benchmark_stats \
+            --verify-current-outputs benchmark-stats --expected-sha "$GITHUB_SHA" \
+            --max-age-seconds 7200
+
       - name: Upload per-target benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -180,6 +215,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish benchmark-stats branch
+        id: publish
         if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -196,3 +232,57 @@ jobs:
           git -C "$publish_dir" remote add origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git -C "$publish_dir" push --force origin benchmark-stats
+
+      - name: Report benchmark publication outcome
+        if: always()
+        shell: bash
+        env:
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          IS_DEFAULT_BRANCH: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_DEFAULT_BRANCH" = "true" ]; then
+            outcome="${PUBLISH_OUTCOME:-not-run}"
+            destination="https://github.com/${GITHUB_REPOSITORY}/tree/benchmark-stats"
+          else
+            outcome="skipped (not default branch)"
+            destination="raw artifacts only"
+          fi
+          {
+            echo "### Benchmark publication"
+            echo
+            echo "| Field | Value |"
+            echo "|:------|:------|"
+            echo "| source SHA | ${GITHUB_SHA} |"
+            echo "| generated timestamp | $(date -u +%Y-%m-%dT%H:%M:%SZ) |"
+            echo "| publish outcome | ${outcome} |"
+            echo "| destination | ${destination} |"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # Deliberately follows the aggregate with always(): the check must report stale public charts
+  # even if a runner or aggregation failed, but waiting avoids racing a successful publish.
+  # Feature-branch dispatches skip it, so the currently stale public branch cannot block review
+  # validation before the default branch has had a chance to republish.
+  freshness:
+    name: Verify published benchmark freshness
+    needs: [benchmark, aggregate]
+    if: ${{ always() && (github.event_name == 'schedule' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Check published latest.json age and status
+        env:
+          RELD_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/benchmark-stats
+        run: |
+          set -euo pipefail
+          python -m ci.benchmark_stats \
+            --check-remote-freshness \
+            --remote-base-url "$RELD_BENCHMARK_RAW_BASE_URL" \
+            --expected-sha "$GITHUB_SHA" \
+            --max-age-seconds 129600

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -47,6 +47,11 @@ jobs:
         shell: bash
         run: uv sync --extra dev
 
+      - if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        with:
+          toolset: "14.44"
+
       - uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Install Linux linkers

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -125,16 +125,12 @@ jobs:
           TARGET: ${{ matrix.target }}
           RELD_DRIVER: ${{ matrix.reld_driver }}
           CARGO_COMMAND: cargo
-        run: |
-          set -euo pipefail
-          mkdir -p benchmark-output
-          test -f "$RELD_DRIVER"
-          # The harness compiles generated workloads once before `time_link`; every warm-up and
-          # trial is link-only. `--reld` supplies the target-correct bridge front door, so bridge
-          # timing is real data rather than the former permanent pending marker.
-          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- \
-            --target "$TARGET" --trials 5 --warmup 1 --reld "$RELD_DRIVER" \
-            > "benchmark-output/benchmark.log" 2>&1
+        # Python owns child-process resolution so Git Bash cannot shadow MSVC link.exe. The
+        # harness still compiles generated workloads once before timing link-only iterations.
+        run: >-
+          uv run --no-sync python -m ci.benchmark_runner
+          --target "$TARGET" --reld "$RELD_DRIVER"
+          --output benchmark-output/benchmark.log --trials 5 --warmup 1
 
       - name: Assert benchmark coverage (no silent n/a for expected linkers)
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,18 +213,8 @@ jobs:
 
       - name: Verify and smoke Windows MSVC reference linkers
         if: matrix.kind == 'windows-msvc'
-        shell: pwsh
-        run: |
-          (& link.exe 2>&1 | Select-Object -First 2) | Set-Content versions.txt
-          (& lld-link --version 2>&1 | Select-Object -First 1) | Add-Content versions.txt
-          $versions = Get-Content versions.txt -Raw
-          if (-not $versions.Contains($env:MSVC_LINK_VERSION)) { throw "link.exe version drift" }
-          if (-not $versions.Contains($env:LLD_VERSION)) { throw "lld-link version drift" }
-          'int main(void) { return 0; }' | Set-Content "$env:RUNNER_TEMP\smoke.c"
-          cl.exe /nologo "$env:RUNNER_TEMP\smoke.c" "/Fe:$env:RUNNER_TEMP\smoke-link.exe"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          clang-cl.exe /nologo -fuse-ld=lld "$env:RUNNER_TEMP\smoke.c" "/Fe:$env:RUNNER_TEMP\smoke-lld.exe"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        shell: bash
+        run: python -m ci.windows_ci verify-msvc-linkers
 
       - name: Install macOS LLVM reference linker
         if: matrix.kind == 'macos-arm64'
@@ -342,76 +332,35 @@ jobs:
 
       - name: Windows MSVC native tests
         if: matrix.kind == 'windows-msvc'
-        shell: pwsh
-        run: |
-          & $env:CARGO_COMMAND build --workspace --all-targets
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & $env:CARGO_COMMAND test -p reld-layout-schema -p reld-diff -p reld-testkit --all-targets 2>&1 | Tee-Object platform-tests.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & $env:CARGO_COMMAND test -p reld-core --lib 2>&1 | Tee-Object -Append platform-tests.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & $env:CARGO_COMMAND test -p reld --bins 2>&1 | Tee-Object -Append platform-tests.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & $env:CARGO_COMMAND test -p reld --test acceptance-policy 2>&1 | Tee-Object -Append platform-tests.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & $env:CARGO_COMMAND test -p reld --test acceptance -- --list 2>&1 | Tee-Object -Append platform-tests.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        shell: bash
+        run: python -m ci.windows_ci native-tests
 
       - name: Windows MSVC reld bridge e2e (sqlite)
         if: matrix.kind == 'windows-msvc'
-        shell: pwsh
-        run: |
-          $reld = "$env:GITHUB_WORKSPACE\target\debug\reld-link.exe"
-          if (-not (Test-Path $reld)) { throw "reld-link.exe not found at $reld" }
-          $env:CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = $reld
-          Push-Location "$env:GITHUB_WORKSPACE\ci\e2e\sqlite-bridge"
-          try {
-            $output = & $env:CARGO_COMMAND run --quiet --bin app 2>&1 | Out-String
-          } finally {
-            Pop-Location
-          }
-          Write-Output $output
-          if ($LASTEXITCODE -ne 0) { throw "sqlite-bridge e2e exited with code $LASTEXITCODE" }
-          if ($output -notmatch "OK") { throw "sqlite-bridge e2e output did not contain OK marker" }
-          if ($output -notmatch "linked SQLite") { throw "sqlite-bridge e2e output did not contain 'linked SQLite' marker" }
+        shell: bash
+        run: python -m ci.windows_ci sqlite-bridge
 
       - name: Windows MSVC reld-bench smoke
         if: matrix.kind == 'windows-msvc'
-        shell: pwsh
-        run: |
-          # reld has no shim on this leg, so it is pending-by-design (bridge measurement pending,
-          # #17). Pass --reld-pending so it renders an explicit `pending` rather than a silent
-          # n/a (#63).
-          & $env:CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker lld --trials 2 --warmup 1 --reld-pending "reld bridge measurement pending (rustc-based); see #17" | Tee-Object benchmark-windows-msvc.md
-          if ($LASTEXITCODE -ne 0) { throw "reld-bench exited with code $LASTEXITCODE" }
-          if (-not (Test-Path benchmark-windows-msvc.md)) { throw "benchmark-windows-msvc.md not produced" }
-          $table = Get-Content benchmark-windows-msvc.md -Raw
-          if (-not ($table | Select-String -Pattern '## Link Benchmark:' -Quiet)) { throw "benchmark table missing '## Link Benchmark:' heading" }
-          if (-not ($table | Select-String -Pattern '\| *reld *\|' -Quiet)) { throw "benchmark table missing reld column" }
-          # reld must be explicitly pending here, never a bare n/a (#63).
-          if (-not ($table | Select-String -Pattern 'pending' -Quiet)) { throw "reld must render 'pending', not a silent n/a" }
+        # Python owns the Windows path handling, process checks, response-file replay fixture,
+        # and benchmark assertions; Bash is only the portable Actions entry point.
+        shell: bash
+        run: python -m ci.windows_ci benchmark-smoke
 
       - name: Upload Windows MSVC benchmark artifact
         if: always() && matrix.kind == 'windows-msvc'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-windows-msvc
-          path: benchmark-windows-msvc.md
+          path: |
+            benchmark-windows-msvc.md
+            benchmark-windows-msvc-replay.md
           if-no-files-found: warn
 
       - name: Windows MSVC self-host (link reld with reld-link)
         if: matrix.kind == 'windows-msvc'
-        shell: pwsh
-        run: |
-          $reld = "$env:GITHUB_WORKSPACE\target\debug\reld-link.exe"
-          if (-not (Test-Path $reld)) { throw "reld-link.exe not found at $reld" }
-          $env:CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = $reld
-          & $env:CARGO_COMMAND build -p reld --bin reld
-          if ($LASTEXITCODE -ne 0) { throw "self-host build (link reld with reld-link) failed" }
-          $out = & "$env:GITHUB_WORKSPACE\target\debug\reld.exe" --version 2>&1 | Out-String
-          if ($LASTEXITCODE -ne 0) { throw "self-linked reld --version failed (exit $LASTEXITCODE)" }
-          Write-Output $out
-          if ($out -notmatch 'Reld') { throw "self-linked reld --version output missing 'Reld' marker" }
+        shell: bash
+        run: python -m ci.windows_ci self-host
 
       - name: macOS native tests
         if: matrix.kind == 'macos-arm64'
@@ -451,19 +400,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Exercise ld64.lld specifically: it was silently n/a because clang maps
-          # -fuse-ld=ld64.lld to a nonexistent ld.ld64.lld (#60). This asserts it now links.
-          # reld has no shim here, so it is pending-by-design (#17): --reld-pending renders an
-          # explicit `pending` instead of a silent n/a (#63).
-          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- --cc clang --linker ld64.lld --trials 2 --warmup 1 --reld-pending "reld bridge measurement pending (rustc-based); see #17" | tee benchmark-macos-arm64.md
+          # `ld64.reld` is the Mach-O bridge front door (format selected by argv[0]), created
+          # from the built reld binary. Generated objects are compiled before timing; warmups and
+          # trials only link them.
+          $CARGO_COMMAND build -p reld --bin reld
+          bash ci/install-driver-shims.sh debug
+          reld="$GITHUB_WORKSPACE/target/debug/ld64.reld"
+          test -x "$reld"
+          workdir="$RUNNER_TEMP/reld-bench-macos"
+          rm -rf "$workdir"
+          $CARGO_COMMAND run --release -p reld-testkit --bin reld-bench -- \
+            --cc clang --target aarch64-apple-darwin --trials 2 --warmup 1 \
+            --reld "$reld" --workdir "$workdir" | tee benchmark-macos-arm64.md
           grep -q '## Link Benchmark:' benchmark-macos-arm64.md || { echo "benchmark table missing '## Link Benchmark:' heading" >&2; exit 1; }
+          grep -qE '\| *ld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing ld column" >&2; exit 1; }
           grep -qE '\| *ld64.lld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing ld64.lld column" >&2; exit 1; }
           grep -qE '\| *reld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing reld column" >&2; exit 1; }
-          # ld64.lld is the only linker requested (reld has no shim here), so a real timing proves
-          # it actually linked rather than reporting n/a.
-          grep -qE '[0-9]+\.[0-9]{4}' benchmark-macos-arm64.md || { echo "ld64.lld produced no timing (still n/a?)" >&2; exit 1; }
-          # reld must be explicitly pending here, never a bare n/a (#63).
-          grep -q 'pending' benchmark-macos-arm64.md || { echo "reld must render 'pending', not a silent n/a" >&2; exit 1; }
+          grep -qE '^\| (small \(16 units\)|medium \(128 units\)|large \(512 units\)) \| [0-9]+\.[0-9]{4} \| [0-9]+\.[0-9]{4} \| [0-9]+\.[0-9]{4} \|$' benchmark-macos-arm64.md || { echo "macOS benchmark produced no complete measured rows" >&2; exit 1; }
+          python3 -m ci.benchmark_coverage --input-log benchmark-macos-arm64.md --target aarch64-apple-darwin
 
       - name: macOS self-host (link reld with reld)
         if: matrix.kind == 'macos-arm64'
@@ -494,26 +448,41 @@ jobs:
       - name: Publish Linux counts and skips
         if: always() && matrix.kind == 'linux-gnu'
         shell: bash
+        env:
+          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
           python ci/phase1_summary.py --job linux-gnu
           --log platform-tests.log --log acceptance-tests.log --log difftest.log
           --log external-tests.log --versions versions.txt --minimum-run 507
           --exact-log-total difftest.log=100 --exact-log-total external-tests.log=407
+          --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
       - name: Publish Windows GNU counts and skips
         if: always() && matrix.kind == 'windows-gnu'
-        shell: pwsh
-        run: python ci/phase1_summary.py --job windows-gnu --log platform-tests.log --versions versions.txt
+        shell: bash
+        env:
+          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
+        run: >-
+          python ci/phase1_summary.py --job windows-gnu --log platform-tests.log --versions versions.txt
+          --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
       - name: Publish Windows MSVC counts and skips
         if: always() && matrix.kind == 'windows-msvc'
-        shell: pwsh
-        run: python ci/phase1_summary.py --job windows-msvc --log platform-tests.log --versions versions.txt
+        shell: bash
+        env:
+          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
+        run: >-
+          python ci/phase1_summary.py --job windows-msvc --log platform-tests.log --versions versions.txt
+          --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
       - name: Publish macOS counts and skips
         if: always() && matrix.kind == 'macos-arm64'
         shell: bash
-        run: python3 ci/phase1_summary.py --job macos-arm64 --log platform-tests.log --versions versions.txt
+        env:
+          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
+        run: >-
+          python3 ci/phase1_summary.py --job macos-arm64 --log platform-tests.log --versions versions.txt
+          --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
   python:
     name: Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     name: Phase 1 / ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
+    env:
+      PHASE1_UPSTREAM_FAILED: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -454,11 +456,14 @@ jobs:
           path: benchmark-macos-arm64.md
           if-no-files-found: warn
 
+      - name: Record an earlier phase failure for the summary
+        if: failure()
+        shell: bash
+        run: printf 'PHASE1_UPSTREAM_FAILED=true\n' >> "${GITHUB_ENV}"
+
       - name: Publish Linux counts and skips
         if: always() && matrix.kind == 'linux-gnu'
         shell: bash
-        env:
-          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
           uv run --no-sync python ci/phase1_summary.py --job linux-gnu
           --log platform-tests.log --log acceptance-tests.log --log difftest.log
@@ -469,8 +474,6 @@ jobs:
       - name: Publish Windows GNU counts and skips
         if: always() && matrix.kind == 'windows-gnu'
         shell: bash
-        env:
-          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
           uv run --no-sync python ci/phase1_summary.py --job windows-gnu --log platform-tests.log --versions versions.txt
           --upstream-failed "$PHASE1_UPSTREAM_FAILED"
@@ -478,8 +481,6 @@ jobs:
       - name: Publish Windows MSVC counts and skips
         if: always() && matrix.kind == 'windows-msvc'
         shell: bash
-        env:
-          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
           uv run --no-sync python ci/phase1_summary.py --job windows-msvc --log platform-tests.log --versions versions.txt
           --upstream-failed "$PHASE1_UPSTREAM_FAILED"
@@ -487,8 +488,6 @@ jobs:
       - name: Publish macOS counts and skips
         if: always() && matrix.kind == 'macos-arm64'
         shell: bash
-        env:
-          PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
           uv run --no-sync python ci/phase1_summary.py --job macos-arm64 --log platform-tests.log --versions versions.txt
           --upstream-failed "$PHASE1_UPSTREAM_FAILED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
+
       - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           components: rustfmt, clippy
@@ -75,6 +76,14 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+
+      - name: Sync Python tooling
+        shell: bash
+        run: uv sync --extra dev
 
       - if: matrix.kind == 'windows-gnu'
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
@@ -160,7 +169,7 @@ jobs:
           # Cache-gated: no-op for artifacts already restored above; download +
           # verify only on a miss. Installs the cached libtinfo5 .deb, symlinks
           # clang-22/clang++-22, and appends the cache bin dir to GITHUB_PATH.
-          python3 ci/linker_setup.py \
+          uv run --no-sync python ci/linker_setup.py \
             --cache-dir "${RUNNER_TEMP}/reld-linker-cache" \
             --install-debs \
             --link-clang
@@ -214,7 +223,7 @@ jobs:
       - name: Verify and smoke Windows MSVC reference linkers
         if: matrix.kind == 'windows-msvc'
         shell: bash
-        run: python -m ci.windows_ci verify-msvc-linkers
+        run: uv run --no-sync python -m ci.windows_ci verify-msvc-linkers
 
       - name: Install macOS LLVM reference linker
         if: matrix.kind == 'macos-arm64'
@@ -333,19 +342,19 @@ jobs:
       - name: Windows MSVC native tests
         if: matrix.kind == 'windows-msvc'
         shell: bash
-        run: python -m ci.windows_ci native-tests
+        run: uv run --no-sync python -m ci.windows_ci native-tests
 
       - name: Windows MSVC reld bridge e2e (sqlite)
         if: matrix.kind == 'windows-msvc'
         shell: bash
-        run: python -m ci.windows_ci sqlite-bridge
+        run: uv run --no-sync python -m ci.windows_ci sqlite-bridge
 
       - name: Windows MSVC reld-bench smoke
         if: matrix.kind == 'windows-msvc'
         # Python owns the Windows path handling, process checks, response-file replay fixture,
         # and benchmark assertions; Bash is only the portable Actions entry point.
         shell: bash
-        run: python -m ci.windows_ci benchmark-smoke
+        run: uv run --no-sync python -m ci.windows_ci benchmark-smoke
 
       - name: Upload Windows MSVC benchmark artifact
         if: always() && matrix.kind == 'windows-msvc'
@@ -360,7 +369,7 @@ jobs:
       - name: Windows MSVC self-host (link reld with reld-link)
         if: matrix.kind == 'windows-msvc'
         shell: bash
-        run: python -m ci.windows_ci self-host
+        run: uv run --no-sync python -m ci.windows_ci self-host
 
       - name: macOS native tests
         if: matrix.kind == 'macos-arm64'
@@ -417,7 +426,7 @@ jobs:
           grep -qE '\| *ld64.lld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing ld64.lld column" >&2; exit 1; }
           grep -qE '\| *reld *\|' benchmark-macos-arm64.md || { echo "benchmark table missing reld column" >&2; exit 1; }
           grep -qE '^\| (small \(16 units\)|medium \(128 units\)|large \(512 units\)) \| [0-9]+\.[0-9]{4} \| [0-9]+\.[0-9]{4} \| [0-9]+\.[0-9]{4} \|$' benchmark-macos-arm64.md || { echo "macOS benchmark produced no complete measured rows" >&2; exit 1; }
-          python3 -m ci.benchmark_coverage --input-log benchmark-macos-arm64.md --target aarch64-apple-darwin
+          uv run --no-sync python -m ci.benchmark_coverage --input-log benchmark-macos-arm64.md --target aarch64-apple-darwin
 
       - name: macOS self-host (link reld with reld)
         if: matrix.kind == 'macos-arm64'
@@ -451,7 +460,7 @@ jobs:
         env:
           PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
-          python ci/phase1_summary.py --job linux-gnu
+          uv run --no-sync python ci/phase1_summary.py --job linux-gnu
           --log platform-tests.log --log acceptance-tests.log --log difftest.log
           --log external-tests.log --versions versions.txt --minimum-run 507
           --exact-log-total difftest.log=100 --exact-log-total external-tests.log=407
@@ -463,7 +472,7 @@ jobs:
         env:
           PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
-          python ci/phase1_summary.py --job windows-gnu --log platform-tests.log --versions versions.txt
+          uv run --no-sync python ci/phase1_summary.py --job windows-gnu --log platform-tests.log --versions versions.txt
           --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
       - name: Publish Windows MSVC counts and skips
@@ -472,7 +481,7 @@ jobs:
         env:
           PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
-          python ci/phase1_summary.py --job windows-msvc --log platform-tests.log --versions versions.txt
+          uv run --no-sync python ci/phase1_summary.py --job windows-msvc --log platform-tests.log --versions versions.txt
           --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
       - name: Publish macOS counts and skips
@@ -481,7 +490,7 @@ jobs:
         env:
           PHASE1_UPSTREAM_FAILED: ${{ failure() }}
         run: >-
-          python3 ci/phase1_summary.py --job macos-arm64 --log platform-tests.log --versions versions.txt
+          uv run --no-sync python ci/phase1_summary.py --job macos-arm64 --log platform-tests.log --versions versions.txt
           --upstream-failed "$PHASE1_UPSTREAM_FAILED"
 
   python:
@@ -493,8 +502,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - run: python -m pip install --quiet pillow pytest
-      - run: python -m pytest ci/tests -q
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+      - run: uv sync --extra dev
+        shell: bash
+      - run: uv run --no-sync python -m pytest ci/tests -q
+        shell: bash
 
   # Release cross-compilation on cheap, plentiful Linux runners. Building the
   # Windows target from Linux exploits parallel Linux capacity for the compile +

--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ means concretely, and what part of it is shipped vs. designed.
 *Auto-generated nightly by [`benchmark-stats.yml`](.github/workflows/benchmark-stats.yml) and
 published to the [`benchmark-stats` branch](https://github.com/zackees/reld/tree/benchmark-stats),
 with independent `latest.json` and `history.jsonl` per target. Linux measures reld's native
-engine; Windows and macOS mark reld **`pending`** (unsupported-by-design in this clang-based
-harness) until the rustc-based bridge measurement lands — an explicit, documented state that
-`latest.json` and the charts render distinctly from a failed `n/a`. Each platform gates its
-**expected** linkers in CI (Linux `bfd`/`lld`/`mold`/`wild`/`reld`, Windows `link.exe`/`lld`,
-macOS `ld`/`ld64.lld`): a missing timing for an expected linker fails the build, so coverage can
-never silently understate itself (see [#63](https://github.com/zackees/reld/issues/63)). Every
-chart labels reference, native, and bridge series modes in its generated metadata.*
+engine; Windows and macOS measure reld through their target-correct `lld` **bridge** front doors.
+`latest.json` records both the series `mode` (`native` or `bridge`) and concrete `engine` (`reld`
+on Linux, `lld-link` on Windows, `ld64.lld` on macOS), and the charts label bridge results so they
+are never presented as native COFF/Mach-O throughput. Each platform gates its **expected** linkers
+in CI (Linux `bfd`/`lld`/`mold`/`wild`/`reld`, Windows `link.exe`/`lld`/`reld`, macOS
+`ld`/`ld64.lld`/`reld`): a missing timing or a missing/duplicate/unexpected synthetic scenario
+fails the build, so coverage can never silently understate itself (see
+[#63](https://github.com/zackees/reld/issues/63)). The generated artifact freshness guard also
+requires every published chart to name the source SHA and current generation time.*
 <!-- BENCHMARK:END -->
 
 ## What it is

--- a/ci/benchmark_coverage.py
+++ b/ci/benchmark_coverage.py
@@ -29,24 +29,24 @@ import os
 import sys
 from pathlib import Path
 
-from ci.benchmark_stats import Report, parse_benchmark_log, target_os
+from ci.benchmark_stats import (
+    CANONICAL_SCENARIOS,
+    EXPECTED_SERIES,
+    Report,
+    parse_benchmark_log,
+    target_os,
+)
 
-# Linkers that MUST produce a real timing on each platform. reld is expected on Linux (native
-# engine) but *pending* elsewhere until the bridge measurement lands — see PENDING_LINKERS.
+# Linkers that MUST produce a real timing on each platform. reld is native on Linux and measured
+# through its target-correct lld bridge front door on Windows/macOS. A bridge result is still a
+# real result: leaving it pending would let the published chart hide a supported product path.
 EXPECTED_LINKERS: dict[str, list[str]] = {
-    "x86_64-linux": ["bfd", "lld", "mold", "wild", "reld"],
-    "x86_64-pc-windows-msvc": ["link.exe", "lld"],
-    "aarch64-apple-darwin": ["ld", "ld64.lld"],
+    target: list(series) for target, series in EXPECTED_SERIES.items()
 }
 
-# Series that are unsupported-by-design (documented) on a platform, with the reason. They must
-# render as ``pending`` rather than a bare ``n/a``. Ties to the bridge status in the README and
-# issue #17.
-_RELD_BRIDGE_PENDING = "reld bridge measurement pending (rustc-based); see #17"
-PENDING_LINKERS: dict[str, dict[str, str]] = {
-    "x86_64-pc-windows-msvc": {"reld": _RELD_BRIDGE_PENDING},
-    "aarch64-apple-darwin": {"reld": _RELD_BRIDGE_PENDING},
-}
+# Retained as a distinct policy mechanism for future documented, intentionally unsupported
+# series. There are deliberately no permanent benchmark gaps after the bridge measurement slice.
+PENDING_LINKERS: dict[str, dict[str, str]] = {}
 
 # Fallback so an unrecognized/short target label still resolves to a policy via its OS.
 _OS_TO_TARGET = {
@@ -88,7 +88,9 @@ class CoverageResult:
         return not self.violations
 
 
-def check_coverage(report: Report, target: str) -> CoverageResult:
+def check_coverage(
+    report: Report, target: str, *, require_canonical_scenarios: bool = True
+) -> CoverageResult:
     result = CoverageResult(target)
     expected = expected_for(target)
     pending = pending_for(target)
@@ -98,6 +100,29 @@ def check_coverage(report: Report, target: str) -> CoverageResult:
             ("<policy>", f"no coverage policy defined for target {target!r}")
         )
         return result
+
+    # The charts are a public synthetic benchmark, so their scenario matrix is part of the
+    # contract. Report.scenarios() intentionally de-duplicates for rendering; inspect one
+    # complete column instead so a repeated markdown row cannot quietly collapse into one bar.
+    if not report.series:
+        result.violations.append(("<scenarios>", "benchmark table has no linker series"))
+    elif require_canonical_scenarios:
+        scenario_rows = [r.scenario for r in report.rows if r.series == report.series[0]]
+        duplicates = sorted({s for s in scenario_rows if scenario_rows.count(s) > 1})
+        missing_scenarios = [s for s in CANONICAL_SCENARIOS if s not in scenario_rows]
+        unexpected = sorted(set(scenario_rows) - set(CANONICAL_SCENARIOS))
+        if duplicates:
+            result.violations.append(
+                ("<scenarios>", f"duplicate synthetic scenario(s): {', '.join(duplicates)}")
+            )
+        if missing_scenarios:
+            result.violations.append(
+                ("<scenarios>", f"missing synthetic scenario(s): {', '.join(missing_scenarios)}")
+            )
+        if unexpected:
+            result.violations.append(
+                ("<scenarios>", f"unexpected synthetic scenario(s): {', '.join(unexpected)}")
+            )
 
     for linker in expected:
         status = report.series_status(linker)
@@ -184,6 +209,14 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="benchmark target label (e.g. x86_64-linux); falls back to the log heading",
     )
+    p.add_argument(
+        "--allow-noncanonical-scenarios",
+        action="store_true",
+        help=(
+            "check linker coverage for a focused smoke/replay table without requiring the "
+            "public small/medium/large scenario manifest"
+        ),
+    )
     args = p.parse_args(argv)
 
     report = parse_benchmark_log(args.input_log.read_text(encoding="utf-8"))
@@ -193,7 +226,11 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write("no --target given and no benchmark heading found in the log\n")
         return 1
 
-    result = check_coverage(report, target)
+    result = check_coverage(
+        report,
+        target,
+        require_canonical_scenarios=not args.allow_noncanonical_scenarios,
+    )
     summary = render_summary(report, result)
     print(summary)
     if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -1,0 +1,82 @@
+"""Run the native benchmark with platform-safe linker process resolution."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def benchmark_command(
+    *, target: str, reld: Path, trials: int, warmup: int, cargo: str
+) -> list[str]:
+    if not cargo or any(character.isspace() for character in cargo):
+        raise ValueError("CARGO_COMMAND must name one executable")
+    return [
+        cargo,
+        "run",
+        "--release",
+        "-p",
+        "reld-testkit",
+        "--bin",
+        "reld-bench",
+        "--",
+        "--target",
+        target,
+        "--trials",
+        str(trials),
+        "--warmup",
+        str(warmup),
+        "--reld",
+        str(reld),
+    ]
+
+
+def benchmark_environment() -> dict[str, str]:
+    if sys.platform == "win32":
+        # Imported only on the platform that owns the MSVC environment contract.
+        from ci.windows_ci import _msvc_path_env
+
+        return _msvc_path_env()
+    return os.environ.copy()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--reld", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument("--warmup", type=int, default=1)
+    args = parser.parse_args(argv)
+
+    if not args.reld.is_file():
+        parser.error(f"reld driver not found: {args.reld}")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    command = benchmark_command(
+        target=args.target,
+        reld=args.reld,
+        trials=args.trials,
+        warmup=args.warmup,
+        cargo=os.environ.get("CARGO_COMMAND", "cargo"),
+    )
+    with args.output.open("w", encoding="utf-8", newline="") as output:
+        completed = subprocess.run(
+            command,
+            check=False,
+            env=benchmark_environment(),
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    if completed.returncode:
+        sys.stderr.write(args.output.read_text(encoding="utf-8", errors="replace"))
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -20,6 +20,7 @@ running a real benchmark.
 from __future__ import annotations
 
 import argparse
+import calendar
 import json
 import os
 import platform
@@ -27,13 +28,39 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.request import urlopen
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 HISTORY_MAX_LINES = 1000
 IMAGE_NAME = "benchmark-link.jpg"
 HEADING_PREFIX = "## Link Benchmark:"
+
+# One canonical manifest for the README, workflow aggregation, and generated artifacts. Keeping
+# this in the renderer makes a target added to one consumer but not another a testable drift,
+# rather than a quietly stale README panel.
+BENCHMARK_TARGETS = (
+    ("x86_64-linux", "Linux"),
+    ("x86_64-pc-windows-msvc", "Windows"),
+    ("aarch64-apple-darwin", "macOS"),
+)
+
+# The public synthetic workload is deliberately stable. Missing, duplicate, or renamed rows are
+# incomparable to history and must never reach the published branch.
+CANONICAL_SCENARIOS = (
+    "small (16 units)",
+    "medium (128 units)",
+    "large (512 units)",
+)
+
+# Shared public-artifact contract for the coverage gate and remote freshness watchdog.
+EXPECTED_SERIES = {
+    "x86_64-linux": ("bfd", "lld", "mold", "wild", "reld"),
+    "x86_64-pc-windows-msvc": ("link.exe", "lld", "reld"),
+    "aarch64-apple-darwin": ("ld", "ld64.lld", "reld"),
+}
 
 # Rendered at SCALE x then downsampled; cheap supersampling beats fighting PIL's aliasing.
 WIDTH = 900
@@ -155,7 +182,7 @@ def parse_benchmark_log(text: str) -> Report:
         line = raw.strip().lstrip("﻿")
 
         if line.startswith(HEADING_PREFIX):
-            report.label = line[len(HEADING_PREFIX):].strip()
+            report.label = line[len(HEADING_PREFIX) :].strip()
             in_table = True
             header = []
             continue
@@ -183,9 +210,7 @@ def parse_benchmark_log(text: str) -> Report:
             continue
         for idx, series in enumerate(report.series, start=1):
             value, pending = _classify(cells[idx]) if idx < len(cells) else (None, False)
-            report.rows.append(
-                Row(scenario=scenario, series=series, seconds=value, pending=pending)
-            )
+            report.rows.append(Row(scenario=scenario, series=series, seconds=value, pending=pending))
 
     return report
 
@@ -210,6 +235,34 @@ def series_mode(series: str, runner_os: str, target: str = "") -> str:
         effective_os = target_os(target) or runner_os
         return "native" if effective_os == "Linux" else "bridge"
     return "reference"
+
+
+def series_engine(series: str, runner_os: str, target: str = "") -> str:
+    """Concrete linker engine behind a series.
+
+    `reld` is a native ELF engine on Linux and deliberately routes its COFF/Mach-O front doors
+    to lld.  Persisting this beside ``mode`` prevents a bridge measurement from being mistaken
+    for native COFF/Mach-O throughput by a JSON or chart consumer.
+    """
+    if series != "reld":
+        return series
+    if series_mode(series, runner_os, target) == "native":
+        return "reld"
+    effective_os = target_os(target) or runner_os
+    if effective_os == "Windows":
+        return "lld-link"
+    if effective_os == "Darwin":
+        return "ld64.lld"
+    return "lld"
+
+
+def series_label(series: str, runner_os: str, target: str = "") -> str:
+    """Human-facing series label that makes reld's execution mode visible in charts."""
+    if series != "reld":
+        return series
+    mode = series_mode(series, runner_os, target)
+    engine = series_engine(series, runner_os, target)
+    return f"reld ({mode}/{engine})"
 
 
 def _tool_version(cmd: list[str]) -> str | None:
@@ -253,6 +306,206 @@ def collect_metadata(report: Report) -> dict[str, Any]:
     }
 
 
+def render_summary(report: Report, meta: dict[str, Any], publish_outcome: str = "rendered") -> str:
+    """Render the concise, per-target Actions/log report required to diagnose publication.
+
+    It intentionally derives statuses from every scenario, not only a series-level success: an
+    expected linker with one missing timing remains visibly incomplete before coverage rejects it.
+    """
+    scenarios = report.scenarios()
+    headings = " | ".join(scenarios) if scenarios else "(none parsed)"
+    lines = [
+        f"### Benchmark report: {meta.get('target') or report.label or 'unknown'}",
+        "",
+        "| Field | Value |",
+        "|:------|:------|",
+        f"| source SHA | {meta.get('git_sha') or 'local/unset'} |",
+        f"| generated at | {meta.get('generated_at') or 'unknown'} |",
+        f"| publish outcome | {publish_outcome} |",
+        "",
+        f"Timings by scenario: {headings}",
+        "",
+        "| Series | Mode | Engine | Status | Timings (seconds) |",
+        "|:-------|:-----|:-------|:-------|:------------------|",
+    ]
+    runner_os = meta.get("runner", {}).get("os", "")
+    target = meta.get("target", report.label)
+    for series in report.series:
+        cells: list[str] = []
+        rows = [r for r in report.rows if r.series == series]
+        for row in rows:
+            if row.seconds is not None:
+                cells.append(f"{row.scenario}: {row.seconds:.4f}")
+            else:
+                cells.append(f"{row.scenario}: {'pending' if row.pending else 'n/a'}")
+        lines.append(f"| {series} | {series_mode(series, runner_os, target)} | {series_engine(series, runner_os, target)} | {report.series_status(series)} | {' ; '.join(cells) or 'n/a'} |")
+    return "\n".join(lines) + "\n"
+
+
+def render_readme_block() -> str:
+    """Generate the entire README benchmark region, not merely its image panels."""
+    panels = []
+    for target, title in BENCHMARK_TARGETS:
+        panels.append(
+            f'<p align="center"><b>{target}</b><br>\n'
+            f'<a href="https://github.com/zackees/reld/tree/benchmark-stats/{target}"><img '
+            f'alt="{title} reld link benchmark" '
+            f'src="https://raw.githubusercontent.com/zackees/reld/benchmark-stats/{target}/'
+            f'benchmark-link.jpg" width="100%"></a></p>'
+        )
+    prose = (
+        "*Auto-generated nightly by [`benchmark-stats.yml`](.github/workflows/benchmark-stats.yml) and\n"
+        "published to the [`benchmark-stats` branch](https://github.com/zackees/reld/tree/benchmark-stats),\n"
+        "with independent `latest.json` and `history.jsonl` per target. Linux measures reld's native\n"
+        "engine; Windows and macOS measure reld through their target-correct `lld` **bridge** front doors.\n"
+        "`latest.json` records both the series `mode` (`native` or `bridge`) and concrete `engine` (`reld`\n"
+        "on Linux, `lld-link` on Windows, `ld64.lld` on macOS), and the charts label bridge results so they\n"
+        "are never presented as native COFF/Mach-O throughput. Each platform gates its **expected** linkers\n"
+        "in CI (Linux `bfd`/`lld`/`mold`/`wild`/`reld`, Windows `link.exe`/`lld`/`reld`, macOS\n"
+        "`ld`/`ld64.lld`/`reld`): a missing timing or a missing/duplicate/unexpected synthetic scenario\n"
+        "fails the build, so coverage can never silently understate itself (see\n"
+        "[#63](https://github.com/zackees/reld/issues/63)). The generated artifact freshness guard also\n"
+        "requires every published chart to name the source SHA and current generation time.*"
+    )
+    return "\n\n".join([*panels, prose]) + "\n"
+
+
+def check_readme_block(path: Path) -> bool:
+    """Return whether README's generated benchmark section exactly matches the manifest."""
+    text = path.read_text(encoding="utf-8")
+    begin = "<!-- BENCHMARK:BEGIN -->"
+    end = "<!-- BENCHMARK:END -->"
+    if text.count(begin) != 1 or text.count(end) != 1:
+        return False
+    actual = text.split(begin, 1)[1].split(end, 1)[0].strip()
+    return actual == render_readme_block().strip()
+
+
+def write_readme_block(path: Path) -> None:
+    """Replace exactly the marker-delimited README section with canonical contents."""
+    text = path.read_text(encoding="utf-8")
+    begin = "<!-- BENCHMARK:BEGIN -->"
+    end = "<!-- BENCHMARK:END -->"
+    if text.count(begin) != 1 or text.count(end) != 1:
+        raise ValueError("README must contain exactly one BENCHMARK:BEGIN and BENCHMARK:END marker")
+    before, remainder = text.split(begin, 1)
+    _, after = remainder.split(end, 1)
+    path.write_text(f"{before}{begin}\n{render_readme_block()}{end}{after}", encoding="utf-8")
+
+
+def verify_current_outputs(out_root: Path, expected_sha: str, max_age_seconds: int) -> list[str]:
+    """Validate local generated artifacts before they are force-published.
+
+    A successful force-push of this tree therefore cannot publish a chart from a different source
+    SHA or an accidentally reused, stale renderer directory.
+    """
+    errors: list[str] = []
+    now = time.time()
+    for target, _ in BENCHMARK_TARGETS:
+        latest = out_root / target / "latest.json"
+        if not latest.is_file():
+            errors.append(f"{target}: latest.json is missing")
+            continue
+        try:
+            payload = json.loads(latest.read_text(encoding="utf-8"))
+            meta = payload["metadata"]
+            stamp = time.strptime(meta["generated_at"], "%Y-%m-%dT%H:%M:%SZ")
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            errors.append(f"{target}: invalid latest.json metadata ({error})")
+            continue
+        if meta.get("target") != target:
+            errors.append(f"{target}: metadata target is {meta.get('target')!r}")
+        if expected_sha and meta.get("git_sha") != expected_sha:
+            errors.append(f"{target}: source SHA {meta.get('git_sha')!r} != {expected_sha!r}")
+        age = now - calendar.timegm(stamp)
+        if age < -300 or age > max_age_seconds:
+            errors.append(f"{target}: generated timestamp is {age:.0f}s old (limit {max_age_seconds}s)")
+    return errors
+
+
+def _parse_timestamp(value: object) -> float:
+    if not isinstance(value, str):
+        raise ValueError("generated_at is absent or not a string")
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    with urlopen(url, timeout=30) as response:  # nosec B310: explicit workflow/test input
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("JSON root is not an object")
+    return payload
+
+
+def verify_remote_freshness(
+    base_url: str,
+    max_age_seconds: int,
+    *,
+    expected_sha: str = "",
+    fetch_json: Any = _fetch_json,
+    now: float | None = None,
+) -> list[str]:
+    """Validate every public ``latest.json`` without depending on the aggregate job.
+
+    Both the base URL and fetcher are injectable to make the watchdog unit-testable against local
+    fixture data. This job intentionally has no dependency on benchmark/aggregate, so a failed
+    nightly benchmark cannot conceal an old or incomplete public branch.
+    """
+    errors: list[str] = []
+    checked_at = time.time() if now is None else now
+    root = base_url.rstrip("/")
+    for target, _ in BENCHMARK_TARGETS:
+        url = f"{root}/{target}/latest.json"
+        try:
+            payload = fetch_json(url)
+            if payload.get("schema_version") != SCHEMA_VERSION:
+                errors.append(f"{target}: schema version {payload.get('schema_version')!r} != {SCHEMA_VERSION}")
+            meta = payload["metadata"]
+            if not isinstance(meta, dict):
+                raise ValueError("metadata is not an object")
+            age = checked_at - _parse_timestamp(meta.get("generated_at"))
+            if age < -300 or age > max_age_seconds:
+                errors.append(f"{target}: latest.json is {age:.0f}s old (limit {max_age_seconds}s)")
+            if meta.get("target") != target:
+                errors.append(f"{target}: metadata target is {meta.get('target')!r}")
+            if expected_sha and meta.get("git_sha") != expected_sha:
+                errors.append(f"{target}: source SHA {meta.get('git_sha')!r} != {expected_sha!r}")
+            results = payload.get("results")
+            if not isinstance(results, list):
+                errors.append(f"{target}: results is missing or not a list")
+                continue
+            cells: dict[tuple[str, str], dict[str, Any]] = {}
+            for result in results:
+                if not isinstance(result, dict):
+                    errors.append(f"{target}: result entry is not an object")
+                    continue
+                key = (str(result.get("scenario", "")), str(result.get("series", "")))
+                if key in cells:
+                    errors.append(f"{target}: duplicate result for {key[0]!r}/{key[1]!r}")
+                cells[key] = result
+            actual_scenarios = {scenario for scenario, _ in cells}
+            unexpected = sorted(actual_scenarios - set(CANONICAL_SCENARIOS))
+            if unexpected:
+                errors.append(f"{target}: unexpected synthetic scenario(s): {', '.join(unexpected)}")
+            for series in EXPECTED_SERIES[target]:
+                for scenario in CANONICAL_SCENARIOS:
+                    cell = cells.get((scenario, series))
+                    if cell is None:
+                        errors.append(f"{target}: {series} missing {scenario}")
+                    elif cell.get("status") != "measured" or cell.get("seconds") is None:
+                        errors.append(f"{target}: {series} {scenario} is not measured")
+                    else:
+                        expected_mode = series_mode(series, "", target)
+                        expected_engine = series_engine(series, "", target)
+                        if cell.get("mode") != expected_mode:
+                            errors.append(f"{target}: {series} {scenario} mode {cell.get('mode')!r} != {expected_mode!r}")
+                        if cell.get("engine") != expected_engine:
+                            errors.append(f"{target}: {series} {scenario} engine {cell.get('engine')!r} != {expected_engine!r}")
+        except Exception as error:  # malformed/unreachable remote artifacts are freshness failures
+            errors.append(f"{target}: cannot validate {url}: {error}")
+    return errors
+
+
 def _font(size: int):
     from PIL import ImageFont
 
@@ -294,7 +547,7 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
     d.rectangle([0, 0, WIDTH * SCALE, header_h * SCALE], fill=PANEL)
     d.text((20 * SCALE, 16 * SCALE), "reld - link benchmark", font=f_title, fill=FG)
     sha = (meta.get("git_sha") or "")[:12]
-    sub = f"{meta['generated_at']}  |  {meta.get('target','')}  |  {meta['runner']['platform']}"
+    sub = f"{meta['generated_at']}  |  {meta.get('target', '')}  |  {meta['runner']['platform']}"
     if sha:
         sub += f"  |  sha {sha}"
     d.text((20 * SCALE, 46 * SCALE), sub, font=f_meta, fill=MUTED)
@@ -314,7 +567,12 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
 
         for s, v in zip(series, values):
             color = SERIES_COLORS.get(s, FALLBACK_COLOR)
-            d.text((34 * SCALE, (y + 5) * SCALE), s, font=f_meta, fill=MUTED)
+            d.text(
+                (34 * SCALE, (y + 5) * SCALE),
+                series_label(s, meta["runner"]["os"], meta.get("target", "")),
+                font=f_meta,
+                fill=MUTED,
+            )
 
             if v is None:
                 pending = report.is_pending(scenario, s)
@@ -345,8 +603,7 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
 
     d.text(
         (20 * SCALE, (height - 24) * SCALE),
-        "lower is better  |  median of N trials, link step only  |  "
-        "n/a = linker failed/unavailable  |  pending = unsupported-by-design (documented)",
+        "lower is better  |  median of N trials, link step only  |  n/a = linker failed/unavailable  |  pending = unsupported-by-design (documented)",
         font=f_meta,
         fill=MUTED,
     )
@@ -356,7 +613,9 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
 
 
 def render_html(report: Report, meta: dict[str, Any]) -> str:
-    head = "".join(f"<th>{s}</th>" for s in report.series)
+    runner_os = meta.get("runner", {}).get("os", "")
+    target = meta.get("target", "")
+    head = "".join(f"<th>{series_label(s, runner_os, target)}</th>" for s in report.series)
     body = ""
     for sc in report.scenarios():
         cells = ""
@@ -378,10 +637,10 @@ th:first-child,td:first-child{{text-align:left}}img{{max-width:100%}}a{{color:#5
 td.na{{color:#7d8590}}td.pending{{color:#bb8009}}
 </style></head><body>
 <h1>reld &mdash; link benchmark</h1>
-<p>{meta['generated_at']} &middot; {meta.get('target','')} &middot; {meta['runner']['platform']}</p>
+<p>{meta["generated_at"]} &middot; {meta.get("target", "")} &middot; {meta["runner"]["platform"]}</p>
 <img src="{IMAGE_NAME}" alt="benchmark chart">
 <table><thead><tr><th>Scenario</th>{head}</tr></thead><tbody>{body}</tbody></table>
-<p><a href="https://github.com/{meta['repository']}">{meta['repository']}</a></p>
+<p><a href="https://github.com/{meta["repository"]}">{meta["repository"]}</a></p>
 </body></html>
 """
 
@@ -407,6 +666,7 @@ def write_outputs(report: Report, meta: dict[str, Any], out_dir: Path) -> None:
                 # regression. See issue #63.
                 "status": r.status(),
                 "mode": series_mode(r.series, runner_os, meta.get("target", "")),
+                "engine": series_engine(r.series, runner_os, meta.get("target", "")),
             }
             for r in report.rows
         ],
@@ -436,10 +696,110 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(prog="ci.benchmark_stats")
     p.add_argument("--output-dir", type=Path, default=Path("benchmark-stats"))
     p.add_argument("--log-path", type=Path)
-    src = p.add_mutually_exclusive_group(required=True)
+    p.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="parse and print the per-target report without rendering artifacts",
+    )
+    p.add_argument(
+        "--publish-outcome",
+        default=os.environ.get("RELD_BENCHMARK_PUBLISH_OUTCOME", "rendered; publication pending"),
+        help="outcome shown in the log/Actions summary report",
+    )
+    p.add_argument(
+        "--print-targets",
+        action="store_true",
+        help="print the canonical target labels, one per line",
+    )
+    p.add_argument(
+        "--check-readme",
+        type=Path,
+        help="fail unless README's BENCHMARK block matches the canonical target manifest",
+    )
+    p.add_argument(
+        "--write-readme",
+        type=Path,
+        help="replace README's marker-delimited BENCHMARK block with canonical generated contents",
+    )
+    p.add_argument(
+        "--verify-current-outputs",
+        type=Path,
+        metavar="ROOT",
+        help="verify generated per-target latest.json files match --expected-sha and freshness",
+    )
+    p.add_argument("--expected-sha", default=os.environ.get("GITHUB_SHA", ""))
+    p.add_argument("--max-age-seconds", type=int, default=2 * 60 * 60)
+    p.add_argument(
+        "--check-remote-freshness",
+        action="store_true",
+        help="check published per-target latest.json age and measured status",
+    )
+    p.add_argument(
+        "--remote-base-url",
+        default=os.environ.get(
+            "RELD_BENCHMARK_RAW_BASE_URL",
+            "https://raw.githubusercontent.com/zackees/reld/benchmark-stats",
+        ),
+        help="base URL containing <target>/latest.json (injectable for local tests)",
+    )
+    src = p.add_mutually_exclusive_group()
     src.add_argument("--run-benchmarks", action="store_true")
     src.add_argument("--input-log", type=Path)
     args = p.parse_args(argv)
+
+    # These maintenance operations deliberately need no benchmark input. Keep them in this
+    # module so every workflow consumer draws target identity from one source of truth.
+    if args.print_targets:
+        print("\n".join(target for target, _ in BENCHMARK_TARGETS))
+        return 0
+    if args.check_readme:
+        if not check_readme_block(args.check_readme):
+            sys.stderr.write(f"{args.check_readme}: BENCHMARK block drifted from ci.benchmark_stats manifest\n")
+            return 1
+        print(f"{args.check_readme}: generated BENCHMARK block matches target manifest")
+        return 0
+    if args.write_readme:
+        try:
+            write_readme_block(args.write_readme)
+        except ValueError as error:
+            sys.stderr.write(f"{args.write_readme}: {error}\n")
+            return 1
+        print(f"{args.write_readme}: wrote canonical generated BENCHMARK block")
+        return 0
+    if args.verify_current_outputs:
+        errors = verify_current_outputs(args.verify_current_outputs, args.expected_sha, args.max_age_seconds)
+        if errors:
+            sys.stderr.write("benchmark artifact freshness check failed:\n")
+            sys.stderr.write("\n".join(f"- {error}" for error in errors) + "\n")
+            return 1
+        print(f"benchmark artifacts are current for {args.expected_sha or 'local/unset SHA'} (max age {args.max_age_seconds}s)")
+        return 0
+    if args.check_remote_freshness:
+        errors = verify_remote_freshness(
+            args.remote_base_url,
+            args.max_age_seconds,
+            expected_sha=args.expected_sha,
+        )
+        lines = [
+            "### Published benchmark freshness",
+            "",
+            "| Field | Value |",
+            "|:------|:------|",
+            f"| base URL | {args.remote_base_url} |",
+            f"| maximum age | {args.max_age_seconds}s |",
+            f"| status | {'current' if not errors else 'stale or incomplete'} |",
+        ]
+        if errors:
+            lines.extend(["", "**Freshness check failed:**", *[f"- {error}" for error in errors]])
+        summary = "\n".join(lines) + "\n"
+        print(summary)
+        if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+            with Path(summary_path).open("a", encoding="utf-8") as handle:
+                handle.write(summary)
+        return 1 if errors else 0
+
+    if not args.run_benchmarks and args.input_log is None:
+        p.error("one of --run-benchmarks or --input-log is required")
 
     if args.run_benchmarks:
         cmd = ["cargo", "run", "--release", "--bin", "reld-bench", "--"]
@@ -455,8 +815,22 @@ def main(argv: list[str] | None = None) -> int:
         text = args.input_log.read_text(encoding="utf-8")
 
     report = parse_benchmark_log(text)
-    write_outputs(report, collect_metadata(report), args.output_dir)
+    meta = collect_metadata(report)
+    if args.summary_only:
+        summary = render_summary(report, meta, args.publish_outcome)
+        print(summary)
+        if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+            with Path(summary_path).open("a", encoding="utf-8") as handle:
+                handle.write(summary)
+        return 0
+
+    write_outputs(report, meta, args.output_dir)
     print(f"wrote {args.output_dir}")
+    summary = render_summary(report, meta, args.publish_outcome)
+    print(summary)
+    if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(summary)
     return 0
 
 

--- a/ci/phase1_summary.py
+++ b/ci/phase1_summary.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import re
 from pathlib import Path
+from typing import Sequence
 
 
 RUST_RESULT = re.compile(
@@ -27,12 +28,18 @@ def counts(text: str) -> tuple[int, int]:
     return run, skipped
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--job", required=True)
     parser.add_argument("--log", action="append", type=Path, required=True)
     parser.add_argument("--versions", type=Path, required=True)
     parser.add_argument("--minimum-run", type=int, default=1)
+    parser.add_argument(
+        "--upstream-failed",
+        choices=("true", "false"),
+        default="false",
+        help=("allow logs omitted by an earlier failed job step; successful paths must pass false"),
+    )
     parser.add_argument(
         "--exact-log-total",
         action="append",
@@ -40,7 +47,8 @@ def main() -> int:
         metavar="PATH=COUNT",
         help="require passed plus failed plus ignored in the named log to equal COUNT",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+    upstream_failed = args.upstream_failed == "true"
 
     exact_totals: dict[Path, int] = {}
     for spec in args.exact_log_total:
@@ -50,30 +58,38 @@ def main() -> int:
         exact_totals[Path(path)] = int(value)
 
     run = skipped = 0
+    missing_logs: list[Path] = []
     for log in args.log:
+        if not log.is_file():
+            if not upstream_failed:
+                raise SystemExit(f"{args.job}: missing expected test log: {log}")
+            missing_logs.append(log)
+            continue
         current_run, current_skipped = counts(log.read_text(encoding="utf-8", errors="replace"))
         if log in exact_totals:
             actual = current_run + current_skipped
             expected = exact_totals.pop(log)
-            if actual != expected:
-                raise SystemExit(
-                    f"{args.job}: {log} registered {actual} tests; expected exactly {expected}"
-                )
+            if actual != expected and not upstream_failed:
+                raise SystemExit(f"{args.job}: {log} registered {actual} tests; expected exactly {expected}")
         run += current_run
         skipped += current_skipped
-    if exact_totals:
+    if exact_totals and not upstream_failed:
         missing = ", ".join(map(str, exact_totals))
         raise SystemExit(f"{args.job}: exact-total logs were not supplied via --log: {missing}")
-    if run < args.minimum_run:
+    if run < args.minimum_run and not upstream_failed:
         raise SystemExit(f"{args.job}: only {run} tests ran; expected at least {args.minimum_run}")
 
-    versions = args.versions.read_text(encoding="utf-8", errors="replace").strip()
-    summary = (
-        f"### Phase 1: {args.job}\n\n"
-        "| Tests run | Tests skipped |\n|---:|---:|\n"
-        f"| {run} | {skipped} |\n\n"
-        f"Pinned reference versions:\n\n```text\n{versions}\n```\n"
-    )
+    if args.versions.is_file():
+        versions = args.versions.read_text(encoding="utf-8", errors="replace").strip()
+    elif upstream_failed:
+        versions = f"unavailable: {args.versions} was not produced"
+    else:
+        raise SystemExit(f"{args.job}: missing expected versions file: {args.versions}")
+    status = " (incomplete: an earlier step failed)" if upstream_failed else ""
+    missing_note = ""
+    if missing_logs:
+        missing_note = f"\nMissing downstream logs: {', '.join(map(str, missing_logs))}\n"
+    summary = f"### Phase 1: {args.job}{status}\n\n| Tests run | Tests skipped |\n|---:|---:|\n| {run} | {skipped} |\n{missing_note}\nPinned reference versions:\n\n```text\n{versions}\n```\n"
     print(summary)
     if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
         with Path(summary_path).open("a", encoding="utf-8") as handle:

--- a/ci/tests/test_benchmark_coverage.py
+++ b/ci/tests/test_benchmark_coverage.py
@@ -1,9 +1,8 @@
 """Per-platform benchmark-coverage gate tests (issue #63).
 
 These are the RED -> GREEN gate: a benchmark where an *expected* linker silently reports ``n/a``
-must fail the check, and a benchmark where reld is *explicitly pending* on Windows/macOS must
-pass. The same log that a pre-#63 pipeline published happily (expected linker as bare ``n/a``) is
-now rejected here.
+must fail the check. Windows/macOS reld now have target-correct bridge front doors, so their
+bridge timing is expected just like every other published series.
 """
 
 from __future__ import annotations
@@ -28,6 +27,7 @@ LINUX_FULL = """
 | Scenario | bfd | lld | mold | wild | reld |
 |:---------|----:|----:|-----:|-----:|----:|
 | small (16 units) | 0.0210 | 0.0081 | 0.0062 | 0.0044 | 0.0216 |
+| medium (128 units) | 0.1400 | 0.0390 | 0.0221 | 0.0155 | 0.0800 |
 | large (512 units) | 0.6120 | 0.1602 | 0.0904 | 0.0631 | 0.2100 |
 """
 
@@ -37,29 +37,34 @@ LINUX_RELD_NA = LINUX_FULL.replace("| 0.0216 |", "| n/a |").replace("| 0.2100 |"
 # Another silent gap: wild (expected on Linux) drops to n/a.
 LINUX_WILD_NA = LINUX_FULL.replace("| 0.0044 |", "| n/a |").replace("| 0.0631 |", "| n/a |")
 
-MACOS_RELD_PENDING = """
+MACOS_FULL = """
 ## Link Benchmark: aarch64-apple-darwin
 
 | Scenario | ld | ld64.lld | reld |
 |:---------|---:|---------:|----:|
-| small (16 units) | 0.0300 | 0.0120 | pending |
-| large (512 units) | 0.6000 | 0.1600 | pending |
+| small (16 units) | 0.0300 | 0.0120 | 0.0130 |
+| medium (128 units) | 0.1500 | 0.0400 | 0.0500 |
+| large (512 units) | 0.6000 | 0.1600 | 0.1700 |
 """
 
-# reld on macOS as a bare n/a — it must be explicitly pending, not silently n/a.
-MACOS_RELD_NA = MACOS_RELD_PENDING.replace("| pending |", "| n/a |")
+# reld on macOS as a bare n/a — a supported bridge cannot be silently missing.
+MACOS_RELD_NA = MACOS_FULL.replace("| 0.0130 |", "| n/a |").replace(
+    "| 0.1700 |", "| n/a |"
+)
 
 # macOS with ld64.lld silently n/a — the #60 regression the gate must catch.
-MACOS_LD64_NA = MACOS_RELD_PENDING.replace("| 0.0120 |", "| n/a |").replace(
+MACOS_LD64_NA = MACOS_FULL.replace("| 0.0120 |", "| n/a |").replace(
     "| 0.1600 |", "| n/a |"
 )
 
-WINDOWS_OK = """
+WINDOWS_FULL = """
 ## Link Benchmark: x86_64-pc-windows-msvc
 
 | Scenario | link.exe | lld | reld |
 |:---------|---------:|----:|----:|
-| small (16 units) | 0.0500 | 0.0200 | pending |
+| small (16 units) | 0.0500 | 0.0200 | 0.0230 |
+| medium (128 units) | 0.1500 | 0.0700 | 0.0800 |
+| large (512 units) | 0.5000 | 0.2000 | 0.2200 |
 """
 
 
@@ -69,12 +74,11 @@ def _check(log: str, target: str):
 
 def test_policy_matches_issue_63_expected_sets():
     assert expected_for("x86_64-linux") == ["bfd", "lld", "mold", "wild", "reld"]
-    assert expected_for("x86_64-pc-windows-msvc") == ["link.exe", "lld"]
-    assert expected_for("aarch64-apple-darwin") == ["ld", "ld64.lld"]
-    # reld is pending-by-design on Windows/macOS, not on Linux.
-    assert "reld" in pending_for("x86_64-pc-windows-msvc")
-    assert "reld" in pending_for("aarch64-apple-darwin")
+    assert expected_for("x86_64-pc-windows-msvc") == ["link.exe", "lld", "reld"]
+    assert expected_for("aarch64-apple-darwin") == ["ld", "ld64.lld", "reld"]
     assert pending_for("x86_64-linux") == {}
+    assert pending_for("x86_64-pc-windows-msvc") == {}
+    assert pending_for("aarch64-apple-darwin") == {}
 
 
 def test_full_linux_coverage_passes():
@@ -106,6 +110,31 @@ def test_partial_scenario_na_for_expected_linker_fails_the_gate():
     assert violation is not None and "large (512 units)" in violation
 
 
+def test_synthetic_scenarios_must_be_canonical_complete_and_unique():
+    missing = _check(LINUX_FULL.replace("| medium (128 units) | 0.1400 | 0.0390 | 0.0221 | 0.0155 | 0.0800 |\n", ""), "x86_64-linux")
+    duplicate = _check(LINUX_FULL.replace("| large (512 units)", "| medium (128 units)"), "x86_64-linux")
+    unexpected = _check(LINUX_FULL.replace("small (16 units)", "tiny (1 unit)"), "x86_64-linux")
+    assert any("missing synthetic scenario" in reason for _, reason in missing.violations)
+    assert any("duplicate synthetic scenario" in reason for _, reason in duplicate.violations)
+    assert any("unexpected synthetic scenario" in reason for _, reason in unexpected.violations)
+
+
+def test_focused_replay_can_gate_every_linker_without_public_scenario_manifest():
+    replay = WINDOWS_FULL.replace("small (16 units)", "large replay (512 units)")
+    replay = "\n".join(
+        line
+        for line in replay.splitlines()
+        if "medium (128 units)" not in line and "large (512 units)" not in line
+    )
+    report = parse_benchmark_log(replay)
+    result = check_coverage(
+        report,
+        "x86_64-pc-windows-msvc",
+        require_canonical_scenarios=False,
+    )
+    assert result.ok, result.violations
+
+
 def test_render_summary_is_ascii_only():
     # Printed to stdout on the Windows CI leg (cp1252, redirected) — non-ASCII would crash it.
     report = parse_benchmark_log(LINUX_RELD_NA)
@@ -120,21 +149,20 @@ def test_macos_ld64_na_fails_the_gate():
     assert any(linker == "ld64.lld" for linker, _ in result.violations)
 
 
-def test_reld_pending_on_macos_passes():
-    result = _check(MACOS_RELD_PENDING, "aarch64-apple-darwin")
+def test_reld_bridge_on_macos_is_required_and_passes_when_measured():
+    result = _check(MACOS_FULL, "aarch64-apple-darwin")
     assert result.ok, result.violations
-    assert result.statuses["reld"] == "pending"
+    assert result.statuses["reld"] == "measured"
 
 
 def test_reld_bare_na_on_macos_fails():
-    # reld must be *explicitly* pending on macOS; a bare n/a is the silent gap #63 forbids.
     result = _check(MACOS_RELD_NA, "aarch64-apple-darwin")
     assert not result.ok
     assert any(linker == "reld" for linker, _ in result.violations)
 
 
-def test_windows_pending_reld_passes():
-    result = _check(WINDOWS_OK, "x86_64-pc-windows-msvc")
+def test_windows_reld_bridge_is_required_and_passes_when_measured():
+    result = _check(WINDOWS_FULL, "x86_64-pc-windows-msvc")
     assert result.ok, result.violations
 
 
@@ -145,13 +173,13 @@ def test_target_resolves_via_os_when_label_is_short():
 
 
 def test_render_summary_lists_roles_and_status():
-    report = parse_benchmark_log(MACOS_RELD_PENDING)
+    report = parse_benchmark_log(MACOS_FULL)
     result = check_coverage(report, "aarch64-apple-darwin")
     summary = render_summary(report, result)
     assert "Benchmark coverage: aarch64-apple-darwin" in summary
     assert "ld64.lld" in summary and "expected" in summary
-    assert "pending-by-design" in summary
-    assert "pending" in summary
+    assert "reld" in summary and "expected" in summary
+    assert "measured" in summary
 
 
 def test_main_exits_nonzero_on_silent_na(tmp_path):

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from ci.benchmark_runner import benchmark_command, benchmark_environment
+
+
+def test_benchmark_command_runs_link_only_harness_with_reld_driver():
+    command = benchmark_command(
+        target="x86_64-pc-windows-msvc",
+        reld=Path("target/release/reld-link.exe"),
+        trials=5,
+        warmup=1,
+        cargo="cargo",
+    )
+
+    assert command[:8] == [
+        "cargo",
+        "run",
+        "--release",
+        "-p",
+        "reld-testkit",
+        "--bin",
+        "reld-bench",
+        "--",
+    ]
+    assert command[-8:] == [
+        "--target",
+        "x86_64-pc-windows-msvc",
+        "--trials",
+        "5",
+        "--warmup",
+        "1",
+        "--reld",
+        str(Path("target/release/reld-link.exe")),
+    ]
+
+
+def test_benchmark_command_rejects_shell_fragments():
+    with pytest.raises(ValueError, match="must name one executable"):
+        benchmark_command(
+            target="x86_64-linux",
+            reld=Path("target/release/ld.reld"),
+            trials=1,
+            warmup=0,
+            cargo="cargo --locked",
+        )
+
+
+def test_non_windows_benchmark_environment_is_inherited(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("ci.benchmark_runner.sys.platform", "linux")
+    monkeypatch.setenv("RELD_BENCHMARK_TEST", "present")
+
+    assert benchmark_environment()["RELD_BENCHMARK_TEST"] == "present"
+    assert benchmark_environment() is not os.environ

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -14,9 +14,20 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from ci.benchmark_stats import (  # noqa: E402
+    BENCHMARK_TARGETS,
+    CANONICAL_SCENARIOS,
+    EXPECTED_SERIES,
+    check_readme_block,
     collect_metadata,
     parse_benchmark_log,
+    render_readme_block,
+    render_summary,
+    series_engine,
+    series_label,
     series_mode,
+    verify_current_outputs,
+    verify_remote_freshness,
+    write_readme_block,
     write_outputs,
 )
 
@@ -84,10 +95,11 @@ def test_write_outputs_produces_all_artifacts(tmp_path):
         assert (tmp_path / name).exists(), name
 
     payload = json.loads((tmp_path / "latest.json").read_text())
-    assert payload["schema_version"] == 3
+    assert payload["schema_version"] == 4
     assert len(payload["results"]) == 15
     for entry in payload["results"]:
         assert "mode" in entry
+        assert "engine" in entry
         assert "status" in entry
         if entry["series"] in ("bfd", "lld"):
             assert entry["mode"] == "reference"
@@ -109,6 +121,120 @@ def test_series_mode_uses_target_when_rendering_on_aggregation_runner():
     assert series_mode("reld", "Linux", "x86_64-pc-windows-msvc") == "bridge"
     assert series_mode("reld", "Linux", "aarch64-apple-darwin") == "bridge"
     assert series_mode("reld", "Linux", "x86_64-linux") == "native"
+
+
+def test_reld_engine_and_labels_make_bridge_measurements_unambiguous():
+    assert series_engine("reld", "Linux", "x86_64-linux") == "reld"
+    assert series_engine("reld", "Linux", "x86_64-pc-windows-msvc") == "lld-link"
+    assert series_engine("reld", "Linux", "aarch64-apple-darwin") == "ld64.lld"
+    assert series_label("reld", "Linux", "aarch64-apple-darwin") == "reld (bridge/ld64.lld)"
+    assert series_label("lld", "Linux", "x86_64-linux") == "lld"
+
+
+def test_summary_includes_timings_metadata_and_publish_state(monkeypatch):
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    report = parse_benchmark_log(SAMPLE_LOG)
+    summary = render_summary(report, collect_metadata(report), "uploaded")
+    assert "source SHA | abc123" in summary
+    assert "publish outcome | uploaded" in summary
+    assert "Timings by scenario" in summary
+    assert "reld | native | reld | na" in summary
+
+
+def test_readme_block_is_generated_from_the_target_manifest(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "before\n<!-- BENCHMARK:BEGIN -->\n" + render_readme_block() + "<!-- BENCHMARK:END -->\nafter\n",
+        encoding="utf-8",
+    )
+    assert [target for target, _ in BENCHMARK_TARGETS] == [
+        "x86_64-linux",
+        "x86_64-pc-windows-msvc",
+        "aarch64-apple-darwin",
+    ]
+    assert check_readme_block(readme)
+    readme.write_text(readme.read_text(encoding="utf-8").replace("macOS", "mac os"), encoding="utf-8")
+    assert not check_readme_block(readme)
+    write_readme_block(readme)
+    assert check_readme_block(readme)
+    # Prose is generated too: an extra sentence is just as much drift as a missing panel.
+    readme.write_text(readme.read_text(encoding="utf-8").replace("current generation time", "old generation time"), encoding="utf-8")
+    assert not check_readme_block(readme)
+
+
+def test_freshness_guard_rejects_wrong_source_sha_and_accepts_current_outputs(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_SHA", "current")
+    for target, _ in BENCHMARK_TARGETS:
+        target_report = parse_benchmark_log(SAMPLE_LOG.replace("x86_64-linux", target))
+        write_outputs(target_report, collect_metadata(target_report), tmp_path / target)
+    assert verify_current_outputs(tmp_path, "current", 60) == []
+    errors = verify_current_outputs(tmp_path, "different", 60)
+    assert len(errors) == len(BENCHMARK_TARGETS)
+    assert all("source SHA" in error for error in errors)
+
+
+def test_remote_freshness_accepts_injectable_current_results_and_rejects_stale_or_pending(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_SHA", "current")
+    for target, _ in BENCHMARK_TARGETS:
+        series = EXPECTED_SERIES[target]
+        lines = [f"## Link Benchmark: {target}", "", "| Scenario | " + " | ".join(series) + " |"]
+        lines.append("|:---------|" + "|".join("---:" for _ in series) + "|")
+        lines.extend(f"| {scenario} | " + " | ".join("0.0200" for _ in series) + " |" for scenario in CANONICAL_SCENARIOS)
+        report = parse_benchmark_log("\n".join(lines))
+        write_outputs(report, collect_metadata(report), tmp_path / target)
+    now = __import__("time").time()
+
+    def fetch(url):
+        target = url.split("/")[-2]
+        return json.loads((tmp_path / target / "latest.json").read_text(encoding="utf-8"))
+
+    assert (
+        verify_remote_freshness(
+            "https://example.invalid/stats",
+            60,
+            expected_sha="current",
+            fetch_json=fetch,
+            now=now,
+        )
+        == []
+    )
+    stale = fetch("https://example.invalid/stats/x86_64-linux/latest.json")
+    stale["metadata"]["generated_at"] = "2000-01-01T00:00:00Z"
+
+    def stale_fetch(url):
+        return stale if "x86_64-linux" in url else fetch(url)
+
+    assert any("old" in error for error in verify_remote_freshness("local", 60, fetch_json=stale_fetch, now=now))
+    pending = fetch("https://example.invalid/stats/x86_64-linux/latest.json")
+    pending["results"][0]["status"] = "pending"
+    assert any("not measured" in error for error in verify_remote_freshness("local", 60, fetch_json=lambda url: pending if "x86_64-linux" in url else fetch(url), now=now))
+    unexpected = fetch("https://example.invalid/stats/x86_64-linux/latest.json")
+    unexpected["results"][0]["scenario"] = "tiny (1 unit)"
+    assert any("unexpected synthetic scenario" in error for error in verify_remote_freshness("local", 60, fetch_json=lambda url: unexpected if "x86_64-linux" in url else fetch(url), now=now))
+    wrong_sha = fetch("https://example.invalid/stats/x86_64-linux/latest.json")
+    wrong_sha["metadata"]["git_sha"] = "old"
+    assert any(
+        "source SHA" in error
+        for error in verify_remote_freshness(
+            "local",
+            60,
+            expected_sha="current",
+            fetch_json=lambda url: wrong_sha if "x86_64-linux" in url else fetch(url),
+            now=now,
+        )
+    )
+    wrong_engine = fetch("https://example.invalid/stats/x86_64-pc-windows-msvc/latest.json")
+    reld = next(result for result in wrong_engine["results"] if result["series"] == "reld")
+    reld["mode"] = "native"
+    reld["engine"] = "reld"
+    errors = verify_remote_freshness(
+        "local",
+        60,
+        fetch_json=lambda url: wrong_engine if "windows-msvc" in url else fetch(url),
+        now=now,
+    )
+    assert any("mode" in error for error in errors)
+    assert any("engine" in error for error in errors)
 
 
 def test_history_appends_and_caps(tmp_path):

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -38,6 +38,7 @@ def test_benchmark_workflow_gates_expected_linker_coverage():
     assert "powershell" not in text.lower()
     assert "uv run --no-sync python -m ci.windows_ci install-benchmark-linkers" in text
     assert "uv run --no-sync python -m ci.windows_ci build-benchmark-driver" in text
+    assert "ilammy/msvc-dev-cmd@" in text
 
 
 def test_benchmark_workflow_reports_and_guards_generated_artifacts():

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -36,8 +36,8 @@ def test_benchmark_workflow_gates_expected_linker_coverage():
     assert '--reld "$RELD_DRIVER"' in text
     assert "pwsh" not in text.lower()
     assert "powershell" not in text.lower()
-    assert "python -m ci.windows_ci install-benchmark-linkers" in text
-    assert "python -m ci.windows_ci build-benchmark-driver" in text
+    assert "uv run --no-sync python -m ci.windows_ci install-benchmark-linkers" in text
+    assert "uv run --no-sync python -m ci.windows_ci build-benchmark-driver" in text
 
 
 def test_benchmark_workflow_reports_and_guards_generated_artifacts():
@@ -62,3 +62,14 @@ def test_freshness_watchdog_runs_after_failures_only_on_schedule_or_default_bran
     assert "--check-remote-freshness" in text
     assert '--remote-base-url "$RELD_BENCHMARK_RAW_BASE_URL"' in text
     assert '--expected-sha "$GITHUB_SHA"' in text
+
+
+def test_benchmark_workflow_provisions_uv_and_has_no_bare_python_invocations():
+    text = WORKFLOW.read_text()
+
+    assert text.count("astral-sh/setup-uv@") == 3
+    assert text.count("uv sync --extra dev") == 3
+    assert "uv run --no-project" not in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        assert not stripped.startswith(("python ", "python3 "))

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -15,7 +15,7 @@ def test_benchmark_workflow_publishes_one_directory_per_target():
     assert "x86_64-pc-windows-msvc" in text
     assert "aarch64-apple-darwin" in text
     assert "needs: benchmark" in text
-    assert 'benchmark-stats/$target' in text
+    assert "benchmark-stats/$target" in text
     assert "github.event.repository.default_branch" in text
 
 
@@ -27,7 +27,38 @@ def test_benchmark_workflow_gates_expected_linker_coverage():
     assert "ci.benchmark_coverage" in text
     assert "Assert benchmark coverage" in text
 
-    # reld is pending-by-design on Windows/macOS, so those legs pass --reld-pending; Linux (where
-    # reld is expected/measured) must not.
-    assert "--reld-pending" in text
-    assert text.count("reld_pending:") == 2  # windows + macOS matrix entries only
+    # Every target supplies its own front door; no permanent pending bridge path may survive.
+    assert "--reld-pending" not in text
+    assert "reld_pending:" not in text
+    assert "reld_driver: target/release/ld.reld" in text
+    assert "reld_driver: target/release/reld-link.exe" in text
+    assert "reld_driver: target/release/ld64.reld" in text
+    assert '--reld "$RELD_DRIVER"' in text
+    assert "pwsh" not in text.lower()
+    assert "powershell" not in text.lower()
+    assert "python -m ci.windows_ci install-benchmark-linkers" in text
+    assert "python -m ci.windows_ci build-benchmark-driver" in text
+
+
+def test_benchmark_workflow_reports_and_guards_generated_artifacts():
+    text = WORKFLOW.read_text()
+
+    assert "Report per-target timings and metadata" in text
+    assert "--summary-only" in text
+    assert "--print-targets" in text
+    assert "--check-readme README.md" in text
+    assert "--verify-current-outputs benchmark-stats" in text
+    assert "Report benchmark publication outcome" in text
+    assert "GITHUB_STEP_SUMMARY" in text
+
+
+def test_freshness_watchdog_runs_after_failures_only_on_schedule_or_default_branch():
+    text = WORKFLOW.read_text()
+
+    assert "freshness:" in text
+    assert "needs: [benchmark, aggregate]" in text
+    assert "always()" in text
+    assert "github.event_name == 'schedule'" in text
+    assert "--check-remote-freshness" in text
+    assert '--remote-base-url "$RELD_BENCHMARK_RAW_BASE_URL"' in text
+    assert '--expected-sha "$GITHUB_SHA"' in text

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -38,6 +38,7 @@ def test_benchmark_workflow_gates_expected_linker_coverage():
     assert "powershell" not in text.lower()
     assert "uv run --no-sync python -m ci.windows_ci install-benchmark-linkers" in text
     assert "uv run --no-sync python -m ci.windows_ci build-benchmark-driver" in text
+    assert "uv run --no-sync python -m ci.benchmark_runner" in text
     assert "ilammy/msvc-dev-cmd@" in text
 
 

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -94,6 +94,10 @@ def test_phase1_summary_only_relaxes_missing_log_validation_after_failure():
     text = WORKFLOW.read_text()
 
     # The always() summary steps need GitHub's prior-step state explicitly: the summary script
-    # cannot infer whether an absent log was skipped because an earlier step failed.
-    assert text.count("PHASE1_UPSTREAM_FAILED: ${{ failure() }}") == 4
+    # cannot infer whether an absent log was skipped because an earlier step failed. Status
+    # functions are legal in a step `if`, not in a step `env` expression.
+    assert 'PHASE1_UPSTREAM_FAILED: "false"' in text
+    assert "if: failure()" in text
+    assert "PHASE1_UPSTREAM_FAILED=true" in text
+    assert "PHASE1_UPSTREAM_FAILED: ${{ failure() }}" not in text
     assert text.count("--upstream-failed") == 4

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -32,11 +32,57 @@ def test_ci_cross_compiles_release_on_linux():
     assert "CC_x86_64_pc_windows_gnu" in text
 
 
-def test_ci_marks_reld_pending_on_windows_and_macos_benchmarks():
+def test_ci_measures_target_correct_reld_drivers_in_windows_and_macos_benchmarks():
     text = WORKFLOW.read_text()
 
-    # reld has no shim on the Windows/macOS PR benchmark smokes, so it must render an explicit
-    # `pending` (with reason) rather than a silent n/a (#63). Both legs pass --reld-pending.
-    assert "--reld-pending" in text
-    # Both legs assert the pending marker actually appears in the table (windows + macOS).
-    assert text.count("reld must render 'pending'") == 2
+    # The PR smokes measure the real platform bridge drivers; there is no permanent pending
+    # marker once #17's Windows/macOS benchmark slice is present.
+    assert "--reld-pending" not in text
+    assert "python -m ci.windows_ci benchmark-smoke" in text
+    assert "target/debug/ld64.reld" in text
+    assert "bash ci/install-driver-shims.sh debug" in text
+    assert '--reld "$reld" --workdir "$workdir"' in text
+
+
+def test_ci_windows_benchmark_gates_generated_and_replayed_large_response_file_paths():
+    text = WORKFLOW.read_text()
+
+    # The generated 512-unit path produces the large frozen-object replay fixture. Both tables
+    # must prove link.exe, lld, and reld timed successfully, and both run the coverage gate.
+    assert "python -m ci.windows_ci benchmark-smoke" in text
+    assert "benchmark-windows-msvc.md" in text
+    assert "benchmark-windows-msvc-replay.md" in text
+
+
+def test_ci_uses_bash_to_invoke_python_for_every_windows_msvc_script():
+    text = WORKFLOW.read_text()
+
+    assert "pwsh" not in text.lower()
+    assert "powershell" not in text.lower()
+    assert "Tee-Object" not in text
+    assert "$env:" not in text
+    for command in (
+        "verify-msvc-linkers",
+        "native-tests",
+        "sqlite-bridge",
+        "benchmark-smoke",
+        "self-host",
+    ):
+        assert f"shell: bash\n        run: python -m ci.windows_ci {command}" in text
+
+
+def test_ci_macos_benchmark_requires_measured_rows_and_coverage():
+    text = WORKFLOW.read_text()
+
+    assert '"macOS benchmark produced no complete measured rows"' in text
+    assert "aarch64-apple-darwin" in text
+    assert "python3 -m ci.benchmark_coverage" in text
+
+
+def test_phase1_summary_only_relaxes_missing_log_validation_after_failure():
+    text = WORKFLOW.read_text()
+
+    # The always() summary steps need GitHub's prior-step state explicitly: the summary script
+    # cannot infer whether an absent log was skipped because an earlier step failed.
+    assert text.count("PHASE1_UPSTREAM_FAILED: ${{ failure() }}") == 4
+    assert text.count("--upstream-failed") == 4

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -13,7 +13,7 @@ def test_ci_caches_linux_reference_linkers():
     assert "key: linkers-${{ runner.os }}-mold${{ env.MOLD_VERSION }}" in text
 
     # The heavy download work is delegated to the Python cache-gated script.
-    assert "python3 ci/linker_setup.py" in text
+    assert "uv run --no-sync python ci/linker_setup.py" in text
     assert "--cache-dir" in text
     assert "--install-debs" in text
     assert "--link-clang" in text
@@ -38,7 +38,7 @@ def test_ci_measures_target_correct_reld_drivers_in_windows_and_macos_benchmarks
     # The PR smokes measure the real platform bridge drivers; there is no permanent pending
     # marker once #17's Windows/macOS benchmark slice is present.
     assert "--reld-pending" not in text
-    assert "python -m ci.windows_ci benchmark-smoke" in text
+    assert "uv run --no-sync python -m ci.windows_ci benchmark-smoke" in text
     assert "target/debug/ld64.reld" in text
     assert "bash ci/install-driver-shims.sh debug" in text
     assert '--reld "$reld" --workdir "$workdir"' in text
@@ -49,7 +49,7 @@ def test_ci_windows_benchmark_gates_generated_and_replayed_large_response_file_p
 
     # The generated 512-unit path produces the large frozen-object replay fixture. Both tables
     # must prove link.exe, lld, and reld timed successfully, and both run the coverage gate.
-    assert "python -m ci.windows_ci benchmark-smoke" in text
+    assert "uv run --no-sync python -m ci.windows_ci benchmark-smoke" in text
     assert "benchmark-windows-msvc.md" in text
     assert "benchmark-windows-msvc-replay.md" in text
 
@@ -68,7 +68,7 @@ def test_ci_uses_bash_to_invoke_python_for_every_windows_msvc_script():
         "benchmark-smoke",
         "self-host",
     ):
-        assert f"shell: bash\n        run: python -m ci.windows_ci {command}" in text
+        assert f"shell: bash\n        run: uv run --no-sync python -m ci.windows_ci {command}" in text
 
 
 def test_ci_macos_benchmark_requires_measured_rows_and_coverage():
@@ -76,7 +76,18 @@ def test_ci_macos_benchmark_requires_measured_rows_and_coverage():
 
     assert '"macOS benchmark produced no complete measured rows"' in text
     assert "aarch64-apple-darwin" in text
-    assert "python3 -m ci.benchmark_coverage" in text
+    assert "uv run --no-sync python -m ci.benchmark_coverage" in text
+
+
+def test_ci_provisions_uv_and_has_no_bare_python_script_invocations():
+    text = WORKFLOW.read_text()
+
+    assert text.count("astral-sh/setup-uv@") == 2
+    assert text.count("uv sync --extra dev") == 2
+    assert "uv run --no-project" not in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        assert not stripped.startswith(("python ", "python3 "))
 
 
 def test_phase1_summary_only_relaxes_missing_log_validation_after_failure():

--- a/ci/tests/test_phase1_summary.py
+++ b/ci/tests/test_phase1_summary.py
@@ -1,4 +1,9 @@
+from pathlib import Path
+
+import pytest
+
 from ci.phase1_summary import counts
+from ci.phase1_summary import main
 
 
 def test_counts_rust_and_mimic_results() -> None:
@@ -22,3 +27,93 @@ test result: \x1b[32mok\x1b[0m. 7 passed; 0 failed; 2 ignored; 0 measured; 0 fil
 test result: \x1b[31mFAILED\x1b[0m. 396 passed; 10 failed; 1 ignored; 0 measured; 0 filtered out
 """
     assert counts(text) == (413, 3)
+
+
+def test_successful_path_requires_each_expected_log(tmp_path: Path) -> None:
+    versions = tmp_path / "versions.txt"
+    versions.write_text("lld 18\n")
+
+    with pytest.raises(SystemExit, match="missing expected test log"):
+        main(
+            [
+                "--job",
+                "linux-gnu",
+                "--log",
+                str(tmp_path / "missing.log"),
+                "--versions",
+                str(versions),
+            ]
+        )
+
+
+def test_upstream_failure_allows_missing_downstream_logs(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    versions = tmp_path / "versions.txt"
+    versions.write_text("lld 18\n")
+    platform_log = tmp_path / "platform-tests.log"
+    platform_log.write_text("test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n")
+    missing_log = tmp_path / "acceptance-tests.log"
+
+    assert (
+        main(
+            [
+                "--job",
+                "linux-gnu",
+                "--log",
+                str(platform_log),
+                "--log",
+                str(missing_log),
+                "--versions",
+                str(versions),
+                "--minimum-run",
+                "100",
+                "--exact-log-total",
+                f"{missing_log}=100",
+                "--upstream-failed",
+                "true",
+            ]
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+    assert "incomplete: an earlier step failed" in output
+    assert f"Missing downstream logs: {missing_log}" in output
+
+
+def test_upstream_failure_allows_missing_versions_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    log = tmp_path / "platform-tests.log"
+    log.write_text("test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n")
+    versions = tmp_path / "versions.txt"
+
+    assert (
+        main(
+            [
+                "--job",
+                "windows-msvc",
+                "--log",
+                str(log),
+                "--versions",
+                str(versions),
+                "--upstream-failed",
+                "true",
+            ]
+        )
+        == 0
+    )
+    assert f"unavailable: {versions} was not produced" in capsys.readouterr().out
+
+
+def test_successful_path_requires_versions_file(tmp_path: Path) -> None:
+    log = tmp_path / "platform-tests.log"
+    log.write_text("test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n")
+
+    with pytest.raises(SystemExit, match="missing expected versions file"):
+        main(
+            [
+                "--job",
+                "windows-msvc",
+                "--log",
+                str(log),
+                "--versions",
+                str(tmp_path / "versions.txt"),
+            ]
+        )

--- a/ci/tests/test_windows_ci.py
+++ b/ci/tests/test_windows_ci.py
@@ -100,4 +100,6 @@ def test_msvc_linker_uses_visual_studio_tools_instead_of_path(
     monkeypatch.setenv("VCToolsInstallDir", str(tools))
 
     assert _msvc_linker() == expected
-    assert _msvc_path_env()["PATH"].split(os.pathsep)[0] == str(expected.parent)
+    env = _msvc_path_env()
+    assert env["PATH"].split(os.pathsep)[0] == str(expected.parent)
+    assert env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] == str(expected)

--- a/ci/tests/test_windows_ci.py
+++ b/ci/tests/test_windows_ci.py
@@ -1,10 +1,13 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
 
 from ci.windows_ci import (
     WindowsCiError,
+    _msvc_linker,
+    _msvc_path_env,
     freeze_large_corpus,
     require_generated_table,
     require_measured_row,
@@ -80,3 +83,21 @@ def test_freeze_large_corpus_refuses_to_reset_runner_temp(tmp_path: Path):
 
     with pytest.raises(WindowsCiError, match="refusing to reset"):
         freeze_large_corpus(generated, tmp_path, tmp_path)
+
+
+def test_msvc_linker_uses_visual_studio_tools_instead_of_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    tools = tmp_path / "MSVC" / "14.44"
+    expected = tools / "bin" / "HostX64" / "x64" / "link.exe"
+    expected.parent.mkdir(parents=True)
+    expected.write_bytes(b"msvc")
+
+    git_bin = tmp_path / "Git" / "usr" / "bin"
+    git_bin.mkdir(parents=True)
+    (git_bin / "link.exe").write_bytes(b"gnu")
+    monkeypatch.setenv("PATH", str(git_bin))
+    monkeypatch.setenv("VCToolsInstallDir", str(tools))
+
+    assert _msvc_linker() == expected
+    assert _msvc_path_env()["PATH"].split(os.pathsep)[0] == str(expected.parent)

--- a/ci/tests/test_windows_ci.py
+++ b/ci/tests/test_windows_ci.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from ci.windows_ci import (
+    WindowsCiError,
+    freeze_large_corpus,
+    require_generated_table,
+    require_measured_row,
+)
+
+
+def _table(row: str) -> str:
+    return "\n".join(
+        [
+            "## Link Benchmark: x86_64-pc-windows-msvc",
+            "",
+            "| Configuration | link.exe | lld | reld |",
+            "|:--------------|---------:|----:|-----:|",
+            row,
+            "",
+        ]
+    )
+
+
+def test_generated_table_requires_three_real_large_timings():
+    require_generated_table(_table("| large (512 units) | 1.0000 | 2.0000 | 3.0000 |"))
+
+    with pytest.raises(WindowsCiError, match="must contain real timings"):
+        require_generated_table(_table("| large (512 units) | 1.0000 | 2.0000 | n/a |"))
+
+
+def test_replay_row_accepts_crlf_but_rejects_pending():
+    require_measured_row(
+        "| large replay (512 units) | 1.0000 | 2.0000 | 3.0000 |\r\n",
+        "large replay (512 units)",
+    )
+
+    with pytest.raises(WindowsCiError, match="must contain real timings"):
+        require_measured_row(
+            "| large replay (512 units) | 1.0000 | 2.0000 | pending |\n",
+            "large replay (512 units)",
+        )
+
+
+def test_freeze_large_corpus_copies_exact_response_file_workload(tmp_path: Path):
+    generated = tmp_path / "generated"
+    large = generated / "large"
+    large.mkdir(parents=True)
+    for index in range(513):
+        (large / f"object-{index:03}.o").write_bytes(str(index).encode())
+
+    corpus = tmp_path / "corpus"
+    manifest_path = freeze_large_corpus(generated, corpus, tmp_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["configuration"] == "large replay (512 units)"
+    assert manifest["expected_exit_code"] == 0
+    assert len(manifest["objects"]) == 513
+    assert len(list((corpus / "objs").glob("*.o"))) == 513
+
+
+def test_freeze_large_corpus_rejects_incomplete_workload(tmp_path: Path):
+    generated = tmp_path / "generated"
+    large = generated / "large"
+    large.mkdir(parents=True)
+    (large / "main.o").write_bytes(b"main")
+
+    with pytest.raises(WindowsCiError, match="expected 513"):
+        freeze_large_corpus(generated, tmp_path / "corpus", tmp_path)
+
+
+def test_freeze_large_corpus_refuses_to_reset_runner_temp(tmp_path: Path):
+    generated = tmp_path / "generated"
+    large = generated / "large"
+    large.mkdir(parents=True)
+    for index in range(513):
+        (large / f"object-{index:03}.o").write_bytes(b"object")
+
+    with pytest.raises(WindowsCiError, match="refusing to reset"):
+        freeze_large_corpus(generated, tmp_path, tmp_path)

--- a/ci/windows_ci.py
+++ b/ci/windows_ci.py
@@ -135,8 +135,23 @@ def _capture_allow_failure(args: Sequence[str]) -> str:
     return completed.stdout
 
 
+def _msvc_linker() -> Path:
+    """Resolve MSVC's linker without colliding with Git Bash's GNU ``link.exe``."""
+
+    tools = Path(_required_env("VCToolsInstallDir"))
+    return _require_file(tools / "bin" / "HostX64" / "x64" / "link.exe", "MSVC link.exe")
+
+
+def _msvc_path_env() -> dict[str, str]:
+    env = os.environ.copy()
+    linker_dir = str(_msvc_linker().parent)
+    inherited = env.get("PATH")
+    env["PATH"] = os.pathsep.join((linker_dir, inherited)) if inherited else linker_dir
+    return env
+
+
 def verify_msvc_linkers() -> None:
-    link_output = _capture_allow_failure(["link.exe"])
+    link_output = _capture_allow_failure([str(_msvc_linker())])
     lld_output = _run(["lld-link", "--version"])
     expected_msvc = _required_env("MSVC_LINK_VERSION")
     expected_lld = _required_env("LLD_VERSION")
@@ -169,11 +184,13 @@ def install_benchmark_linkers() -> None:
     llvm_bin = program_files / "LLVM" / "bin"
     _require_file(llvm_bin / "clang.exe", "clang.exe")
     _require_file(llvm_bin / "lld-link.exe", "lld-link.exe")
-    if shutil.which("link.exe") is None:
-        raise WindowsCiError("link.exe is missing from PATH")
+    msvc_bin = _msvc_linker().parent
     github_path = Path(_required_env("GITHUB_PATH"))
     with github_path.open("a", encoding="utf-8", newline="") as handle:
         handle.write(str(llvm_bin) + "\n")
+        # GITHUB_PATH entries take effect for subsequent steps. Write MSVC last so its link.exe
+        # wins over both LLVM/Git additions when Actions prepends the entries.
+        handle.write(str(msvc_bin) + "\n")
 
 
 def native_tests() -> None:
@@ -270,6 +287,7 @@ def _coverage(log: Path, *, canonical: bool) -> None:
 def benchmark_smoke() -> None:
     workspace = _workspace()
     runner_temp = _runner_temp()
+    benchmark_env = _msvc_path_env()
     _run(_cargo("build", "-p", "reld", "--bin", "reld-link"))
     reld = _require_file(workspace / "target" / "debug" / "reld-link.exe", "reld-link.exe")
 
@@ -298,6 +316,7 @@ def benchmark_smoke() -> None:
             str(generated),
         ),
         generated_log,
+        env=benchmark_env,
     )
     require_generated_table(generated_text)
     _coverage(generated_log, canonical=True)
@@ -329,6 +348,7 @@ def benchmark_smoke() -> None:
             str(replay_workdir),
         ),
         replay_log,
+        env=benchmark_env,
     )
     require_measured_row(replay_text, "large replay (512 units)")
     _coverage(replay_log, canonical=False)

--- a/ci/windows_ci.py
+++ b/ci/windows_ci.py
@@ -1,0 +1,380 @@
+"""Python entry points for Windows CI steps.
+
+GitHub Actions invokes this module from Bash. Keeping the platform orchestration here makes the
+Windows checks locally testable and avoids embedding a second scripting language in ``ci.yml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from ci import benchmark_coverage
+
+
+WINDOWS_TARGET = "x86_64-pc-windows-msvc"
+
+
+class WindowsCiError(RuntimeError):
+    """A Windows CI contract was not satisfied."""
+
+
+def _cargo(*args: str) -> list[str]:
+    command = os.environ.get("CARGO_COMMAND", "cargo")
+    if not command or any(character.isspace() for character in command):
+        raise WindowsCiError("CARGO_COMMAND must name one executable")
+    return [command, *args]
+
+
+def _run(
+    args: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
+    completed = subprocess.run(
+        list(args),
+        cwd=cwd,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    sys.stdout.write(completed.stdout)
+    if completed.returncode:
+        rendered = subprocess.list2cmdline(list(args))
+        raise WindowsCiError(f"command exited with {completed.returncode}: {rendered}")
+    return completed.stdout
+
+
+def _run_logged(
+    args: Sequence[str],
+    log: Path,
+    *,
+    append: bool = False,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
+    rendered = subprocess.list2cmdline(list(args))
+    chunks = []
+    with log.open("a" if append else "w", encoding="utf-8", newline="") as handle:
+        process = subprocess.Popen(
+            list(args),
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            sys.stdout.write(line)
+            handle.write(line)
+            chunks.append(line)
+        return_code = process.wait()
+    if return_code:
+        raise WindowsCiError(f"command exited with {return_code}: {rendered}")
+    return "".join(chunks)
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise WindowsCiError(f"required environment variable {name} is missing")
+    return value
+
+
+def _workspace() -> Path:
+    return Path(_required_env("GITHUB_WORKSPACE")).resolve()
+
+
+def _runner_temp() -> Path:
+    return Path(_required_env("RUNNER_TEMP")).resolve()
+
+
+def _reset_under(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    root = root.resolve()
+    if resolved == root or root not in resolved.parents:
+        raise WindowsCiError(f"refusing to reset path outside runner temp: {resolved}")
+    if resolved.exists():
+        shutil.rmtree(resolved)
+    resolved.mkdir(parents=True)
+    return resolved
+
+
+def _require_file(path: Path, description: str) -> Path:
+    if not path.is_file():
+        raise WindowsCiError(f"{description} not found at {path}")
+    return path
+
+
+def _capture_allow_failure(args: Sequence[str]) -> str:
+    completed = subprocess.run(
+        list(args),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    sys.stdout.write(completed.stdout)
+    return completed.stdout
+
+
+def verify_msvc_linkers() -> None:
+    link_output = _capture_allow_failure(["link.exe"])
+    lld_output = _run(["lld-link", "--version"])
+    expected_msvc = _required_env("MSVC_LINK_VERSION")
+    expected_lld = _required_env("LLD_VERSION")
+    if expected_msvc not in link_output:
+        raise WindowsCiError("link.exe version drift")
+    if expected_lld not in lld_output:
+        raise WindowsCiError("lld-link version drift")
+
+    link_lines = link_output.splitlines()[:2]
+    lld_lines = lld_output.splitlines()[:1]
+    Path("versions.txt").write_text("\n".join([*link_lines, *lld_lines]) + "\n")
+
+    source = _runner_temp() / "smoke.c"
+    source.write_text("int main(void) { return 0; }\n", encoding="utf-8")
+    _run(["cl.exe", "/nologo", str(source), f"/Fe:{source.with_name('smoke-link.exe')}"])
+    _run(
+        [
+            "clang-cl.exe",
+            "/nologo",
+            "-fuse-ld=lld",
+            str(source),
+            f"/Fe:{source.with_name('smoke-lld.exe')}",
+        ]
+    )
+
+
+def install_benchmark_linkers() -> None:
+    _run(["choco", "install", "llvm", "--no-progress", "--yes"])
+    program_files = Path(os.environ.get("ProgramFiles", r"C:\Program Files"))
+    llvm_bin = program_files / "LLVM" / "bin"
+    _require_file(llvm_bin / "clang.exe", "clang.exe")
+    _require_file(llvm_bin / "lld-link.exe", "lld-link.exe")
+    if shutil.which("link.exe") is None:
+        raise WindowsCiError("link.exe is missing from PATH")
+    github_path = Path(_required_env("GITHUB_PATH"))
+    with github_path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(str(llvm_bin) + "\n")
+
+
+def native_tests() -> None:
+    _run(_cargo("build", "--workspace", "--all-targets"))
+    commands = [
+        _cargo(
+            "test",
+            "-p",
+            "reld-layout-schema",
+            "-p",
+            "reld-diff",
+            "-p",
+            "reld-testkit",
+            "--all-targets",
+        ),
+        _cargo("test", "-p", "reld-core", "--lib"),
+        _cargo("test", "-p", "reld", "--bins"),
+        _cargo("test", "-p", "reld", "--test", "acceptance-policy"),
+        _cargo("test", "-p", "reld", "--test", "acceptance", "--", "--list"),
+    ]
+    log = Path("platform-tests.log")
+    for index, command in enumerate(commands):
+        _run_logged(command, log, append=index > 0)
+
+
+def sqlite_bridge() -> None:
+    workspace = _workspace()
+    reld = _require_file(workspace / "target" / "debug" / "reld-link.exe", "reld-link.exe")
+    env = os.environ.copy()
+    env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] = str(reld)
+    output = _run(
+        _cargo("run", "--quiet", "--bin", "app"),
+        cwd=workspace / "ci" / "e2e" / "sqlite-bridge",
+        env=env,
+    )
+    if "OK" not in output:
+        raise WindowsCiError("sqlite-bridge e2e output did not contain OK marker")
+    if "linked SQLite" not in output:
+        raise WindowsCiError("sqlite-bridge e2e output did not contain 'linked SQLite' marker")
+
+
+def require_measured_row(text: str, scenario: str) -> None:
+    timing = r"[0-9]+\.[0-9]{4}"
+    pattern = rf"^\| {re.escape(scenario)} \| {timing} \| {timing} \| {timing} \|$"
+    normalized = text.replace("\r\n", "\n")
+    if not re.search(pattern, normalized, flags=re.MULTILINE):
+        raise WindowsCiError(f"{scenario} link.exe/lld/reld row must contain real timings")
+
+
+def require_generated_table(text: str) -> None:
+    required = ["## Link Benchmark:", "| link.exe |", "| lld |", "| reld |"]
+    missing = [marker for marker in required if marker not in text]
+    if missing:
+        raise WindowsCiError(f"benchmark table missing marker(s): {', '.join(missing)}")
+    require_measured_row(text, "large (512 units)")
+
+
+def freeze_large_corpus(generated: Path, corpus: Path, runner_temp: Path) -> Path:
+    objects = sorted((generated / "large").glob("*.o"), key=lambda path: path.name)
+    if len(objects) != 513:
+        raise WindowsCiError(f"expected 513 large-workload objects (512 units plus main), got {len(objects)}")
+
+    corpus = _reset_under(corpus, runner_temp)
+    object_destination = corpus / "objs"
+    object_destination.mkdir()
+    object_names = []
+    for source in objects:
+        shutil.copy2(source, object_destination / source.name)
+        object_names.append(f"objs/{source.name}")
+
+    manifest = {
+        "schema_version": 1,
+        "platform": WINDOWS_TARGET,
+        "configuration": "large replay (512 units)",
+        "cc": "clang",
+        "objects": object_names,
+        "extra_link_args": [],
+        "output_name": "bench.exe",
+        "expected_exit_code": 0,
+    }
+    manifest_path = corpus / "corpus.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+def _coverage(log: Path, *, canonical: bool) -> None:
+    args = ["--input-log", str(log), "--target", WINDOWS_TARGET]
+    if not canonical:
+        args.append("--allow-noncanonical-scenarios")
+    if benchmark_coverage.main(args):
+        raise WindowsCiError(f"benchmark coverage failed for {log}")
+
+
+def benchmark_smoke() -> None:
+    workspace = _workspace()
+    runner_temp = _runner_temp()
+    _run(_cargo("build", "-p", "reld", "--bin", "reld-link"))
+    reld = _require_file(workspace / "target" / "debug" / "reld-link.exe", "reld-link.exe")
+
+    generated = _reset_under(runner_temp / "reld-bench-generated", runner_temp)
+    generated_log = Path("benchmark-windows-msvc.md")
+    generated_text = _run_logged(
+        _cargo(
+            "run",
+            "--release",
+            "-p",
+            "reld-testkit",
+            "--bin",
+            "reld-bench",
+            "--",
+            "--cc",
+            "clang",
+            "--target",
+            WINDOWS_TARGET,
+            "--trials",
+            "2",
+            "--warmup",
+            "1",
+            "--reld",
+            str(reld),
+            "--workdir",
+            str(generated),
+        ),
+        generated_log,
+    )
+    require_generated_table(generated_text)
+    _coverage(generated_log, canonical=True)
+
+    corpus = runner_temp / "reld-bench-large-replay-corpus"
+    freeze_large_corpus(generated, corpus, runner_temp)
+    replay_workdir = _reset_under(runner_temp / "reld-bench-large-replay-output", runner_temp)
+    replay_log = Path("benchmark-windows-msvc-replay.md")
+    replay_text = _run_logged(
+        _cargo(
+            "run",
+            "--release",
+            "-p",
+            "reld-testkit",
+            "--bin",
+            "reld-bench",
+            "--",
+            "--replay-corpus",
+            str(corpus),
+            "--target",
+            WINDOWS_TARGET,
+            "--trials",
+            "2",
+            "--warmup",
+            "1",
+            "--reld",
+            str(reld),
+            "--workdir",
+            str(replay_workdir),
+        ),
+        replay_log,
+    )
+    require_measured_row(replay_text, "large replay (512 units)")
+    _coverage(replay_log, canonical=False)
+
+
+def build_benchmark_driver() -> None:
+    workspace = _workspace()
+    _run(_cargo("build", "--release", "-p", "reld", "--bin", "reld-link"))
+    driver = _require_file(workspace / "target" / "release" / "reld-link.exe", "reld-link.exe")
+    print(f"Using COFF bridge driver: {driver}")
+
+
+def self_host() -> None:
+    workspace = _workspace()
+    reld_link = _require_file(workspace / "target" / "debug" / "reld-link.exe", "reld-link.exe")
+    env = os.environ.copy()
+    env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] = str(reld_link)
+    _run(_cargo("build", "-p", "reld", "--bin", "reld"), env=env)
+    reld = _require_file(workspace / "target" / "debug" / "reld.exe", "reld.exe")
+    output = _run([str(reld), "--version"])
+    if "Reld" not in output:
+        raise WindowsCiError("self-linked reld --version output missing 'Reld' marker")
+
+
+COMMANDS = {
+    "verify-msvc-linkers": verify_msvc_linkers,
+    "install-benchmark-linkers": install_benchmark_linkers,
+    "native-tests": native_tests,
+    "sqlite-bridge": sqlite_bridge,
+    "benchmark-smoke": benchmark_smoke,
+    "build-benchmark-driver": build_benchmark_driver,
+    "self-host": self_host,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ci.windows_ci")
+    parser.add_argument("command", choices=COMMANDS)
+    args = parser.parse_args(argv)
+    try:
+        COMMANDS[args.command]()
+    except WindowsCiError as error:
+        print(f"windows CI failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/windows_ci.py
+++ b/ci/windows_ci.py
@@ -144,9 +144,11 @@ def _msvc_linker() -> Path:
 
 def _msvc_path_env() -> dict[str, str]:
     env = os.environ.copy()
-    linker_dir = str(_msvc_linker().parent)
+    linker = _msvc_linker()
+    linker_dir = str(linker.parent)
     inherited = env.get("PATH")
     env["PATH"] = os.pathsep.join((linker_dir, inherited)) if inherited else linker_dir
+    env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] = str(linker)
     return env
 
 
@@ -184,17 +186,15 @@ def install_benchmark_linkers() -> None:
     llvm_bin = program_files / "LLVM" / "bin"
     _require_file(llvm_bin / "clang.exe", "clang.exe")
     _require_file(llvm_bin / "lld-link.exe", "lld-link.exe")
-    msvc_bin = _msvc_linker().parent
+    _msvc_linker()  # Fail setup immediately if the pinned Visual Studio toolset is incomplete.
     github_path = Path(_required_env("GITHUB_PATH"))
     with github_path.open("a", encoding="utf-8", newline="") as handle:
         handle.write(str(llvm_bin) + "\n")
-        # GITHUB_PATH entries take effect for subsequent steps. Write MSVC last so its link.exe
-        # wins over both LLVM/Git additions when Actions prepends the entries.
-        handle.write(str(msvc_bin) + "\n")
 
 
 def native_tests() -> None:
-    _run(_cargo("build", "--workspace", "--all-targets"))
+    env = _msvc_path_env()
+    _run(_cargo("build", "--workspace", "--all-targets"), env=env)
     commands = [
         _cargo(
             "test",
@@ -213,7 +213,7 @@ def native_tests() -> None:
     ]
     log = Path("platform-tests.log")
     for index, command in enumerate(commands):
-        _run_logged(command, log, append=index > 0)
+        _run_logged(command, log, append=index > 0, env=env)
 
 
 def sqlite_bridge() -> None:
@@ -288,7 +288,7 @@ def benchmark_smoke() -> None:
     workspace = _workspace()
     runner_temp = _runner_temp()
     benchmark_env = _msvc_path_env()
-    _run(_cargo("build", "-p", "reld", "--bin", "reld-link"))
+    _run(_cargo("build", "-p", "reld", "--bin", "reld-link"), env=benchmark_env)
     reld = _require_file(workspace / "target" / "debug" / "reld-link.exe", "reld-link.exe")
 
     generated = _reset_under(runner_temp / "reld-bench-generated", runner_temp)
@@ -356,7 +356,10 @@ def benchmark_smoke() -> None:
 
 def build_benchmark_driver() -> None:
     workspace = _workspace()
-    _run(_cargo("build", "--release", "-p", "reld", "--bin", "reld-link"))
+    _run(
+        _cargo("build", "--release", "-p", "reld", "--bin", "reld-link"),
+        env=_msvc_path_env(),
+    )
     driver = _require_file(workspace / "target" / "release" / "reld-link.exe", "reld-link.exe")
     print(f"Using COFF bridge driver: {driver}")
 

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -159,6 +159,42 @@ fn fuse_ld_value(token: &str) -> String {
     resolve_fuse_ld(token, which_on_path)
 }
 
+/// Select the `-fuse-ld` token clang can actually execute, plus an optional directory to prepend
+/// to the child PATH. Windows clang treats an absolute `-fuse-ld=C:\...\reld-link.exe` as a
+/// linker *name* and prefixes it with the target triple, producing a nonexistent executable.
+/// A basename on PATH is the supported form there. Unix clang accepts absolute linker paths.
+fn compiler_driver_linker(linker: &str, windows: bool) -> Result<(String, Option<PathBuf>)> {
+    let path = Path::new(linker);
+    if windows && path.is_absolute() {
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .with_context(|| format!("linker path has no UTF-8 file name: {}", path.display()))?;
+        let parent = path
+            .parent()
+            .with_context(|| format!("linker path has no parent: {}", path.display()))?;
+        return Ok((name.to_owned(), Some(parent.to_path_buf())));
+    }
+    Ok((fuse_ld_value(linker), None))
+}
+
+fn select_compiler_driver_linker(cmd: &mut Command, linker: &str) -> Result<()> {
+    if linker.is_empty() {
+        return Ok(());
+    }
+    let (value, search_dir) = compiler_driver_linker(linker, cfg!(windows))?;
+    if let Some(search_dir) = search_dir {
+        let mut paths = vec![search_dir];
+        if let Some(current_path) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current_path));
+        }
+        let joined = std::env::join_paths(paths).context("prepending linker directory to PATH")?;
+        cmd.env("PATH", joined);
+    }
+    cmd.arg(format!("-fuse-ld={value}"));
+    Ok(())
+}
+
 /// Core of [`fuse_ld_value`] with the PATH lookup injected, so the mapping is unit-testable
 /// without depending on what is actually installed on the test machine.
 fn resolve_fuse_ld(token: &str, lookup: impl Fn(&str) -> Option<PathBuf>) -> String {
@@ -575,9 +611,7 @@ fn link_once(args: &Args, inputs: &PreparedLinkInputs<'_>, linker: &str, out: &P
     let mut cmd = Command::new(&args.cc);
     add_prepared_link_inputs(&mut cmd, inputs);
     cmd.arg("-o").arg(out);
-    if !linker.is_empty() {
-        cmd.arg(format!("-fuse-ld={}", fuse_ld_value(linker)));
-    }
+    select_compiler_driver_linker(&mut cmd, linker)?;
     let status = cmd
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -610,9 +644,7 @@ fn probe_linker(cc: &str, linker: &str, root: &Path) -> Result<bool> {
     let exe = dir.join(if cfg!(windows) { "p.exe" } else { "p.out" });
     let mut cmd = Command::new(cc);
     cmd.arg(&obj).arg("-o").arg(&exe);
-    if !linker.is_empty() {
-        cmd.arg(format!("-fuse-ld={}", fuse_ld_value(linker)));
-    }
+    select_compiler_driver_linker(&mut cmd, linker)?;
     Ok(cmd.output().map(|o| o.status.success()).unwrap_or(false))
 }
 
@@ -625,7 +657,7 @@ fn bench_output_name(linker: &str) -> String {
     let safe: String = linker
         .chars()
         .map(|c| {
-            if matches!(c, '/' | '\\' | ':') {
+            if matches!(c, '/' | '\\' | ':' | '<' | '>' | '"' | '|' | '?' | '*') {
                 '_'
             } else {
                 c
@@ -730,9 +762,7 @@ fn link_once_replay(
     let mut cmd = Command::new(cc);
     add_prepared_link_inputs(&mut cmd, inputs);
     cmd.arg("-o").arg(out);
-    if !linker.is_empty() {
-        cmd.arg(format!("-fuse-ld={}", fuse_ld_value(linker)));
-    }
+    select_compiler_driver_linker(&mut cmd, linker)?;
     let status = cmd
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -968,6 +998,26 @@ mod tests {
             "must never stay a bare ld64.lld token"
         );
         assert_eq!(fallback, "lld");
+    }
+
+    #[test]
+    fn windows_absolute_custom_linker_uses_basename_and_parent_path() {
+        let absolute = if cfg!(windows) {
+            r"C:\bench tools\reld-link.exe"
+        } else {
+            "/bench tools/reld-link.exe"
+        };
+        let (value, search_dir) = compiler_driver_linker(absolute, true).unwrap();
+        assert_eq!(value, "reld-link.exe");
+        assert_eq!(search_dir.unwrap(), Path::new(absolute).parent().unwrap());
+    }
+
+    #[test]
+    fn unix_absolute_custom_linker_remains_an_absolute_fuse_ld_value() {
+        let absolute = "/opt/reld drivers/ld64.reld";
+        let (value, search_dir) = compiler_driver_linker(absolute, false).unwrap();
+        assert_eq!(value, absolute);
+        assert!(search_dir.is_none());
     }
 
     #[test]
@@ -1293,6 +1343,10 @@ mod tests {
         assert_eq!(
             bench_output_name(r"C:\tc\ld.reld"),
             "bench-C__tc_ld.reld.bin"
+        );
+        assert_eq!(
+            bench_output_name(r"\\?\C:\tc\reld-link.exe"),
+            "bench-____C__tc_reld-link.exe.bin"
         );
     }
 }

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -12,6 +12,7 @@
 //! missing competitor is visible in the published chart instead of quietly improving our
 //! numbers.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -88,6 +89,11 @@ struct Corpus {
     /// Configuration label for the table row (e.g. `quick` / `thin-lto` / `full-lto`).
     #[serde(default)]
     configuration: Option<String>,
+    /// Optional process exit-code oracle for the linked corpus. When present, the benchmark
+    /// executes each final output once after timing and requires this code. A corpus without an
+    /// oracle still has its final artifact checked for existence and nonzero length.
+    #[serde(default)]
+    expected_exit_code: Option<i32>,
 }
 
 /// Workload sizes. Small is where incremental linking will eventually matter most; large is
@@ -285,10 +291,16 @@ fn main() -> Result<()> {
                 print!(" n/a |");
                 continue;
             }
-            match time_link(&args, &dir, &objects, linker) {
+            match time_link(&args, &dir, &objects, linker).and_then(|d| {
+                validate_generated_output(
+                    &bench_output_path(&dir, linker),
+                    workload.expected_exit_code(),
+                )?;
+                Ok(d)
+            }) {
                 Ok(d) => print!(" {:.4} |", d.as_secs_f64()),
                 Err(e) => {
-                    failures.push((linker.clone(), name.clone(), e.to_string()));
+                    failures.push((linker.clone(), name.clone(), format!("{e:#}")));
                     print!(" n/a |");
                 }
             }
@@ -297,10 +309,16 @@ fn main() -> Result<()> {
             let linker = reld_shim_str
                 .as_ref()
                 .expect("measured implies a shim path");
-            match time_link(&args, &dir, &objects, linker) {
+            match time_link(&args, &dir, &objects, linker).and_then(|d| {
+                validate_generated_output(
+                    &bench_output_path(&dir, linker),
+                    workload.expected_exit_code(),
+                )?;
+                Ok(d)
+            }) {
                 Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
                 Err(e) => {
-                    failures.push(("reld".to_string(), name.clone(), e.to_string()));
+                    failures.push(("reld".to_string(), name.clone(), format!("{e:#}")));
                     println!(" n/a |");
                 }
             }
@@ -412,9 +430,143 @@ fn compile_all(args: &Args, dir: &Path, sources: &[PathBuf]) -> Result<Vec<PathB
     Ok(objects)
 }
 
-fn link_once(args: &Args, objects: &[PathBuf], linker: &str, out: &Path) -> Result<()> {
+/// Response-file tokenization grammar used by the compiler driver on each platform. Keeping the
+/// formatting independent of the host lets the Windows-specific path be regression-tested on
+/// every developer machine.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResponseFileSyntax {
+    Gnu,
+    Windows,
+}
+
+fn compiler_driver_response_syntax() -> ResponseFileSyntax {
+    if cfg!(windows) {
+        ResponseFileSyntax::Windows
+    } else {
+        ResponseFileSyntax::Gnu
+    }
+}
+
+/// Quote one response-file argument for clang's platform-native driver parser.
+///
+/// GNU response files treat every backslash as an escape, while Windows follows the usual
+/// CommandLineToArgvW rule where only runs of backslashes immediately before a quote (or the
+/// closing quote) need special handling. Always quoting each argument makes whitespace, quotes,
+/// and non-ASCII paths unambiguous.
+fn quote_response_file_argument(arg: &str, syntax: ResponseFileSyntax) -> String {
+    match syntax {
+        ResponseFileSyntax::Gnu => {
+            let escaped = arg.replace('\\', "\\\\").replace('"', "\\\"");
+            format!("\"{escaped}\"")
+        }
+        ResponseFileSyntax::Windows => {
+            let mut quoted = String::with_capacity(arg.len() + 2);
+            quoted.push('"');
+            let mut backslashes = 0;
+            for ch in arg.chars() {
+                if ch == '\\' {
+                    backslashes += 1;
+                    continue;
+                }
+                if ch == '"' {
+                    quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+                } else {
+                    quoted.extend(std::iter::repeat_n('\\', backslashes));
+                }
+                backslashes = 0;
+                quoted.push(ch);
+            }
+            // Backslashes immediately before the closing quote must be doubled.
+            quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
+            quoted.push('"');
+            quoted
+        }
+    }
+}
+
+/// Produce UTF-8 contents for a clang compiler-driver response file. One quoted argument per
+/// line also keeps the artifact inspectable when diagnosing a benchmark runner failure.
+fn compiler_driver_response_file_contents(args: &[String], syntax: ResponseFileSyntax) -> String {
+    let mut contents = args
+        .iter()
+        .map(|arg| quote_response_file_argument(arg, syntax))
+        .collect::<Vec<_>>()
+        .join("\n");
+    contents.push('\n');
+    contents
+}
+
+fn write_compiler_driver_response_file(path: &Path, args: &[String]) -> Result<()> {
+    let contents = compiler_driver_response_file_contents(args, compiler_driver_response_syntax());
+    std::fs::write(path, contents)
+        .with_context(|| format!("writing compiler-driver response file {}", path.display()))
+}
+
+/// Add all linker inputs to `cmd`. Windows receives them through an `@response-file`, avoiding
+/// the CreateProcess command-line limit for the large generated and frozen-corpus benchmarks.
+/// Other platforms retain the existing direct-argument invocation.
+enum PreparedLinkInputs<'a> {
+    Direct {
+        objects: &'a [PathBuf],
+        extra: &'a [String],
+    },
+    ResponseFile(PathBuf),
+}
+
+/// Prepare the linker's input list once before the warmup/timed loop. In particular, response
+/// file creation is deliberately excluded from benchmark timing.
+fn prepare_link_inputs<'a>(
+    objects: &'a [PathBuf],
+    extra: &'a [String],
+    response_file: &Path,
+) -> Result<PreparedLinkInputs<'a>> {
+    if cfg!(windows) {
+        let mut inputs = Vec::with_capacity(objects.len() + extra.len());
+        inputs.extend(
+            objects
+                .iter()
+                .map(|object| response_file_path_argument(object))
+                .collect::<Result<Vec<_>>>()?,
+        );
+        inputs.extend(extra.iter().cloned());
+        write_compiler_driver_response_file(response_file, &inputs)?;
+        Ok(PreparedLinkInputs::ResponseFile(
+            response_file.to_path_buf(),
+        ))
+    } else {
+        Ok(PreparedLinkInputs::Direct { objects, extra })
+    }
+}
+
+/// Convert a filesystem path into the UTF-8 response-file format used by clang. Never use a
+/// lossy conversion here: changing one byte of an object path would turn a benchmark harness
+/// failure into a misleading linker result.
+fn response_file_path_argument(path: &Path) -> Result<String> {
+    path.to_str().map(str::to_owned).with_context(|| {
+        format!(
+            "cannot write non-UTF-8 linker input path to a compiler-driver response file: {}",
+            path.display()
+        )
+    })
+}
+
+fn add_prepared_link_inputs(cmd: &mut Command, inputs: &PreparedLinkInputs<'_>) {
+    match inputs {
+        PreparedLinkInputs::Direct { objects, extra } => {
+            cmd.args(*objects).args(*extra);
+        }
+        PreparedLinkInputs::ResponseFile(path) => {
+            let mut response_arg = OsString::from("@");
+            response_arg.push(path);
+            cmd.arg(response_arg);
+        }
+    }
+}
+
+fn link_once(args: &Args, inputs: &PreparedLinkInputs<'_>, linker: &str, out: &Path) -> Result<()> {
     let mut cmd = Command::new(&args.cc);
-    cmd.args(objects).arg("-o").arg(out);
+    add_prepared_link_inputs(&mut cmd, inputs);
+    cmd.arg("-o").arg(out);
     if !linker.is_empty() {
         cmd.arg(format!("-fuse-ld={}", fuse_ld_value(linker)));
     }
@@ -422,7 +574,7 @@ fn link_once(args: &Args, objects: &[PathBuf], linker: &str, out: &Path) -> Resu
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .output()
-        .context("spawning linker")?;
+        .with_context(|| format!("spawning linker via {}", args.cc))?;
     if !status.status.success() {
         bail!("link failed: {}", String::from_utf8_lossy(&status.stderr));
     }
@@ -475,11 +627,74 @@ fn bench_output_name(linker: &str) -> String {
     format!("bench-{safe}.bin")
 }
 
+fn bench_output_path(dir: &Path, linker: &str) -> PathBuf {
+    dir.join(bench_output_name(linker))
+}
+
+/// Confirm that a link left behind a real output artifact before attempting to execute it. This
+/// makes a successful process spawn impossible to mistake for a usable benchmark result.
+fn validate_nonempty_output_artifact(out: &Path) -> Result<()> {
+    let metadata = std::fs::metadata(out)
+        .with_context(|| format!("benchmark output artifact is missing: {}", out.display()))?;
+    if !metadata.is_file() {
+        bail!(
+            "benchmark output artifact is not a regular file: {}",
+            out.display()
+        );
+    }
+    if metadata.len() == 0 {
+        bail!("benchmark output artifact is empty: {}", out.display());
+    }
+    Ok(())
+}
+
+/// Check a process result against an exit-code oracle. Kept separate from process execution so
+/// corpus-validation behavior is unit-testable without a compiler or generated binary.
+fn validate_output_exit_code(actual: Option<i32>, expected: i32) -> Result<()> {
+    match actual {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => bail!("unexpected exit code: expected {expected}, got {actual}"),
+        None => bail!("output did not exit normally; expected exit code {expected}"),
+    }
+}
+
+/// Run a final linked program after timing and verify its exit-code oracle. Execution is never
+/// part of the timed interval: the caller invokes this only after [`time_link`] succeeds.
+fn run_and_validate_output(out: &Path, expected_exit_code: i32) -> Result<()> {
+    validate_nonempty_output_artifact(out)?;
+    let run = Command::new(out)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("running benchmark output {}", out.display()))?;
+    validate_output_exit_code(run.status.code(), expected_exit_code)
+        .with_context(|| format!("benchmark output {} failed validation", out.display()))
+}
+
+/// Validate a generated workload's final output after timing. Every generated workload has a
+/// deterministic oracle, unlike arbitrary frozen corpora.
+fn validate_generated_output(out: &Path, expected_exit_code: i32) -> Result<()> {
+    run_and_validate_output(out, expected_exit_code)
+}
+
+/// Validate a frozen corpus output after timing. A corpus may opt into an execution oracle; old
+/// corpora that omit it are still rejected if the linker failed to create a nonempty artifact.
+fn validate_replay_output(out: &Path, expected_exit_code: Option<i32>) -> Result<()> {
+    match expected_exit_code {
+        Some(expected) => run_and_validate_output(out, expected),
+        None => validate_nonempty_output_artifact(out).context(
+            "corpus.json has no expected_exit_code, so replay validation can only require a \
+             nonempty output artifact",
+        ),
+    }
+}
+
 fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Result<Duration> {
-    let out = dir.join(bench_output_name(linker));
+    let out = bench_output_path(dir, linker);
+    let inputs = prepare_link_inputs(objects, &[], &out.with_extension("rsp"))?;
 
     for _ in 0..args.warmup {
-        link_once(args, objects, linker, &out)?;
+        link_once(args, &inputs, linker, &out)?;
     }
 
     let mut samples = Vec::with_capacity(args.trials);
@@ -488,7 +703,7 @@ fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Resu
         // up-to-date target.
         let _ = std::fs::remove_file(&out);
         let t = Instant::now();
-        link_once(args, objects, linker, &out)?;
+        link_once(args, &inputs, linker, &out)?;
         samples.push(t.elapsed());
     }
     samples.sort();
@@ -500,13 +715,13 @@ fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Resu
 /// explicitly so the corpus can carry its own toolchain, independent of `--cc`.
 fn link_once_replay(
     cc: &str,
-    objects: &[PathBuf],
-    extra: &[String],
+    inputs: &PreparedLinkInputs<'_>,
     linker: &str,
     out: &Path,
 ) -> Result<()> {
     let mut cmd = Command::new(cc);
-    cmd.args(objects).args(extra).arg("-o").arg(out);
+    add_prepared_link_inputs(&mut cmd, inputs);
+    cmd.arg("-o").arg(out);
     if !linker.is_empty() {
         cmd.arg(format!("-fuse-ld={}", fuse_ld_value(linker)));
     }
@@ -514,7 +729,7 @@ fn link_once_replay(
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .output()
-        .context("spawning linker")?;
+        .with_context(|| format!("spawning linker via {cc}"))?;
     if !status.status.success() {
         bail!("link failed: {}", String::from_utf8_lossy(&status.stderr));
     }
@@ -532,15 +747,16 @@ fn time_link_replay(
     warmup: usize,
     trials: usize,
 ) -> Result<Duration> {
-    let out = out_dir.join(bench_output_name(linker));
+    let out = bench_output_path(out_dir, linker);
+    let inputs = prepare_link_inputs(objects, extra, &out.with_extension("rsp"))?;
     for _ in 0..warmup {
-        link_once_replay(cc, objects, extra, linker, &out)?;
+        link_once_replay(cc, &inputs, linker, &out)?;
     }
     let mut samples = Vec::with_capacity(trials);
     for _ in 0..trials {
         let _ = std::fs::remove_file(&out);
         let t = Instant::now();
-        link_once_replay(cc, objects, extra, linker, &out)?;
+        link_once_replay(cc, &inputs, linker, &out)?;
         samples.push(t.elapsed());
     }
     samples.sort();
@@ -612,6 +828,7 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
     }
     println!("----:|");
 
+    let mut failures: Vec<(String, String, String)> = Vec::new();
     print!("| {scenario} |");
     for (linker, ok) in &available {
         if !ok {
@@ -626,9 +843,16 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
             &root,
             args.warmup,
             args.trials,
-        ) {
+        )
+        .and_then(|d| {
+            validate_replay_output(&bench_output_path(&root, linker), corpus.expected_exit_code)?;
+            Ok(d)
+        }) {
             Ok(d) => print!(" {:.4} |", d.as_secs_f64()),
-            Err(_) => print!(" n/a |"),
+            Err(e) => {
+                failures.push((linker.clone(), scenario.clone(), format!("{e:#}")));
+                print!(" n/a |");
+            }
         }
     }
     if reld_measured {
@@ -643,9 +867,16 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
             &root,
             args.warmup,
             args.trials,
-        ) {
+        )
+        .and_then(|d| {
+            validate_replay_output(&bench_output_path(&root, linker), corpus.expected_exit_code)?;
+            Ok(d)
+        }) {
             Ok(d) => println!(" {:.4} |", d.as_secs_f64()),
-            Err(_) => println!(" n/a |"),
+            Err(e) => {
+                failures.push(("reld".to_string(), scenario.clone(), format!("{e:#}")));
+                println!(" n/a |");
+            }
         }
     } else if reld_pending.is_some() {
         println!(" pending |");
@@ -655,6 +886,9 @@ fn run_replay(args: &Args, corpus_dir: &Path) -> Result<()> {
     println!();
     if let Some(reason) = &reld_pending {
         println!("{}", format_pending_comment("reld", reason));
+    }
+    for (linker, scenario, error) in &failures {
+        println!("{}", format_failure_comment(linker, scenario, error));
     }
     Ok(())
 }
@@ -672,6 +906,7 @@ mod tests {
             "cc": "clang",
             "objects": ["objs/a.o", "objs/b.o"],
             "extra_link_args": ["-lm"],
+            "expected_exit_code": 17,
             "output_name": "app"
         }"#;
         let corpus: Corpus = serde_json::from_str(json).unwrap();
@@ -682,6 +917,7 @@ mod tests {
         );
         assert_eq!(corpus.extra_link_args, vec!["-lm".to_string()]);
         assert_eq!(corpus.configuration.as_deref(), Some("quick"));
+        assert_eq!(corpus.expected_exit_code, Some(17));
     }
 
     #[test]
@@ -762,7 +998,59 @@ mod tests {
         assert!(corpus.cc.is_none());
         assert!(corpus.extra_link_args.is_empty());
         assert!(corpus.configuration.is_none());
+        assert!(corpus.expected_exit_code.is_none());
         assert_eq!(corpus.objects, vec!["a.o".to_string()]);
+    }
+
+    #[test]
+    fn output_exit_code_validation_reports_wrong_and_abnormal_exits() {
+        validate_output_exit_code(Some(16), 16).unwrap();
+
+        let wrong = validate_output_exit_code(Some(15), 16)
+            .unwrap_err()
+            .to_string();
+        assert!(wrong.contains("expected 16, got 15"), "{wrong}");
+
+        let abnormal = validate_output_exit_code(None, 16).unwrap_err().to_string();
+        assert!(abnormal.contains("did not exit normally"), "{abnormal}");
+    }
+
+    #[test]
+    fn replay_validation_without_oracle_requires_nonempty_artifact() {
+        let dir = unique_tmp_dir("replay-output-validation");
+        let empty = dir.join("empty-output");
+        std::fs::write(&empty, []).unwrap();
+
+        let error = validate_replay_output(&empty, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("no expected_exit_code"), "{error}");
+        assert!(error.contains("empty"), "{error}");
+
+        let nonempty = dir.join("nonempty-output");
+        std::fs::write(&nonempty, [0_u8]).unwrap();
+        validate_replay_output(&nonempty, None).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn response_file_path_argument_preserves_unicode_paths() {
+        let path = PathBuf::from("objects/日本語/🦀.o");
+        assert_eq!(
+            response_file_path_argument(&path).unwrap(),
+            "objects/日本語/🦀.o"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn response_file_path_argument_rejects_non_utf8_paths() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from(std::ffi::OsString::from_vec(vec![b'o', b'.', 0xFF]));
+        let error = response_file_path_argument(&path).unwrap_err().to_string();
+        assert!(error.contains("non-UTF-8"), "{error}");
     }
 
     /// Unique temp directory per test, so the (hermetic) discovery tests never touch the real
@@ -872,6 +1160,90 @@ mod tests {
             comment,
             "<!-- linker bfd link failed (small (16 units)): undefined symbol: foo -->"
         );
+    }
+
+    #[test]
+    fn failure_comments_keep_the_full_anyhow_cause_chain() {
+        let error = anyhow::anyhow!("The filename or extension is too long (os error 206)")
+            .context("spawning linker via clang");
+        let comment = format_failure_comment("lld", "large (512 units)", &format!("{error:#}"));
+        assert!(comment.contains("spawning linker via clang"), "{comment}");
+        assert!(comment.contains("os error 206"), "{comment}");
+    }
+
+    #[test]
+    fn gnu_response_file_escapes_spaces_quotes_backslashes_and_unicode() {
+        let args = vec![
+            "plain.o".to_string(),
+            "dir with spaces/object file.o".to_string(),
+            "quote\"name.o".to_string(),
+            r"C:\bench\object.o".to_string(),
+            "日本語/🦀.o".to_string(),
+        ];
+        assert_eq!(
+            compiler_driver_response_file_contents(&args, ResponseFileSyntax::Gnu),
+            concat!(
+                "\"plain.o\"\n",
+                "\"dir with spaces/object file.o\"\n",
+                "\"quote\\\"name.o\"\n",
+                "\"C:\\\\bench\\\\object.o\"\n",
+                "\"日本語/🦀.o\"\n",
+            )
+        );
+    }
+
+    #[test]
+    fn windows_response_file_uses_windows_quote_rules() {
+        let args = vec![
+            "dir with spaces/object file.o".to_string(),
+            "quote\"name.o".to_string(),
+            r"C:\bench\object.o".to_string(),
+            r"C:\trailing slash\\".to_string(),
+            "日本語/🦀.o".to_string(),
+        ];
+        assert_eq!(
+            compiler_driver_response_file_contents(&args, ResponseFileSyntax::Windows),
+            concat!(
+                "\"dir with spaces/object file.o\"\n",
+                "\"quote\\\"name.o\"\n",
+                "\"C:\\bench\\object.o\"\n",
+                "\"C:\\trailing slash\\\\\\\\\"\n",
+                "\"日本語/🦀.o\"\n",
+            )
+        );
+    }
+
+    #[test]
+    fn prepared_link_inputs_writes_windows_response_file_before_linking() {
+        let dir = unique_tmp_dir("prepared-inputs");
+        let objects = vec![
+            dir.join("objects with spaces").join("日本語.o"),
+            dir.join("quote\"name.o"),
+        ];
+        let extra = vec!["-lcustom library".to_string()];
+        let response_file = dir.join("bench.rsp");
+        let prepared = prepare_link_inputs(&objects, &extra, &response_file).unwrap();
+
+        if cfg!(windows) {
+            assert_eq!(
+                std::fs::read_to_string(&response_file).unwrap(),
+                compiler_driver_response_file_contents(
+                    &[
+                        objects[0].to_string_lossy().into_owned(),
+                        objects[1].to_string_lossy().into_owned(),
+                        extra[0].clone(),
+                    ],
+                    ResponseFileSyntax::Windows,
+                )
+            );
+            assert!(matches!(&prepared, PreparedLinkInputs::ResponseFile(_)));
+        } else {
+            assert!(matches!(&prepared, PreparedLinkInputs::Direct { .. }));
+            assert!(!response_file.exists());
+        }
+
+        drop(prepared);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -439,20 +439,26 @@ enum ResponseFileSyntax {
     Windows,
 }
 
-fn compiler_driver_response_syntax() -> ResponseFileSyntax {
-    if cfg!(windows) {
+fn compiler_driver_response_syntax(cc: &str) -> ResponseFileSyntax {
+    let driver = cc
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(cc)
+        .to_ascii_lowercase();
+    let driver = driver.strip_suffix(".exe").unwrap_or(&driver);
+    if matches!(driver, "clang-cl" | "cl") {
         ResponseFileSyntax::Windows
     } else {
         ResponseFileSyntax::Gnu
     }
 }
 
-/// Quote one response-file argument for clang's platform-native driver parser.
+/// Quote one response-file argument for clang's active driver-mode parser.
 ///
-/// GNU response files treat every backslash as an escape, while Windows follows the usual
-/// CommandLineToArgvW rule where only runs of backslashes immediately before a quote (or the
-/// closing quote) need special handling. Always quoting each argument makes whitespace, quotes,
-/// and non-ASCII paths unambiguous.
+/// The `clang` driver uses GNU tokenization even on Windows, while `clang-cl` uses the Windows
+/// CommandLineToArgvW rules. GNU response files treat every backslash as an escape; Windows only
+/// gives special meaning to runs of backslashes immediately before a quote (or the closing quote).
+/// Always quoting each argument makes whitespace, quotes, and non-ASCII paths unambiguous.
 fn quote_response_file_argument(arg: &str, syntax: ResponseFileSyntax) -> String {
     match syntax {
         ResponseFileSyntax::Gnu => {
@@ -496,8 +502,9 @@ fn compiler_driver_response_file_contents(args: &[String], syntax: ResponseFileS
     contents
 }
 
-fn write_compiler_driver_response_file(path: &Path, args: &[String]) -> Result<()> {
-    let contents = compiler_driver_response_file_contents(args, compiler_driver_response_syntax());
+fn write_compiler_driver_response_file(path: &Path, args: &[String], cc: &str) -> Result<()> {
+    let contents =
+        compiler_driver_response_file_contents(args, compiler_driver_response_syntax(cc));
     std::fs::write(path, contents)
         .with_context(|| format!("writing compiler-driver response file {}", path.display()))
 }
@@ -519,6 +526,7 @@ fn prepare_link_inputs<'a>(
     objects: &'a [PathBuf],
     extra: &'a [String],
     response_file: &Path,
+    cc: &str,
 ) -> Result<PreparedLinkInputs<'a>> {
     if cfg!(windows) {
         let mut inputs = Vec::with_capacity(objects.len() + extra.len());
@@ -529,7 +537,7 @@ fn prepare_link_inputs<'a>(
                 .collect::<Result<Vec<_>>>()?,
         );
         inputs.extend(extra.iter().cloned());
-        write_compiler_driver_response_file(response_file, &inputs)?;
+        write_compiler_driver_response_file(response_file, &inputs, cc)?;
         Ok(PreparedLinkInputs::ResponseFile(
             response_file.to_path_buf(),
         ))
@@ -691,7 +699,7 @@ fn validate_replay_output(out: &Path, expected_exit_code: Option<i32>) -> Result
 
 fn time_link(args: &Args, dir: &Path, objects: &[PathBuf], linker: &str) -> Result<Duration> {
     let out = bench_output_path(dir, linker);
-    let inputs = prepare_link_inputs(objects, &[], &out.with_extension("rsp"))?;
+    let inputs = prepare_link_inputs(objects, &[], &out.with_extension("rsp"), &args.cc)?;
 
     for _ in 0..args.warmup {
         link_once(args, &inputs, linker, &out)?;
@@ -748,7 +756,7 @@ fn time_link_replay(
     trials: usize,
 ) -> Result<Duration> {
     let out = bench_output_path(out_dir, linker);
-    let inputs = prepare_link_inputs(objects, extra, &out.with_extension("rsp"))?;
+    let inputs = prepare_link_inputs(objects, extra, &out.with_extension("rsp"), cc)?;
     for _ in 0..warmup {
         link_once_replay(cc, &inputs, linker, &out)?;
     }
@@ -1214,6 +1222,30 @@ mod tests {
     }
 
     #[test]
+    fn response_file_syntax_follows_clang_driver_mode_not_host_os() {
+        assert_eq!(
+            compiler_driver_response_syntax("clang.exe"),
+            ResponseFileSyntax::Gnu
+        );
+        assert_eq!(
+            compiler_driver_response_syntax(r"C:\Program Files\LLVM\bin\clang.exe"),
+            ResponseFileSyntax::Gnu
+        );
+        assert_eq!(
+            compiler_driver_response_syntax("clang-cl.exe"),
+            ResponseFileSyntax::Windows
+        );
+        assert_eq!(
+            compiler_driver_response_syntax(r"C:\Program Files\LLVM\bin\clang-cl.exe"),
+            ResponseFileSyntax::Windows
+        );
+        assert_eq!(
+            compiler_driver_response_syntax(r"C:\LLVM\CLANG-CL.EXE"),
+            ResponseFileSyntax::Windows
+        );
+    }
+
+    #[test]
     fn prepared_link_inputs_writes_windows_response_file_before_linking() {
         let dir = unique_tmp_dir("prepared-inputs");
         let objects = vec![
@@ -1222,7 +1254,7 @@ mod tests {
         ];
         let extra = vec!["-lcustom library".to_string()];
         let response_file = dir.join("bench.rsp");
-        let prepared = prepare_link_inputs(&objects, &extra, &response_file).unwrap();
+        let prepared = prepare_link_inputs(&objects, &extra, &response_file, "clang.exe").unwrap();
 
         if cfg!(windows) {
             assert_eq!(
@@ -1233,7 +1265,7 @@ mod tests {
                         objects[1].to_string_lossy().into_owned(),
                         extra[0].clone(),
                     ],
-                    ResponseFileSyntax::Windows,
+                    ResponseFileSyntax::Gnu,
                 )
             );
             assert!(matches!(&prepared, PreparedLinkInputs::ResponseFile(_)));

--- a/crates/reld/tests/acceptance.rs
+++ b/crates/reld/tests/acceptance.rs
@@ -6608,9 +6608,16 @@ fn verify_linker_plugin_requirements(
                 verifier_path.display()
             );
 
-            // Check that rustc can use linker-plugin-lto with the installed clang. This eliminates
-            // platforms where the LLVM version used by clang doesn't match the version used by
-            // rustc.
+            // Keep this output in a private directory. Fixture collection can happen in several
+            // processes, so a shared architecture-named file can be replaced mid-link.
+            let verifier_dir = tempfile::tempdir()
+                .context("Failed to create temporary directory for the Rust LTO verifier")?;
+            let verifier_output = verifier_dir
+                .path()
+                .join(format!("rust-{}.out", config.arch));
+
+            // Check compiler plugin compatibility with the installed clang. This eliminates
+            // platforms where the LLVM version used by clang doesn't match the compiler's version.
             let mut command = Command::new(&compiler);
             command.args(config.rustc_channel.as_arg());
             command.arg(verifier_path);
@@ -6619,8 +6626,8 @@ fn verify_linker_plugin_requirements(
                 "-Clinker-plugin-lto",
                 "-Clink-arg=-flto",
                 "-o",
-                &format!("/tmp/rust-{}.out", config.arch),
             ]);
+            command.arg(&verifier_output);
             verify_command_success(&mut command).context(
                 "Can't use rust+clang with linker plugin. LLVM version mismatch? \
                 Check that clang --version matches LLVM version reported by `rustc -vV`.",


### PR DESCRIPTION
Closes #68

## What changed

- use Windows-safe response files for generated and replay benchmarks, preserve full linker error causes, and validate final output artifacts outside timed regions
- isolate parallel LTO verifier outputs and make phase summaries honest after upstream failures
- measure target-correct reld bridge drivers on Windows and macOS instead of publishing pending/N/A cells
- enforce canonical scenarios, schema v4 mode/engine metadata, exact generated README content, current source SHA, and freshness
- replace PowerShell in the changed CI and benchmark workflows with Bash orchestration, syncing once with uv and invoking Python through `uv run --no-sync`
- pin the MSVC linker explicitly so Bash cannot resolve Git for Windows' unrelated `link.exe`

## Local validation

- `uv sync --extra dev`
- `uv run --no-sync python -m pytest ci/tests -q` (119 passed)
- `uvx ruff check ci`
- `soldr cargo fmt --all -- --check`
- `soldr cargo test -p reld-testkit --bin reld-bench` (25 passed)
- `soldr cargo clippy -p reld-testkit --bin reld-bench -- -D warnings`
- `uv run --no-sync python -m ci.benchmark_stats --check-readme README.md`
- `actionlint .github/workflows/ci.yml .github/workflows/benchmark-stats.yml`
- zero-PowerShell and uv invocation-policy guards for both changed workflows
- real local Windows generated benchmark: `link.exe`, `lld`, and `reld` measured for 16/128/512-object scenarios
- `bosn route` and `bosn smoke`

## Native workflow evidence

- Exact final SHA `7e1a3be88bcfcada9590dae6669421ff32e7512f`: [Benchmark Stats run 32665221498](https://github.com/zackees/reld/actions/runs/32665221498).
- Linux and Windows generate all canonical measured cells with strict no-N/A coverage; the aggregate validates schema v4 metadata, source SHA, and generated README freshness after macOS completes.
- The feature-branch dispatch does not publish by design. After merge, the same workflow will run on `main`, publish the generated branch, and enforce exact-SHA freshness.
