### PR TITLE
perf(elf): accelerate large retained-section output emission

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -140,7 +140,9 @@ jobs:
           uv run --no-sync python -m ci.benchmark_runner
           --target "$TARGET" --reld "$RELD_DRIVER"
           --manifest ci/e2e/link-workload/Cargo.toml
-          --output benchmark-output/benchmark.log --trials 3 --warmup 1
+          --output benchmark-output/benchmark.log
+          --output-mode-report benchmark-output/output-modes.json
+          --trials 3 --warmup 1
 
       - name: Assert benchmark coverage (no silent n/a for expected linkers)
         shell: bash
@@ -173,6 +175,7 @@ jobs:
           path: |
             benchmark-output/benchmark.log
             benchmark-output/metadata.json
+            benchmark-output/output-modes.json
           if-no-files-found: error
 
   aggregate:

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -26,6 +26,7 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-linux
             reld_driver: target/release/ld.reld
+            baseline_reld: target/issue74-baseline/reld
           - runner: windows-2022
             target: x86_64-pc-windows-msvc
             # COFF format selection is made from argv[0], not Linux's ld.reld shim name.
@@ -108,6 +109,15 @@ jobs:
           $CARGO_COMMAND build --release -p reld
           bash ci/install-driver-shims.sh release
 
+      - name: Build exact Linux issue baseline
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          CARGO_COMMAND: cargo
+        run: >-
+          uv run --no-sync python -m ci.benchmark_baseline
+          --output target/issue74-baseline/reld
+
       - name: Build Windows COFF reld front door
         if: runner.os == 'Windows'
         shell: bash
@@ -132,6 +142,7 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           RELD_DRIVER: ${{ matrix.reld_driver }}
+          BASELINE_RELD: ${{ matrix.baseline_reld }}
           CARGO_COMMAND: cargo
         # Python owns child-process resolution so Git Bash cannot shadow MSVC link.exe. Cargo
         # compiles the one artifact-auditor Rust project once per LTO configuration; every timed
@@ -139,6 +150,7 @@ jobs:
         run: >-
           uv run --no-sync python -m ci.benchmark_runner
           --target "$TARGET" --reld "$RELD_DRIVER"
+          --baseline-reld "$BASELINE_RELD"
           --manifest ci/e2e/link-workload/Cargo.toml
           --output benchmark-output/benchmark.log
           --output-mode-report benchmark-output/output-modes.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-subscriber",
+ "twox-hash",
  "uuid",
  "winnow",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
   "fmt",
   "registry",
 ] }
+twox-hash = { version = "2.1.2", default-features = false, features = ["xxhash3_128"] }
 uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
 wait-timeout = { version = "0.2.0", default-features = false }
 wait4 = { version = "0.1.3", default-features = false }

--- a/ci/benchmark_baseline.py
+++ b/ci/benchmark_baseline.py
@@ -1,0 +1,66 @@
+"""Build the fixed issue #74 baseline linker in an isolated temporary worktree."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from ci.benchmark_runner import ISSUE_74_BASELINE_SHA, REPO_ROOT
+
+
+def _run(command: list[str], *, cwd: Path) -> None:
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def build_baseline(output: Path, *, cargo: str, baseline_sha: str = ISSUE_74_BASELINE_SHA) -> None:
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_root = Path(tempfile.mkdtemp(prefix="reld-issue74-baseline-", dir=os.environ.get("RUNNER_TEMP")))
+    worktree = temporary_root / "source"
+    target_dir = temporary_root / "target"
+    registered = False
+    try:
+        _run(["git", "fetch", "--no-tags", "--depth=1", "origin", baseline_sha], cwd=REPO_ROOT)
+        _run(["git", "worktree", "add", "--detach", str(worktree), baseline_sha], cwd=REPO_ROOT)
+        registered = True
+        _run(
+            [
+                cargo,
+                "build",
+                "--locked",
+                "--release",
+                "--package",
+                "reld",
+                "--bin",
+                "reld",
+                "--manifest-path",
+                str(worktree / "Cargo.toml"),
+                "--target-dir",
+                str(target_dir),
+            ],
+            cwd=worktree,
+        )
+        binary_name = "reld.exe" if os.name == "nt" else "reld"
+        shutil.copy2(target_dir / "release" / binary_name, output)
+    finally:
+        if registered:
+            subprocess.run(["git", "worktree", "remove", "--force", str(worktree)], cwd=REPO_ROOT, check=False)
+        shutil.rmtree(temporary_root, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--cargo", default=os.environ.get("CARGO_COMMAND", "cargo"))
+    parser.add_argument("--baseline-sha", default=ISSUE_74_BASELINE_SHA)
+    args = parser.parse_args(argv)
+    build_baseline(args.output, cargo=args.cargo, baseline_sha=args.baseline_sha)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 import os
+import platform
 import re
 import shutil
 import statistics
@@ -58,6 +60,7 @@ class LinkCommand:
 class Linker:
     label: str
     path: Path | None = None
+    driver_arguments: tuple[str, ...] = ()
 
 
 _QUOTED_ARGUMENT = re.compile(r'"(?:\\.|[^"\\])*"')
@@ -303,10 +306,7 @@ def assert_significant_workload(
             continue
         fraction = largest_startup / reference_seconds
         if fraction > MAX_STARTUP_FRACTION:
-            failures.append(
-                f"{configuration.label}: largest startup {largest_startup:.4f}s is "
-                f"{fraction:.1%} of {reference} final link {reference_seconds:.4f}s"
-            )
+            failures.append(f"{configuration.label}: largest startup {largest_startup:.4f}s is {fraction:.1%} of {reference} final link {reference_seconds:.4f}s")
     if failures:
         calibration = f" (calibration target: {MIN_REFERENCE_LINK_SECONDS:.3f}s reference link)"
         raise BenchmarkError("startup-dominated workload" + calibration + ":\n" + "\n".join(failures))
@@ -376,13 +376,7 @@ def release_capture_artifacts(*, profile_dir: Path, target_dir: Path, log: TextI
     allowed_profiles = {configuration.profile for configuration in CONFIGURATIONS}
     resolved_target = target_dir.resolve()
     is_junction = getattr(profile_dir, "is_junction", lambda: False)
-    if (
-        profile_dir.name not in allowed_profiles
-        or profile_dir.parent.resolve() != resolved_target
-        or profile_dir.is_symlink()
-        or is_junction()
-        or profile_dir.resolve().parent != resolved_target
-    ):
+    if profile_dir.name not in allowed_profiles or profile_dir.parent.resolve() != resolved_target or profile_dir.is_symlink() or is_junction() or profile_dir.resolve().parent != resolved_target:
         raise BenchmarkError(f"refusing to release unsafe capture profile: {profile_dir}")
     if profile_dir.exists():
         shutil.rmtree(profile_dir)
@@ -416,7 +410,7 @@ def _validate_executable(output: Path, *, cwd: Path, environment: dict[str, str]
         check=False,
     )
     if completed.returncode or "OK" not in completed.stdout:
-        raise BenchmarkError(f"linked output failed its OK oracle ({completed.returncode}):\n" f"{completed.stdout}{completed.stderr}")
+        raise BenchmarkError(f"linked output failed its OK oracle ({completed.returncode}):\n{completed.stdout}{completed.stderr}")
 
 
 def _discard_verified_output(output: Path) -> Path | None:
@@ -470,6 +464,8 @@ def benchmark_replay(
     warmup: int,
     trials: int,
     use_driver_shim: bool,
+    sample_sink: list[float] | None = None,
+    output_size_sink: list[int] | None = None,
 ) -> float:
     output_dir.mkdir(parents=True, exist_ok=True)
     suffix = ".exe" if captured.windows else ""
@@ -483,6 +479,7 @@ def benchmark_replay(
         linker_shim = driver_linker_dir / "ld"
         linker_shim.unlink(missing_ok=True)
         linker_shim.symlink_to(linker.path)
+
     def prepare_replay(output: Path) -> list[str]:
         response_file = output.with_suffix(output.suffix + ".rsp")
         command, response = replay_command(
@@ -493,6 +490,7 @@ def benchmark_replay(
             response_file=response_file,
             driver_linker_dir=driver_linker_dir,
         )
+        command.extend(linker.driver_arguments)
         if response is not None:
             response_file.write_text(response, encoding="utf-8", newline="\n")
         return command
@@ -522,6 +520,8 @@ def benchmark_replay(
             # The oracle runs after the timer stops, once for every produced executable. A bad
             # early trial therefore cannot enter the median and then be hidden by an overwrite.
             _validate_executable(output, cwd=cwd, environment=environment)
+            if output_size_sink is not None:
+                output_size_sink.append(output.stat().st_size)
             if quarantine := _discard_verified_output(output):
                 quarantines.append(quarantine)
     finally:
@@ -529,7 +529,155 @@ def benchmark_replay(
         # Start and join all one-shot helpers only after this linker's timed samples are complete.
         _reclaim_quarantines(quarantines)
 
+    if sample_sink is not None:
+        sample_sink.extend(samples)
     return statistics.median(samples)
+
+
+def _rotated(items: tuple[Linker, ...], offset: int) -> tuple[Linker, ...]:
+    if not items:
+        return ()
+    split = offset % len(items)
+    return items[split:] + items[:split]
+
+
+def benchmark_linkers_round_robin(
+    captured: LinkCommand,
+    linkers: tuple[Linker, ...],
+    *,
+    output_dir: Path,
+    cwd: Path,
+    environment: dict[str, str],
+    warmup: int,
+    trials: int,
+    use_driver_shim: bool,
+) -> tuple[dict[str, float], dict[str, list[float]], dict[str, list[int]], list[list[str]]]:
+    """Replay linkers in rotating order so cache/writeback position cannot pick a winner."""
+    if not linkers:
+        raise BenchmarkError("at least one linker is required")
+
+    samples = {linker.label: [] for linker in linkers}
+    output_sizes = {linker.label: [] for linker in linkers}
+    orders: list[list[str]] = []
+    for round_index in range(warmup + trials):
+        order = _rotated(linkers, round_index)
+        if round_index >= warmup:
+            orders.append([linker.label for linker in order])
+        for linker in order:
+            one_sample: list[float] = []
+            one_size: list[int] = []
+            benchmark_replay(
+                captured,
+                linker,
+                output_dir=output_dir / linker.label.replace("/", "-"),
+                cwd=cwd,
+                environment=environment,
+                warmup=0,
+                trials=1,
+                use_driver_shim=use_driver_shim,
+                sample_sink=one_sample,
+                output_size_sink=one_size,
+            )
+            if round_index >= warmup:
+                samples[linker.label].extend(one_sample)
+                output_sizes[linker.label].extend(one_size)
+
+    medians = {label: statistics.median(values) for label, values in samples.items()}
+    return medians, samples, output_sizes, orders
+
+
+def _sample_summary(samples: list[float]) -> dict[str, float | list[float]]:
+    median = statistics.median(samples)
+    deviations = [abs(sample - median) for sample in samples]
+    return {
+        "samples_seconds": samples,
+        "median_seconds": median,
+        "median_absolute_deviation_seconds": statistics.median(deviations),
+        "min_seconds": min(samples),
+        "max_seconds": max(samples),
+    }
+
+
+def _linux_filesystem_type(path: Path, environment: dict[str, str]) -> str:
+    completed = subprocess.run(
+        ["findmnt", "--noheadings", "--output", "FSTYPE", "--target", str(path)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode:
+        raise BenchmarkError(f"unable to identify benchmark filesystem:\n{completed.stderr}")
+    filesystem = completed.stdout.strip()
+    if not filesystem:
+        raise BenchmarkError("findmnt reported an empty benchmark filesystem type")
+    return filesystem
+
+
+_PHASE_NAMES = (
+    "Create output file",
+    "Wait for output file creation",
+    "Compute build ID",
+    "Write data to file",
+    "Flush and unmap output file",
+)
+
+
+def _parse_phase_timings(output: str) -> dict[str, float]:
+    phases: dict[str, float] = {}
+    for line in output.splitlines():
+        for name in _PHASE_NAMES:
+            match = re.search(rf"([0-9]+(?:\.[0-9]+)?)\s+{re.escape(name)}\s*$", line)
+            if match:
+                phases[name] = float(match.group(1)) / 1000.0
+    required = {"Compute build ID", "Write data to file", "Flush and unmap output file"}
+    missing = sorted(required - phases.keys())
+    if missing:
+        raise BenchmarkError(f"reld phase trace omitted required phases: {', '.join(missing)}\n{output}")
+    return phases
+
+
+def capture_reld_phase_trace(
+    captured: LinkCommand,
+    linker: Linker,
+    *,
+    output_dir: Path,
+    cwd: Path,
+    environment: dict[str, str],
+) -> tuple[dict[str, float], int, str]:
+    """Run one untimed, validated reld link with phase instrumentation enabled."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / "phase-trace"
+    driver_dir = output_dir / "driver"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    if linker.path is None:
+        raise BenchmarkError("no executable resolved for reld phase trace")
+    shim = driver_dir / "ld"
+    shim.unlink(missing_ok=True)
+    shim.symlink_to(linker.path)
+    command, response = replay_command(
+        captured,
+        linker=linker.label,
+        linker_path=linker.path,
+        output=output,
+        response_file=output.with_suffix(".rsp"),
+        driver_linker_dir=driver_dir,
+    )
+    if response is not None:
+        raise BenchmarkError("Linux phase trace unexpectedly required a response file")
+    command.extend(linker.driver_arguments)
+    command.extend(("-Wl,--time", "-Wl,--no-fork"))
+    completed = _run_link(command, cwd=cwd, environment=environment)
+    if completed.returncode:
+        raise BenchmarkError(f"reld phase trace failed:\n{completed.stdout}{completed.stderr}")
+    _validate_executable(output, cwd=cwd, environment=environment)
+    output_size = output.stat().st_size
+    combined_output = completed.stdout + completed.stderr
+    phases = _parse_phase_timings(combined_output)
+    _discard_verified_output(output)
+    return phases, output_size, combined_output
 
 
 def run_benchmark(
@@ -543,12 +691,34 @@ def run_benchmark(
     trials: int,
     warmup: int,
     log: TextIO,
+    output_mode_report: Path | None = None,
 ) -> str:
     environment = benchmark_environment()
     linkers = linkers_for_target(target, reld)
     use_driver_shim = "linux" in target.lower()
     startup_seconds: dict[str, float] | None = None
     final_links: dict[str, dict[str, float]] = {}
+    diagnostic_report: dict[str, object] | None = None
+    if output_mode_report is not None:
+        diagnostic_report = {
+            "schema_version": 1,
+            "target": target,
+            "status": "measured" if use_driver_shim else "not-applicable",
+            "metadata": {},
+            "configurations": {},
+        }
+        if use_driver_shim:
+            workdir.mkdir(parents=True, exist_ok=True)
+            thread_count = os.cpu_count() or 1
+            diagnostic_report["metadata"] = {
+                "runner_os": platform.platform(),
+                "kernel": platform.release(),
+                "machine": platform.machine(),
+                "filesystem": _linux_filesystem_type(workdir, environment),
+                "thread_count": thread_count,
+                "output_mode": "explicit per contender",
+                "timing_scope": "captured final native link only",
+            }
     for configuration in CONFIGURATIONS:
         captured = capture_final_link(
             configuration,
@@ -576,19 +746,65 @@ def run_benchmark(
                 for linker in linkers
             }
         try:
-            final_links[configuration.label] = {
-                linker.label: benchmark_replay(
+            medians, _samples, _sizes, _orders = benchmark_linkers_round_robin(
+                captured,
+                linkers,
+                output_dir=workdir / configuration.profile / "published",
+                cwd=manifest.parent,
+                environment=environment,
+                warmup=warmup,
+                trials=trials,
+                use_driver_shim=use_driver_shim,
+            )
+            final_links[configuration.label] = medians
+
+            if diagnostic_report is not None and use_driver_shim:
+                metadata = diagnostic_report["metadata"]
+                assert isinstance(metadata, dict)
+                thread_count = metadata["thread_count"]
+                common_arguments = (f"-Wl,--threads={thread_count}",)
+                modes = (
+                    Linker("default", reld.absolute(), common_arguments),
+                    Linker("mmap", reld.absolute(), common_arguments + ("-Wl,--mmap-output-file",)),
+                    Linker("buffer", reld.absolute(), common_arguments + ("-Wl,--no-mmap-output-file",)),
+                )
+                _, mode_samples, mode_sizes, mode_orders = benchmark_linkers_round_robin(
                     captured,
-                    linker,
-                    output_dir=workdir / configuration.profile,
+                    modes,
+                    output_dir=workdir / configuration.profile / "output-modes",
                     cwd=manifest.parent,
                     environment=environment,
                     warmup=warmup,
                     trials=trials,
-                    use_driver_shim=use_driver_shim,
+                    use_driver_shim=True,
                 )
-                for linker in linkers
-            }
+                configuration_report: dict[str, object] = {
+                    "trial_orders": mode_orders,
+                    "modes": {},
+                }
+                mode_reports = configuration_report["modes"]
+                assert isinstance(mode_reports, dict)
+                for mode in modes:
+                    sizes = mode_sizes[mode.label]
+                    if not sizes or min(sizes) < 240 * 1024 * 1024:
+                        raise BenchmarkError(f"{configuration.label}/{mode.label} output is not approximately 256 MiB: {sizes}")
+                    phases, phase_output_size, phase_trace = capture_reld_phase_trace(
+                        captured,
+                        mode,
+                        output_dir=workdir / configuration.profile / "phase-traces" / mode.label,
+                        cwd=manifest.parent,
+                        environment=environment,
+                    )
+                    mode_reports[mode.label] = {
+                        **_sample_summary(mode_samples[mode.label]),
+                        "output_sizes_bytes": sizes,
+                        "phase_output_size_bytes": phase_output_size,
+                        "phase_seconds": phases,
+                        "phase_trace": phase_trace,
+                    }
+                configurations = diagnostic_report["configurations"]
+                assert isinstance(configurations, dict)
+                configurations[configuration.label] = configuration_report
         finally:
             # Only one configuration's retained native-link inputs live at a time. Compilation
             # and any Rust LTO preparation still happen once, before this configuration's timed
@@ -608,12 +824,7 @@ def run_benchmark(
         "| Configuration | " + " | ".join(linker.label for linker in linkers) + " |",
         "|:--------------|" + "|".join("----:" for _ in linkers) + "|",
     ]
-    lines.extend(
-        f"| {configuration.label} | "
-        + " | ".join(f"{final_links[configuration.label][linker.label]:.4f}" for linker in linkers)
-        + " |"
-        for configuration in CONFIGURATIONS
-    )
+    lines.extend(f"| {configuration.label} | " + " | ".join(f"{final_links[configuration.label][linker.label]:.4f}" for linker in linkers) + " |" for configuration in CONFIGURATIONS)
     lines.extend(
         [
             "",
@@ -631,6 +842,9 @@ def run_benchmark(
     # calibration diagnosable without subtracting startup or weakening the publication gate.
     log.write(table)
     log.flush()
+    if output_mode_report is not None and diagnostic_report is not None:
+        output_mode_report.parent.mkdir(parents=True, exist_ok=True)
+        output_mode_report.write_text(json.dumps(diagnostic_report, indent=2) + "\n", encoding="utf-8")
     assert_significant_workload(target, startup_seconds, final_links)
     return table
 
@@ -645,6 +859,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--target-dir", type=Path, default=REPO_ROOT / "target" / "link-benchmark")
     parser.add_argument("--trials", type=int, default=5)
     parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--output-mode-report", type=Path)
     args = parser.parse_args(argv)
 
     if not args.reld.is_file():
@@ -667,6 +882,7 @@ def main(argv: list[str] | None = None) -> int:
                 trials=args.trials,
                 warmup=args.warmup,
                 log=log,
+                output_mode_report=args.output_mode_report,
             )
             # ``run_benchmark`` writes the evidence before applying the significance gate.
     except BenchmarkError as error:

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -29,6 +29,7 @@ DEFAULT_MANIFEST = REPO_ROOT / "ci" / "e2e" / "link-workload" / "Cargo.toml"
 BENCHMARK_PACKAGE = "linkbench-app"
 MIN_REFERENCE_LINK_SECONDS = 0.500
 MAX_STARTUP_FRACTION = 0.10
+MIN_OUTPUT_MODE_IMPROVEMENT = 0.10
 
 
 class BenchmarkError(RuntimeError):
@@ -244,7 +245,7 @@ def linkers_for_target(target: str, reld: Path) -> tuple[Linker, ...]:
             Linker("lld", _required_tool("ld.lld")),
             Linker("mold", _required_tool("ld.mold", "mold")),
             Linker("wild", _required_tool("ld.wild", "wild")),
-            Linker("reld", reld.absolute()),
+            Linker("reld", reld.absolute(), ("-Wl,--engine=reld",)),
         )
     raise BenchmarkError(f"unsupported benchmark target {target!r}")
 
@@ -334,6 +335,33 @@ def assert_significant_workload(
     if failures:
         calibration = f" (calibration target: {MIN_REFERENCE_LINK_SECONDS:.3f}s reference link)"
         raise BenchmarkError("startup-dominated workload" + calibration + ":\n" + "\n".join(failures))
+
+
+def assert_output_mode_improvement(diagnostic_report: dict[str, object]) -> None:
+    """Require the optimized Linux default to beat the prior explicit-mmap path in every row."""
+    if diagnostic_report.get("status") != "measured":
+        return
+    configurations = diagnostic_report.get("configurations")
+    if not isinstance(configurations, dict):
+        raise BenchmarkError("output-mode diagnostics omitted configurations")
+
+    failures: list[str] = []
+    for configuration in CONFIGURATIONS:
+        configuration_report = configurations.get(configuration.label)
+        modes = configuration_report.get("modes") if isinstance(configuration_report, dict) else None
+        default = modes.get("default") if isinstance(modes, dict) else None
+        mmap = modes.get("mmap") if isinstance(modes, dict) else None
+        default_seconds = default.get("median_seconds") if isinstance(default, dict) else None
+        mmap_seconds = mmap.get("median_seconds") if isinstance(mmap, dict) else None
+        if not isinstance(default_seconds, int | float) or not isinstance(mmap_seconds, int | float) or mmap_seconds <= 0:
+            failures.append(f"{configuration.label}: missing paired default/mmap medians")
+            continue
+        improvement = 1.0 - (default_seconds / mmap_seconds)
+        configuration_report["default_vs_mmap_improvement_fraction"] = improvement
+        if improvement + 1e-12 < MIN_OUTPUT_MODE_IMPROVEMENT:
+            failures.append(f"{configuration.label}: default improved {improvement:.1%} over mmap ({default_seconds:.4f}s vs {mmap_seconds:.4f}s; required {MIN_OUTPUT_MODE_IMPROVEMENT:.0%})")
+    if failures:
+        raise BenchmarkError("large-output optimization missed its paired performance gate:\n" + "\n".join(failures))
 
 
 def capture_final_link(
@@ -658,7 +686,7 @@ def _parse_phase_timings(output: str) -> dict[str, float]:
             match = re.search(rf"([0-9]+(?:\.[0-9]+)?)\s+{re.escape(name)}\s*$", line)
             if match:
                 phases[name] = float(match.group(1)) / 1000.0
-    required = {"Compute build ID", "Write data to file", "Flush and unmap output file"}
+    required = {"Create output file", "Compute build ID", "Write data to file", "Flush and unmap output file"}
     missing = sorted(required - phases.keys())
     if missing:
         raise BenchmarkError(f"reld phase trace omitted required phases: {', '.join(missing)}\n{output}")
@@ -868,9 +896,16 @@ def run_benchmark(
     # calibration diagnosable without subtracting startup or weakening the publication gate.
     log.write(table)
     log.flush()
+    output_mode_error: BenchmarkError | None = None
     if output_mode_report is not None and diagnostic_report is not None:
+        try:
+            assert_output_mode_improvement(diagnostic_report)
+        except BenchmarkError as error:
+            output_mode_error = error
         output_mode_report.parent.mkdir(parents=True, exist_ok=True)
         output_mode_report.write_text(json.dumps(diagnostic_report, indent=2) + "\n", encoding="utf-8")
+    if output_mode_error is not None:
+        raise output_mode_error
     assert_significant_workload(target, startup_seconds, final_links)
     return table
 

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -251,6 +251,16 @@ def reference_linker_for_target(target: str) -> str:
     return {"linux": "wild", "macos": "ld64.lld", "windows": "lld"}[_target_family(target)]
 
 
+def reld_output_mode_linkers(reld: Path, thread_count: int) -> tuple[Linker, ...]:
+    """Return explicit native-reld output modes for the Linux writer diagnostic."""
+    common_arguments = ("-Wl,--engine=reld", f"-Wl,--threads={thread_count}")
+    return (
+        Linker("default", reld.absolute(), common_arguments),
+        Linker("mmap", reld.absolute(), common_arguments + ("-Wl,--mmap-output-file",)),
+        Linker("buffer", reld.absolute(), common_arguments + ("-Wl,--no-mmap-output-file",)),
+    )
+
+
 def startup_probe_command(target: str, linker: Linker, captured: LinkCommand | None = None) -> list[str]:
     """Build a target-correct, no-link-work command that still loads the concrete linker."""
     executable = str(linker.path) if linker.path is not None else None
@@ -762,12 +772,7 @@ def run_benchmark(
                 metadata = diagnostic_report["metadata"]
                 assert isinstance(metadata, dict)
                 thread_count = metadata["thread_count"]
-                common_arguments = (f"-Wl,--threads={thread_count}",)
-                modes = (
-                    Linker("default", reld.absolute(), common_arguments),
-                    Linker("mmap", reld.absolute(), common_arguments + ("-Wl,--mmap-output-file",)),
-                    Linker("buffer", reld.absolute(), common_arguments + ("-Wl,--no-mmap-output-file",)),
-                )
+                modes = reld_output_mode_linkers(reld, thread_count)
                 _, mode_samples, mode_sizes, mode_orders = benchmark_linkers_round_robin(
                     captured,
                     modes,

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -78,10 +78,17 @@ _LINK_DRIVER_NAMES = {
 }
 
 
-def cargo_capture_command(*, cargo: str, manifest: Path, profile: str, target_dir: Path) -> list[str]:
+def cargo_capture_command(
+    *,
+    cargo: str,
+    manifest: Path,
+    profile: str,
+    target_dir: Path,
+    linker: str | None = None,
+) -> list[str]:
     if not cargo or any(character.isspace() for character in cargo):
         raise BenchmarkError("CARGO_COMMAND must name one executable")
-    return [
+    command = [
         cargo,
         "rustc",
         "--locked",
@@ -94,11 +101,18 @@ def cargo_capture_command(*, cargo: str, manifest: Path, profile: str, target_di
         "--target-dir",
         str(target_dir),
         "--",
-        "-C",
-        "save-temps=yes",
-        "--print",
-        "link-args",
     ]
+    if linker is not None:
+        command.extend(("-C", f"linker={linker}"))
+    command.extend(
+        (
+            "-C",
+            "save-temps=yes",
+            "--print",
+            "link-args",
+        )
+    )
+    return command
 
 
 def benchmark_environment() -> dict[str, str]:
@@ -330,12 +344,14 @@ def capture_final_link(
     target_dir: Path,
     environment: dict[str, str],
     log: TextIO,
+    linker: str | None = None,
 ) -> LinkCommand:
     command = cargo_capture_command(
         cargo=cargo,
         manifest=manifest,
         profile=configuration.profile,
         target_dir=target_dir,
+        linker=linker,
     )
     print(f"capturing {configuration.label}: {' '.join(command)}", file=log, flush=True)
     completed = subprocess.run(
@@ -737,6 +753,11 @@ def run_benchmark(
             target_dir=target_dir,
             environment=environment,
             log=log,
+            # GCC's collect2 injects a passive LTO plugin even when rustc has already emitted
+            # native objects. That makes the conservative reld router bridge an otherwise native
+            # final link. Clang is provisioned on Linux and replays the same target-native inputs
+            # without manufacturing a plugin request.
+            linker="clang" if use_driver_shim else None,
         )
         prune_capture_artifacts(
             captured,

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -27,6 +27,7 @@ from typing import TextIO
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MANIFEST = REPO_ROOT / "ci" / "e2e" / "link-workload" / "Cargo.toml"
 BENCHMARK_PACKAGE = "linkbench-app"
+ISSUE_74_BASELINE_SHA = "be6a8cd032ea6dc788978264c860fe761d5090b6"
 MIN_REFERENCE_LINK_SECONDS = 0.500
 MAX_STARTUP_FRACTION = 0.10
 MIN_OUTPUT_MODE_IMPROVEMENT = 0.10
@@ -266,10 +267,11 @@ def reference_linker_for_target(target: str) -> str:
     return {"linux": "wild", "macos": "ld64.lld", "windows": "lld"}[_target_family(target)]
 
 
-def reld_output_mode_linkers(reld: Path, thread_count: int) -> tuple[Linker, ...]:
-    """Return explicit native-reld output modes for the Linux writer diagnostic."""
+def reld_output_mode_linkers(reld: Path, baseline_reld: Path, thread_count: int) -> tuple[Linker, ...]:
+    """Return HEAD modes plus the fixed pre-issue baseline for the Linux diagnostic."""
     common_arguments = ("-Wl,--engine=reld", f"-Wl,--threads={thread_count}")
     return (
+        Linker("baseline", baseline_reld.absolute(), common_arguments + ("-Wl,--mmap-output-file",)),
         Linker("default", reld.absolute(), common_arguments),
         Linker("mmap", reld.absolute(), common_arguments + ("-Wl,--mmap-output-file",)),
         Linker("buffer", reld.absolute(), common_arguments + ("-Wl,--no-mmap-output-file",)),
@@ -338,7 +340,7 @@ def assert_significant_workload(
 
 
 def assert_output_mode_improvement(diagnostic_report: dict[str, object]) -> None:
-    """Require the optimized Linux default to beat the prior explicit-mmap path in every row."""
+    """Require HEAD to beat the exact pre-issue baseline binary in every Linux row."""
     if diagnostic_report.get("status") != "measured":
         return
     configurations = diagnostic_report.get("configurations")
@@ -350,16 +352,20 @@ def assert_output_mode_improvement(diagnostic_report: dict[str, object]) -> None
         configuration_report = configurations.get(configuration.label)
         modes = configuration_report.get("modes") if isinstance(configuration_report, dict) else None
         default = modes.get("default") if isinstance(modes, dict) else None
+        baseline = modes.get("baseline") if isinstance(modes, dict) else None
         mmap = modes.get("mmap") if isinstance(modes, dict) else None
         default_seconds = default.get("median_seconds") if isinstance(default, dict) else None
+        baseline_seconds = baseline.get("median_seconds") if isinstance(baseline, dict) else None
         mmap_seconds = mmap.get("median_seconds") if isinstance(mmap, dict) else None
-        if not isinstance(default_seconds, int | float) or not isinstance(mmap_seconds, int | float) or mmap_seconds <= 0:
-            failures.append(f"{configuration.label}: missing paired default/mmap medians")
+        if not isinstance(default_seconds, int | float) or not isinstance(baseline_seconds, int | float) or baseline_seconds <= 0:
+            failures.append(f"{configuration.label}: missing paired HEAD/baseline medians")
             continue
-        improvement = 1.0 - (default_seconds / mmap_seconds)
-        configuration_report["default_vs_mmap_improvement_fraction"] = improvement
+        improvement = 1.0 - (default_seconds / baseline_seconds)
+        configuration_report["head_vs_baseline_improvement_fraction"] = improvement
+        if isinstance(mmap_seconds, int | float) and mmap_seconds > 0:
+            configuration_report["default_vs_mmap_improvement_fraction"] = 1.0 - (default_seconds / mmap_seconds)
         if improvement + 1e-12 < MIN_OUTPUT_MODE_IMPROVEMENT:
-            failures.append(f"{configuration.label}: default improved {improvement:.1%} over mmap ({default_seconds:.4f}s vs {mmap_seconds:.4f}s; required {MIN_OUTPUT_MODE_IMPROVEMENT:.0%})")
+            failures.append(f"{configuration.label}: HEAD improved {improvement:.1%} over baseline ({default_seconds:.4f}s vs {baseline_seconds:.4f}s; required {MIN_OUTPUT_MODE_IMPROVEMENT:.0%})")
     if failures:
         raise BenchmarkError("large-output optimization missed its paired performance gate:\n" + "\n".join(failures))
 
@@ -746,6 +752,7 @@ def run_benchmark(
     warmup: int,
     log: TextIO,
     output_mode_report: Path | None = None,
+    baseline_reld: Path | None = None,
 ) -> str:
     environment = benchmark_environment()
     linkers = linkers_for_target(target, reld)
@@ -762,6 +769,8 @@ def run_benchmark(
             "configurations": {},
         }
         if use_driver_shim:
+            if baseline_reld is None or not baseline_reld.is_file():
+                raise BenchmarkError("Linux output-mode diagnostics require the exact baseline reld binary")
             workdir.mkdir(parents=True, exist_ok=True)
             thread_count = os.cpu_count() or 1
             diagnostic_report["metadata"] = {
@@ -772,6 +781,7 @@ def run_benchmark(
                 "thread_count": thread_count,
                 "output_mode": "explicit per contender",
                 "timing_scope": "captured final native link only",
+                "baseline_sha": ISSUE_74_BASELINE_SHA,
             }
     for configuration in CONFIGURATIONS:
         captured = capture_final_link(
@@ -821,7 +831,8 @@ def run_benchmark(
                 metadata = diagnostic_report["metadata"]
                 assert isinstance(metadata, dict)
                 thread_count = metadata["thread_count"]
-                modes = reld_output_mode_linkers(reld, thread_count)
+                assert baseline_reld is not None
+                modes = reld_output_mode_linkers(reld, baseline_reld, thread_count)
                 _, mode_samples, mode_sizes, mode_orders = benchmark_linkers_round_robin(
                     captured,
                     modes,
@@ -921,6 +932,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--trials", type=int, default=5)
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument("--output-mode-report", type=Path)
+    parser.add_argument("--baseline-reld", type=Path)
     args = parser.parse_args(argv)
 
     if not args.reld.is_file():
@@ -944,6 +956,7 @@ def main(argv: list[str] | None = None) -> int:
                 warmup=args.warmup,
                 log=log,
                 output_mode_report=args.output_mode_report,
+                baseline_reld=args.baseline_reld,
             )
             # ``run_benchmark`` writes the evidence before applying the significance gate.
     except BenchmarkError as error:

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -685,14 +685,16 @@ _PHASE_NAMES = (
 )
 
 
-def _parse_phase_timings(output: str) -> dict[str, float]:
+def _parse_phase_timings(output: str, *, require_creation: bool = True) -> dict[str, float]:
     phases: dict[str, float] = {}
     for line in output.splitlines():
         for name in _PHASE_NAMES:
             match = re.search(rf"([0-9]+(?:\.[0-9]+)?)\s+{re.escape(name)}\s*$", line)
             if match:
                 phases[name] = float(match.group(1)) / 1000.0
-    required = {"Create output file", "Compute build ID", "Write data to file", "Flush and unmap output file"}
+    required = {"Compute build ID", "Write data to file", "Flush and unmap output file"}
+    if require_creation:
+        required.add("Create output file")
     missing = sorted(required - phases.keys())
     if missing:
         raise BenchmarkError(f"reld phase trace omitted required phases: {', '.join(missing)}\n{output}")
@@ -706,6 +708,7 @@ def capture_reld_phase_trace(
     output_dir: Path,
     cwd: Path,
     environment: dict[str, str],
+    require_creation: bool = True,
 ) -> tuple[dict[str, float], int, str]:
     """Run one untimed, validated reld link with phase instrumentation enabled."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -735,7 +738,7 @@ def capture_reld_phase_trace(
     _validate_executable(output, cwd=cwd, environment=environment)
     output_size = output.stat().st_size
     combined_output = completed.stdout + completed.stderr
-    phases = _parse_phase_timings(combined_output)
+    phases = _parse_phase_timings(combined_output, require_creation=require_creation)
     _discard_verified_output(output)
     return phases, output_size, combined_output
 
@@ -833,6 +836,8 @@ def run_benchmark(
                 thread_count = metadata["thread_count"]
                 assert baseline_reld is not None
                 modes = reld_output_mode_linkers(reld, baseline_reld, thread_count)
+                diagnostic_trials = max(trials, len(modes))
+                diagnostic_trials = diagnostic_trials + (-diagnostic_trials % len(modes))
                 _, mode_samples, mode_sizes, mode_orders = benchmark_linkers_round_robin(
                     captured,
                     modes,
@@ -840,11 +845,12 @@ def run_benchmark(
                     cwd=manifest.parent,
                     environment=environment,
                     warmup=warmup,
-                    trials=trials,
+                    trials=diagnostic_trials,
                     use_driver_shim=True,
                 )
                 configuration_report: dict[str, object] = {
                     "trial_orders": mode_orders,
+                    "trials_per_mode": diagnostic_trials,
                     "modes": {},
                 }
                 mode_reports = configuration_report["modes"]
@@ -859,6 +865,7 @@ def run_benchmark(
                         output_dir=workdir / configuration.profile / "phase-traces" / mode.label,
                         cwd=manifest.parent,
                         environment=environment,
+                        require_creation=mode.label != "baseline",
                     )
                     mode_reports[mode.label] = {
                         **_sample_summary(mode_samples[mode.label]),
@@ -866,6 +873,7 @@ def run_benchmark(
                         "phase_output_size_bytes": phase_output_size,
                         "phase_seconds": phases,
                         "phase_trace": phase_trace,
+                        "phase_schema": "legacy-pre-creation-instrumentation" if mode.label == "baseline" else "current",
                     }
                 configurations = diagnostic_report["configurations"]
                 assert isinstance(configurations, dict)

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -483,13 +483,7 @@ def validate_startup_and_significance(payload: dict[str, Any], target: str) -> l
         reference = REFERENCE_SERIES[target]
         for scenario in CANONICAL_SCENARIOS:
             reference_cell = next(
-                (
-                    entry
-                    for entry in results
-                    if isinstance(entry, dict)
-                    and entry.get("configuration") == scenario
-                    and entry.get("series") == reference
-                ),
+                (entry for entry in results if isinstance(entry, dict) and entry.get("configuration") == scenario and entry.get("series") == reference),
                 None,
             )
             seconds = reference_cell.get("seconds") if reference_cell else None
@@ -497,9 +491,7 @@ def validate_startup_and_significance(payload: dict[str, Any], target: str) -> l
                 continue
             fraction = largest / seconds
             if fraction > MAX_STARTUP_FRACTION:
-                errors.append(
-                    f"{target}: {scenario} is startup-dominated ({fraction:.1%}; limit {MAX_STARTUP_FRACTION:.0%})"
-                )
+                errors.append(f"{target}: {scenario} is startup-dominated ({fraction:.1%}; limit {MAX_STARTUP_FRACTION:.0%})")
     return errors
 
 
@@ -723,10 +715,7 @@ def render_jpg(report: Report, meta: dict[str, Any], out_path: Path) -> None:
         d.line([(20 * SCALE, y * SCALE), ((WIDTH - 20) * SCALE, y * SCALE)], fill=GRID, width=SCALE)
         y += 8
 
-    startup_text = "  |  ".join(
-        f"{series_label(series, meta['runner']['os'], meta.get('target', ''))}: {seconds:.4f}s"
-        for series, seconds in report.startup_seconds.items()
-    )
+    startup_text = "  |  ".join(f"{series_label(series, meta['runner']['os'], meta.get('target', ''))}: {seconds:.4f}s" for series, seconds in report.startup_seconds.items())
     d.text((20 * SCALE, (y + 6) * SCALE), "fixed linker startup (not subtracted)", font=f_meta, fill=FG)
     d.text((20 * SCALE, (y + 25) * SCALE), startup_text or "startup data missing", font=f_meta, fill=MUTED)
 
@@ -757,10 +746,7 @@ def render_html(report: Report, meta: dict[str, Any]) -> str:
             else:
                 cells += '<td class="na">n/a</td>'
         body += f"<tr><td>{sc}</td>{cells}</tr>"
-    startup_body = "".join(
-        f"<tr><td>{series_label(series, runner_os, target)}</td><td>{seconds:.4f}s</td></tr>"
-        for series, seconds in report.startup_seconds.items()
-    )
+    startup_body = "".join(f"<tr><td>{series_label(series, runner_os, target)}</td><td>{seconds:.4f}s</td></tr>" for series, seconds in report.startup_seconds.items())
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>reld benchmarks</title>
 <style>

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -33,7 +33,7 @@ from typing import Any
 from urllib.request import urlopen
 
 SCHEMA_VERSION = 6
-BENCHMARK_ID = "artifact-auditor-lto-v1"
+BENCHMARK_ID = "artifact-auditor-native-linux-lto-v2"
 HISTORY_MAX_LINES = 1000
 IMAGE_NAME = "benchmark-link.jpg"
 HEADING_PREFIX = "## Link Benchmark:"

--- a/ci/tests/test_benchmark_baseline.py
+++ b/ci/tests/test_benchmark_baseline.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import ci.benchmark_baseline as baseline_module
+from ci.benchmark_runner import ISSUE_74_BASELINE_SHA
+
+
+def test_baseline_builder_uses_isolated_exact_sha_worktree(tmp_path: Path, monkeypatch):
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], *, cwd: Path) -> None:
+        del cwd
+        commands.append(command)
+        if command[:3] == ["git", "worktree", "add"]:
+            Path(command[-2]).mkdir(parents=True)
+        if "--target-dir" in command:
+            target_dir = Path(command[command.index("--target-dir") + 1])
+            binary = target_dir / "release" / ("reld.exe" if baseline_module.os.name == "nt" else "reld")
+            binary.parent.mkdir(parents=True)
+            binary.write_bytes(b"baseline-binary")
+
+    monkeypatch.setattr(baseline_module, "_run", fake_run)
+    monkeypatch.setattr(baseline_module.subprocess, "run", lambda *args, **kwargs: None)
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    output = tmp_path / "out" / "reld"
+
+    baseline_module.build_baseline(output, cargo="cargo")
+
+    assert output.read_bytes() == b"baseline-binary"
+    assert commands[0] == ["git", "fetch", "--no-tags", "--depth=1", "origin", ISSUE_74_BASELINE_SHA]
+    assert commands[1][-1] == ISSUE_74_BASELINE_SHA
+    assert "--locked" in commands[2]
+    assert "--release" in commands[2]

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -210,6 +210,33 @@ def test_linker_trials_rotate_order_and_preserve_every_sample(tmp_path: Path, mo
     assert set(medians) == {"wild", "reld", "mmap"}
 
 
+def test_four_diagnostic_contenders_each_occupy_every_round_position(tmp_path: Path, monkeypatch):
+    captured = LinkCommand("cc", ("main.o", "-o", "/old/app"), Path("/old/app"), False)
+    linkers = tuple(Linker(label, tmp_path / label) for label in ("baseline", "default", "mmap", "buffer"))
+
+    def fake_replay(captured, linker, *, sample_sink, output_size_sink, **kwargs):
+        del captured, linker, kwargs
+        sample_sink.append(1.0)
+        output_size_sink.append(256 * 1024 * 1024)
+        return 1.0
+
+    monkeypatch.setattr(runner_module, "benchmark_replay", fake_replay)
+
+    _, _, _, orders = benchmark_linkers_round_robin(
+        captured,
+        linkers,
+        output_dir=tmp_path / "out",
+        cwd=tmp_path,
+        environment={},
+        warmup=1,
+        trials=4,
+        use_driver_shim=True,
+    )
+
+    for linker in linkers:
+        assert {order.index(linker.label) for order in orders} == {0, 1, 2, 3}
+
+
 def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_path: Path, monkeypatch):
     report_path = tmp_path / "output-modes.json"
     baseline_reld = tmp_path / "baseline-reld"
@@ -222,10 +249,11 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
         return LinkCommand("clang", ("input.o", "-o", str(output)), output, False)
 
     def fake_round_robin(captured, linkers, **kwargs):
-        del captured, kwargs
-        samples = {linker.label: ([0.7, 0.8, 0.9] if linker.label == "default" else [0.9, 1.0, 1.1]) for linker in linkers}
-        sizes = {linker.label: [256 * 1024 * 1024] * 3 for linker in linkers}
-        orders = [[linker.label for linker in linkers]] * 3
+        del captured
+        trial_count = kwargs["trials"]
+        samples = {linker.label: ([0.8] * trial_count if linker.label == "default" else [1.0] * trial_count) for linker in linkers}
+        sizes = {linker.label: [256 * 1024 * 1024] * trial_count for linker in linkers}
+        orders = [[linker.label for linker in linkers]] * trial_count
         return ({linker.label: statistics.median(samples[linker.label]) for linker in linkers}, samples, sizes, orders)
 
     monkeypatch.setattr(runner_module, "linkers_for_target", lambda target, reld: (wild,))
@@ -272,8 +300,9 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
     assert set(report["configurations"]) == {"no-LTO", "ThinLTO", "full-LTO"}
     no_lto = report["configurations"]["no-LTO"]
     assert set(no_lto["modes"]) == {"baseline", "default", "mmap", "buffer"}
-    assert no_lto["modes"]["default"]["samples_seconds"] == [0.7, 0.8, 0.9]
-    assert no_lto["modes"]["default"]["output_sizes_bytes"] == [256 * 1024 * 1024] * 3
+    assert no_lto["trials_per_mode"] == 4
+    assert no_lto["modes"]["default"]["samples_seconds"] == [0.8] * 4
+    assert no_lto["modes"]["default"]["output_sizes_bytes"] == [256 * 1024 * 1024] * 4
     assert no_lto["modes"]["default"]["phase_seconds"]["Write data to file"] == 0.7
 
 
@@ -294,6 +323,9 @@ def test_reld_phase_trace_parser_requires_dominant_output_phases():
 
     with pytest.raises(BenchmarkError, match="omitted required phases"):
         _parse_phase_timings("12.50 Compute build ID\n")
+
+    legacy = output.replace("│ ├──     2.00 Create output file\n", "")
+    assert "Create output file" not in _parse_phase_timings(legacy, require_creation=False)
 
 
 def test_release_capture_artifacts_rejects_outside_directory(tmp_path: Path):

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -1,5 +1,6 @@
 import os
 import json
+import statistics
 from io import StringIO
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from ci.benchmark_runner import (
     Linker,
     _discard_verified_output,
     _parse_phase_timings,
+    assert_output_mode_improvement,
     assert_significant_workload,
     benchmark_environment,
     benchmark_linkers_round_robin,
@@ -219,10 +221,10 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
 
     def fake_round_robin(captured, linkers, **kwargs):
         del captured, kwargs
-        samples = {linker.label: [0.9, 1.0, 1.1] for linker in linkers}
+        samples = {linker.label: ([0.7, 0.8, 0.9] if linker.label == "default" else [0.9, 1.0, 1.1]) for linker in linkers}
         sizes = {linker.label: [256 * 1024 * 1024] * 3 for linker in linkers}
         orders = [[linker.label for linker in linkers]] * 3
-        return ({linker.label: 1.0 for linker in linkers}, samples, sizes, orders)
+        return ({linker.label: statistics.median(samples[linker.label]) for linker in linkers}, samples, sizes, orders)
 
     monkeypatch.setattr(runner_module, "linkers_for_target", lambda target, reld: (wild,))
     monkeypatch.setattr(runner_module, "benchmark_environment", lambda: {})
@@ -237,6 +239,7 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
         "capture_reld_phase_trace",
         lambda *args, **kwargs: (
             {
+                "Create output file": 0.02,
                 "Compute build ID": 0.05,
                 "Write data to file": 0.7,
                 "Flush and unmap output file": 0.01,
@@ -266,19 +269,21 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
     assert set(report["configurations"]) == {"no-LTO", "ThinLTO", "full-LTO"}
     no_lto = report["configurations"]["no-LTO"]
     assert set(no_lto["modes"]) == {"default", "mmap", "buffer"}
-    assert no_lto["modes"]["default"]["samples_seconds"] == [0.9, 1.0, 1.1]
+    assert no_lto["modes"]["default"]["samples_seconds"] == [0.7, 0.8, 0.9]
     assert no_lto["modes"]["default"]["output_sizes_bytes"] == [256 * 1024 * 1024] * 3
     assert no_lto["modes"]["default"]["phase_seconds"]["Write data to file"] == 0.7
 
 
 def test_reld_phase_trace_parser_requires_dominant_output_phases():
     output = """\
+│ ├──     2.00 Create output file
 │ ├──    12.50 Compute build ID
 │ ├──   625.25 Write data to file
 │ └──     8.00 Flush and unmap output file
 """
 
     assert _parse_phase_timings(output) == {
+        "Create output file": 0.002,
         "Compute build ID": 0.0125,
         "Write data to file": 0.62525,
         "Flush and unmap output file": 0.008,
@@ -339,6 +344,38 @@ def test_output_mode_diagnostics_force_the_native_reld_engine(tmp_path: Path):
     assert all("-Wl,--threads=4" in mode.driver_arguments for mode in modes)
     assert "-Wl,--mmap-output-file" in modes[1].driver_arguments
     assert "-Wl,--no-mmap-output-file" in modes[2].driver_arguments
+
+
+def test_published_linux_reld_forces_the_native_engine(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(runner_module, "_required_tool", lambda *names: tmp_path / names[0])
+
+    reld = next(linker for linker in runner_module.linkers_for_target("x86_64-linux", tmp_path / "reld") if linker.label == "reld")
+
+    assert reld.driver_arguments == ("-Wl,--engine=reld",)
+
+
+def test_paired_output_mode_gate_requires_ten_percent_in_every_lto_row():
+    def report(improvements: dict[str, float]) -> dict[str, object]:
+        return {
+            "status": "measured",
+            "configurations": {
+                configuration.label: {
+                    "modes": {
+                        "default": {"median_seconds": 1.0 - improvements[configuration.label]},
+                        "mmap": {"median_seconds": 1.0},
+                    }
+                }
+                for configuration in CONFIGURATIONS
+            },
+        }
+
+    passing = report({"no-LTO": 0.12, "ThinLTO": 0.11, "full-LTO": 0.10})
+    assert_output_mode_improvement(passing)
+    assert passing["configurations"]["no-LTO"]["default_vs_mmap_improvement_fraction"] == pytest.approx(0.12)
+
+    failing = report({"no-LTO": 0.12, "ThinLTO": 0.05, "full-LTO": 0.11})
+    with pytest.raises(BenchmarkError, match=r"ThinLTO: default improved 5\.0%"):
+        assert_output_mode_improvement(failing)
 
 
 def test_old_sqlite_bridge_is_red_and_significant_workload_is_green():

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -1,4 +1,5 @@
 import os
+import json
 from io import StringIO
 from pathlib import Path
 
@@ -205,6 +206,69 @@ def test_linker_trials_rotate_order_and_preserve_every_sample(tmp_path: Path, mo
     assert all(len(values) == 3 for values in samples.values())
     assert all(len(values) == 3 for values in sizes.values())
     assert set(medians) == {"wild", "reld", "mmap"}
+
+
+def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_path: Path, monkeypatch):
+    report_path = tmp_path / "output-modes.json"
+    wild = Linker("wild", tmp_path / "wild")
+
+    def fake_capture(configuration, **kwargs):
+        del kwargs
+        output = tmp_path / configuration.profile / "app"
+        return LinkCommand("clang", ("input.o", "-o", str(output)), output, False)
+
+    def fake_round_robin(captured, linkers, **kwargs):
+        del captured, kwargs
+        samples = {linker.label: [0.9, 1.0, 1.1] for linker in linkers}
+        sizes = {linker.label: [256 * 1024 * 1024] * 3 for linker in linkers}
+        orders = [[linker.label for linker in linkers]] * 3
+        return ({linker.label: 1.0 for linker in linkers}, samples, sizes, orders)
+
+    monkeypatch.setattr(runner_module, "linkers_for_target", lambda target, reld: (wild,))
+    monkeypatch.setattr(runner_module, "benchmark_environment", lambda: {})
+    monkeypatch.setattr(runner_module, "_linux_filesystem_type", lambda path, environment: "ext4")
+    monkeypatch.setattr(runner_module, "capture_final_link", fake_capture)
+    monkeypatch.setattr(runner_module, "prune_capture_artifacts", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runner_module, "release_capture_artifacts", lambda **kwargs: None)
+    monkeypatch.setattr(runner_module, "benchmark_startup", lambda *args, **kwargs: 0.01)
+    monkeypatch.setattr(runner_module, "benchmark_linkers_round_robin", fake_round_robin)
+    monkeypatch.setattr(
+        runner_module,
+        "capture_reld_phase_trace",
+        lambda *args, **kwargs: (
+            {
+                "Compute build ID": 0.05,
+                "Write data to file": 0.7,
+                "Flush and unmap output file": 0.01,
+            },
+            256 * 1024 * 1024,
+            "phase trace",
+        ),
+    )
+
+    runner_module.run_benchmark(
+        target="x86_64-linux",
+        reld=tmp_path / "reld",
+        manifest=tmp_path / "Cargo.toml",
+        workdir=tmp_path / "work",
+        target_dir=tmp_path / "target",
+        cargo="cargo",
+        trials=3,
+        warmup=1,
+        log=StringIO(),
+        output_mode_report=report_path,
+    )
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["status"] == "measured"
+    assert report["metadata"]["filesystem"] == "ext4"
+    assert report["metadata"]["timing_scope"] == "captured final native link only"
+    assert set(report["configurations"]) == {"no-LTO", "ThinLTO", "full-LTO"}
+    no_lto = report["configurations"]["no-LTO"]
+    assert set(no_lto["modes"]) == {"default", "mmap", "buffer"}
+    assert no_lto["modes"]["default"]["samples_seconds"] == [0.9, 1.0, 1.1]
+    assert no_lto["modes"]["default"]["output_sizes_bytes"] == [256 * 1024 * 1024] * 3
+    assert no_lto["modes"]["default"]["phase_seconds"]["Write data to file"] == 0.7
 
 
 def test_reld_phase_trace_parser_requires_dominant_output_phases():

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -21,6 +21,7 @@ from ci.benchmark_runner import (
     cargo_capture_command,
     parse_print_link_args,
     prune_capture_artifacts,
+    reld_output_mode_linkers,
     replay_command,
     replace_output,
     startup_probe_command,
@@ -250,6 +251,16 @@ def test_startup_probe_is_target_correct(tmp_path: Path):
     assert startup_probe_command("x86_64-linux", linker) == [str(linker.path), "--version"]
     assert startup_probe_command("aarch64-apple-darwin", linker) == [str(linker.path), "-v"]
     assert startup_probe_command("x86_64-pc-windows-msvc", linker) == [str(linker.path), "/?"]
+
+
+def test_output_mode_diagnostics_force_the_native_reld_engine(tmp_path: Path):
+    modes = reld_output_mode_linkers(tmp_path / "ld.reld", 4)
+
+    assert [mode.label for mode in modes] == ["default", "mmap", "buffer"]
+    assert all("-Wl,--engine=reld" in mode.driver_arguments for mode in modes)
+    assert all("-Wl,--threads=4" in mode.driver_arguments for mode in modes)
+    assert "-Wl,--mmap-output-file" in modes[1].driver_arguments
+    assert "-Wl,--no-mmap-output-file" in modes[2].driver_arguments
 
 
 def test_old_sqlite_bridge_is_red_and_significant_workload_is_green():

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -13,8 +13,10 @@ from ci.benchmark_runner import (
     LinkCommand,
     Linker,
     _discard_verified_output,
+    _parse_phase_timings,
     assert_significant_workload,
     benchmark_environment,
+    benchmark_linkers_round_robin,
     benchmark_replay,
     cargo_capture_command,
     parse_print_link_args,
@@ -87,8 +89,10 @@ def test_each_configuration_is_replayed_then_released_before_the_next_capture(tm
         return 0.01
 
     def fake_replay(captured, selected_linker, **kwargs):
-        del captured, kwargs
+        del captured
         events.append(f"replay:{selected_linker.label}")
+        kwargs["sample_sink"].append(1.0)
+        kwargs["output_size_sink"].append(256 * 1024 * 1024)
         return 1.0
 
     def fake_release(*, profile_dir, target_dir, log):
@@ -120,14 +124,89 @@ def test_each_configuration_is_replayed_then_released_before_the_next_capture(tm
         "capture:no-LTO",
         "startup",
         "replay:wild",
+        "replay:wild",
+        "replay:wild",
+        "replay:wild",
         "release:linkbench-no-lto",
         "capture:ThinLTO",
+        "replay:wild",
+        "replay:wild",
+        "replay:wild",
         "replay:wild",
         "release:linkbench-thin-lto",
         "capture:full-LTO",
         "replay:wild",
+        "replay:wild",
+        "replay:wild",
+        "replay:wild",
         "release:linkbench-full-lto",
     ]
+
+
+def test_linker_trials_rotate_order_and_preserve_every_sample(tmp_path: Path, monkeypatch):
+    captured = LinkCommand("cc", ("main.o", "-o", "/old/app"), Path("/old/app"), False)
+    linkers = tuple(Linker(label, tmp_path / label) for label in ("wild", "reld", "mmap"))
+    calls: list[str] = []
+
+    def fake_replay(captured, linker, *, sample_sink, output_size_sink, **kwargs):
+        del captured, kwargs
+        calls.append(linker.label)
+        sample_sink.append(float(len(calls)))
+        output_size_sink.append(256 * 1024 * 1024)
+        return sample_sink[0]
+
+    monkeypatch.setattr(runner_module, "benchmark_replay", fake_replay)
+
+    medians, samples, sizes, orders = benchmark_linkers_round_robin(
+        captured,
+        linkers,
+        output_dir=tmp_path / "out",
+        cwd=tmp_path,
+        environment={},
+        warmup=1,
+        trials=3,
+        use_driver_shim=True,
+    )
+
+    assert calls == [
+        "wild",
+        "reld",
+        "mmap",
+        "reld",
+        "mmap",
+        "wild",
+        "mmap",
+        "wild",
+        "reld",
+        "wild",
+        "reld",
+        "mmap",
+    ]
+    assert orders == [
+        ["reld", "mmap", "wild"],
+        ["mmap", "wild", "reld"],
+        ["wild", "reld", "mmap"],
+    ]
+    assert all(len(values) == 3 for values in samples.values())
+    assert all(len(values) == 3 for values in sizes.values())
+    assert set(medians) == {"wild", "reld", "mmap"}
+
+
+def test_reld_phase_trace_parser_requires_dominant_output_phases():
+    output = """\
+│ ├──    12.50 Compute build ID
+│ ├──   625.25 Write data to file
+│ └──     8.00 Flush and unmap output file
+"""
+
+    assert _parse_phase_timings(output) == {
+        "Compute build ID": 0.0125,
+        "Write data to file": 0.62525,
+        "Flush and unmap output file": 0.008,
+    }
+
+    with pytest.raises(BenchmarkError, match="omitted required phases"):
+        _parse_phase_timings("12.50 Compute build ID\n")
 
 
 def test_release_capture_artifacts_rejects_outside_directory(tmp_path: Path):
@@ -335,7 +414,7 @@ def test_cargo_capture_command_rejects_shell_fragments():
 
 
 def test_parse_print_link_args_decodes_rust_escaped_windows_paths():
-    output = 'compiler chatter\n"C:\\\\VS\\\\link.exe" "/NOLOGO" ' '"C:\\\\target\\\\app.o" "/OUT:C:\\\\target\\\\app.exe"\n'
+    output = 'compiler chatter\n"C:\\\\VS\\\\link.exe" "/NOLOGO" "C:\\\\target\\\\app.o" "/OUT:C:\\\\target\\\\app.exe"\n'
 
     command = parse_print_link_args(output, windows=True)
 
@@ -348,7 +427,7 @@ def test_parse_print_link_args_decodes_rust_escaped_windows_paths():
 
 
 def test_parse_print_link_args_reads_unix_driver_command():
-    output = 'LC_ALL="C" PATH="/toolchain/bin:/usr/bin" VSLANG="1033" ' '"cc" "main.o" "-Wl,--gc-sections" "-o" "/tmp/app"\n'
+    output = 'LC_ALL="C" PATH="/toolchain/bin:/usr/bin" VSLANG="1033" "cc" "main.o" "-Wl,--gc-sections" "-o" "/tmp/app"\n'
 
     command = parse_print_link_args(output, windows=False)
 
@@ -357,9 +436,7 @@ def test_parse_print_link_args_reads_unix_driver_command():
 
 
 def test_parse_print_link_args_handles_macos_environment_removals():
-    output = (
-        'env -u IPHONEOS_DEPLOYMENT_TARGET -u SDKROOT LC_ALL="C" ' 'PATH="/toolchain/bin:/usr/bin" VSLANG="1033" ZERO_AR_DATE="1" ' '"cc" "symbols.o" "libapp.rlib" "-arch" "arm64" "-o" "/tmp/app"\n'
-    )
+    output = 'env -u IPHONEOS_DEPLOYMENT_TARGET -u SDKROOT LC_ALL="C" PATH="/toolchain/bin:/usr/bin" VSLANG="1033" ZERO_AR_DATE="1" "cc" "symbols.o" "libapp.rlib" "-arch" "arm64" "-o" "/tmp/app"\n'
 
     command = parse_print_link_args(output, windows=False)
 

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -212,6 +212,8 @@ def test_linker_trials_rotate_order_and_preserve_every_sample(tmp_path: Path, mo
 
 def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_path: Path, monkeypatch):
     report_path = tmp_path / "output-modes.json"
+    baseline_reld = tmp_path / "baseline-reld"
+    baseline_reld.write_bytes(b"baseline")
     wild = Linker("wild", tmp_path / "wild")
 
     def fake_capture(configuration, **kwargs):
@@ -260,6 +262,7 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
         warmup=1,
         log=StringIO(),
         output_mode_report=report_path,
+        baseline_reld=baseline_reld,
     )
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
@@ -268,7 +271,7 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
     assert report["metadata"]["timing_scope"] == "captured final native link only"
     assert set(report["configurations"]) == {"no-LTO", "ThinLTO", "full-LTO"}
     no_lto = report["configurations"]["no-LTO"]
-    assert set(no_lto["modes"]) == {"default", "mmap", "buffer"}
+    assert set(no_lto["modes"]) == {"baseline", "default", "mmap", "buffer"}
     assert no_lto["modes"]["default"]["samples_seconds"] == [0.7, 0.8, 0.9]
     assert no_lto["modes"]["default"]["output_sizes_bytes"] == [256 * 1024 * 1024] * 3
     assert no_lto["modes"]["default"]["phase_seconds"]["Write data to file"] == 0.7
@@ -337,13 +340,14 @@ def test_startup_probe_is_target_correct(tmp_path: Path):
 
 
 def test_output_mode_diagnostics_force_the_native_reld_engine(tmp_path: Path):
-    modes = reld_output_mode_linkers(tmp_path / "ld.reld", 4)
+    modes = reld_output_mode_linkers(tmp_path / "ld.reld", tmp_path / "baseline-reld", 4)
 
-    assert [mode.label for mode in modes] == ["default", "mmap", "buffer"]
+    assert [mode.label for mode in modes] == ["baseline", "default", "mmap", "buffer"]
     assert all("-Wl,--engine=reld" in mode.driver_arguments for mode in modes)
     assert all("-Wl,--threads=4" in mode.driver_arguments for mode in modes)
-    assert "-Wl,--mmap-output-file" in modes[1].driver_arguments
-    assert "-Wl,--no-mmap-output-file" in modes[2].driver_arguments
+    assert "-Wl,--mmap-output-file" in modes[0].driver_arguments
+    assert "-Wl,--mmap-output-file" in modes[2].driver_arguments
+    assert "-Wl,--no-mmap-output-file" in modes[3].driver_arguments
 
 
 def test_published_linux_reld_forces_the_native_engine(tmp_path: Path, monkeypatch):
@@ -361,6 +365,7 @@ def test_paired_output_mode_gate_requires_ten_percent_in_every_lto_row():
             "configurations": {
                 configuration.label: {
                     "modes": {
+                        "baseline": {"median_seconds": 1.0},
                         "default": {"median_seconds": 1.0 - improvements[configuration.label]},
                         "mmap": {"median_seconds": 1.0},
                     }
@@ -371,10 +376,10 @@ def test_paired_output_mode_gate_requires_ten_percent_in_every_lto_row():
 
     passing = report({"no-LTO": 0.12, "ThinLTO": 0.11, "full-LTO": 0.10})
     assert_output_mode_improvement(passing)
-    assert passing["configurations"]["no-LTO"]["default_vs_mmap_improvement_fraction"] == pytest.approx(0.12)
+    assert passing["configurations"]["no-LTO"]["head_vs_baseline_improvement_fraction"] == pytest.approx(0.12)
 
     failing = report({"no-LTO": 0.12, "ThinLTO": 0.05, "full-LTO": 0.11})
-    with pytest.raises(BenchmarkError, match=r"ThinLTO: default improved 5\.0%"):
+    with pytest.raises(BenchmarkError, match=r"ThinLTO: HEAD improved 5\.0%"):
         assert_output_mode_improvement(failing)
 
 

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -71,6 +71,20 @@ def test_cargo_capture_command_builds_the_idiomatic_project_once():
     ]
 
 
+def test_linux_capture_uses_clang_without_gccs_synthetic_lto_plugin():
+    command = cargo_capture_command(
+        cargo="cargo",
+        manifest=Path("ci/e2e/link-workload/Cargo.toml"),
+        profile="linkbench-no-lto",
+        target_dir=Path("target/link-benchmark"),
+        linker="clang",
+    )
+
+    separator = command.index("--")
+    assert command[separator + 1 : separator + 3] == ["-C", "linker=clang"]
+    assert "plugin" not in " ".join(command)
+
+
 def test_each_configuration_is_replayed_then_released_before_the_next_capture(tmp_path: Path, monkeypatch):
     events: list[str] = []
     linker = Linker("wild", tmp_path / "wild")

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -57,6 +57,10 @@ SAMPLE_LOG = """
 """
 
 
+def test_benchmark_identity_isolated_after_native_linux_driver_correction():
+    assert BENCHMARK_ID == "artifact-auditor-native-linux-lto-v2"
+
+
 def sample_log_for_target(target: str) -> str:
     series = EXPECTED_SERIES[target]
     startup = {name: 0.0500 for name in series}

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -47,6 +47,8 @@ def test_benchmark_workflow_gates_expected_linker_coverage():
     assert "RUNNER_ENVIRONMENT: ${{ runner.environment }}" in text
     assert "--trials 3 --warmup 1" in text
     assert "--manifest ci/e2e/link-workload/Cargo.toml" in text
+    assert "--output-mode-report benchmark-output/output-modes.json" in text
+    assert "benchmark-output/output-modes.json" in text
     assert "sqlite-bridge" not in text
     assert "--print link-args" not in text  # Python owns capture/replay, not shell YAML.
     assert "will report n/a" not in text

--- a/crates/reld-core/Cargo.toml
+++ b/crates/reld-core/Cargo.toml
@@ -50,6 +50,7 @@ symbolic-demangle.workspace = true
 thread_local.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+twox-hash.workspace = true
 uuid.workspace = true
 winnow.workspace = true
 zerocopy.workspace = true

--- a/crates/reld-core/src/args/elf.rs
+++ b/crates/reld-core/src/args/elf.rs
@@ -36,6 +36,7 @@ use object::elf::GNU_PROPERTY_X86_ISA_1_V2;
 use object::elf::GNU_PROPERTY_X86_ISA_1_V3;
 use object::elf::GNU_PROPERTY_X86_ISA_1_V4;
 use std::ffi::CString;
+use std::mem::size_of;
 use std::num::NonZero;
 use std::num::NonZeroU32;
 use std::num::NonZeroU64;
@@ -155,12 +156,28 @@ pub(crate) enum Strip {
     Retain(HashSet<Vec<u8>>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum BuildIdOption {
     None,
     Fast,
+    Md5,
+    Sha1,
     Hex(Vec<u8>),
     Uuid,
+}
+
+impl BuildIdOption {
+    pub(crate) fn descriptor_size(&self) -> Option<usize> {
+        match self {
+            Self::None => None,
+            Self::Fast => Some(size_of::<u128>()),
+            // Keep the existing descriptor width for explicitly named modes. Their algorithm
+            // compatibility can be corrected separately without coupling it to the fast path.
+            Self::Md5 | Self::Sha1 => Some(size_of::<blake3::Hash>()),
+            Self::Hex(hex) => Some(hex.len()),
+            Self::Uuid => Some(size_of::<uuid::Uuid>()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1517,7 +1534,9 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .execute(|args, _modifier_stack, value| {
             args.build_id = match value {
                 "none" => BuildIdOption::None,
-                "fast" | "md5" | "sha1" => BuildIdOption::Fast,
+                "fast" => BuildIdOption::Fast,
+                "md5" => BuildIdOption::Md5,
+                "sha1" => BuildIdOption::Sha1,
                 "uuid" => BuildIdOption::Uuid,
                 s if s.starts_with("0x") || s.starts_with("0X") => {
                     let hex_string = &s[2..];
@@ -2072,6 +2091,7 @@ impl platform::Args for ElfArgs {
 
 #[cfg(test)]
 mod tests {
+    use super::BuildIdOption;
     use super::ElfArgs;
     use super::SILENTLY_IGNORED_FLAGS;
     use super::VersionMode;
@@ -2411,6 +2431,30 @@ mod tests {
     fn parse_args_err<'a>(args: impl IntoIterator<Item = &'a str>) -> crate::error::Error {
         let mut elf_args = ElfArgs::new().unwrap();
         elf_args.parse(args.into_iter()).unwrap_err()
+    }
+
+    #[test]
+    fn build_id_modes_remain_distinct() {
+        assert_eq!(parse_args(["--build-id"]).build_id, BuildIdOption::Fast);
+        assert_eq!(
+            parse_args(["--build-id=fast"]).build_id,
+            BuildIdOption::Fast
+        );
+        assert_eq!(parse_args(["--build-id=md5"]).build_id, BuildIdOption::Md5);
+        assert_eq!(
+            parse_args(["--build-id=sha1"]).build_id,
+            BuildIdOption::Sha1
+        );
+
+        assert_eq!(BuildIdOption::Fast.descriptor_size(), Some(16));
+        assert_eq!(
+            BuildIdOption::Md5.descriptor_size(),
+            Some(std::mem::size_of::<blake3::Hash>())
+        );
+        assert_eq!(
+            BuildIdOption::Sha1.descriptor_size(),
+            Some(std::mem::size_of::<blake3::Hash>())
+        );
     }
 
     #[test]

--- a/crates/reld-core/src/elf.rs
+++ b/crates/reld-core/src/elf.rs
@@ -4,7 +4,6 @@ use crate::alignment::Alignment;
 use crate::arch::Architecture;
 use crate::args::BSymbolicKind;
 use crate::args::RelocationModel;
-use crate::args::elf::BuildIdOption;
 use crate::args::elf::ElfArgs;
 use crate::bail;
 use crate::debug_assert_bail;
@@ -1415,12 +1414,7 @@ impl platform::Platform for Elf {
     ) -> EpilogueLayoutExt {
         let gnu_hash_layout = create_gnu_hash_layout(args, output_kind, dynamic_symbol_definitions);
 
-        let build_id_size = match &args.build_id {
-            BuildIdOption::None => None,
-            BuildIdOption::Fast => Some(size_of::<blake3::Hash>()),
-            BuildIdOption::Hex(hex) => Some(hex.len()),
-            BuildIdOption::Uuid => Some(size_of::<uuid::Uuid>()),
-        };
+        let build_id_size = args.build_id.descriptor_size();
 
         EpilogueLayoutExt {
             sysv_hash_layout: Default::default(),

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -215,11 +215,16 @@ fn write_gnu_build_id_note(
     layout: &ElfLayout,
 ) -> Result {
     let hash_placeholder;
+    let legacy_hash_placeholder;
     let uuid_placeholder;
     let build_id = match build_id_option {
         BuildIdOption::Fast => {
-            hash_placeholder = compute_hash(sized_output);
-            hash_placeholder.as_bytes()
+            hash_placeholder = compute_fast_hash(sized_output);
+            hash_placeholder.as_slice()
+        }
+        BuildIdOption::Md5 | BuildIdOption::Sha1 => {
+            legacy_hash_placeholder = compute_legacy_hash(sized_output);
+            legacy_hash_placeholder.as_bytes()
         }
         BuildIdOption::Hex(hex) => hex.as_slice(),
         BuildIdOption::Uuid => {
@@ -246,11 +251,40 @@ fn write_gnu_build_id_note(
     Ok(())
 }
 
-fn compute_hash(sized_output: &SizedOutput<impl OutputFileData>) -> blake3::Hash {
+fn compute_fast_hash(sized_output: &SizedOutput<impl OutputFileData>) -> [u8; size_of::<u128>()] {
+    timing_phase!("Compute build ID");
+    fast_build_id(&sized_output.out)
+}
+
+fn fast_build_id(bytes: &[u8]) -> [u8; size_of::<u128>()] {
+    twox_hash::XxHash3_128::oneshot(bytes).to_le_bytes()
+}
+
+fn compute_legacy_hash(sized_output: &SizedOutput<impl OutputFileData>) -> blake3::Hash {
     timing_phase!("Compute build ID");
     blake3::Hasher::new()
         .update_rayon(&sized_output.out)
         .finalize()
+}
+
+#[cfg(test)]
+mod build_id_tests {
+    use super::fast_build_id;
+
+    #[test]
+    fn fast_build_id_hashes_every_output_byte_deterministically() {
+        let original = (0_u8..=255).cycle().take(8192).collect::<Vec<_>>();
+        let expected = fast_build_id(&original);
+
+        assert_eq!(expected.len(), size_of::<u128>());
+        assert_eq!(expected, fast_build_id(&original));
+
+        for index in [0, original.len() / 2, original.len() - 1] {
+            let mut changed = original.clone();
+            changed[index] ^= 1;
+            assert_ne!(expected, fast_build_id(&changed));
+        }
+    }
 }
 
 fn write_file_contents<'data, A: Arch<Platform = Elf>>(

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -218,12 +218,7 @@ fn write_gnu_build_id_note(
     let uuid_placeholder;
     let build_id = match build_id_option {
         BuildIdOption::Fast => {
-            let build_id_layout = layout
-                .section_layouts
-                .get(output_section_id::NOTE_GNU_BUILD_ID);
-            let build_id_range = build_id_layout.file_offset
-                ..build_id_layout.file_offset + build_id_layout.file_size;
-            hash_placeholder = compute_hash(sized_output, build_id_range)?;
+            hash_placeholder = compute_hash(sized_output);
             hash_placeholder.as_bytes()
         }
         BuildIdOption::Hex(hex) => hex.as_slice(),
@@ -251,16 +246,11 @@ fn write_gnu_build_id_note(
     Ok(())
 }
 
-fn compute_hash(
-    sized_output: &mut SizedOutput<impl OutputFileData>,
-    build_id_range: std::ops::Range<usize>,
-) -> Result<blake3::Hash> {
+fn compute_hash(sized_output: &SizedOutput<impl OutputFileData>) -> blake3::Hash {
     timing_phase!("Compute build ID");
-    sized_output
-        .out
-        .compute_while_preflushing(build_id_range, |bytes| {
-            blake3::Hasher::new().update_rayon(bytes).finalize()
-        })
+    blake3::Hasher::new()
+        .update_rayon(&sized_output.out)
+        .finalize()
 }
 
 fn write_file_contents<'data, A: Arch<Platform = Elf>>(

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -218,7 +218,12 @@ fn write_gnu_build_id_note(
     let uuid_placeholder;
     let build_id = match build_id_option {
         BuildIdOption::Fast => {
-            hash_placeholder = compute_hash(sized_output);
+            let build_id_layout = layout
+                .section_layouts
+                .get(output_section_id::NOTE_GNU_BUILD_ID);
+            let build_id_range = build_id_layout.file_offset
+                ..build_id_layout.file_offset + build_id_layout.file_size;
+            hash_placeholder = compute_hash(sized_output, build_id_range)?;
             hash_placeholder.as_bytes()
         }
         BuildIdOption::Hex(hex) => hex.as_slice(),
@@ -246,11 +251,16 @@ fn write_gnu_build_id_note(
     Ok(())
 }
 
-fn compute_hash(sized_output: &SizedOutput<impl OutputFileData>) -> blake3::Hash {
+fn compute_hash(
+    sized_output: &mut SizedOutput<impl OutputFileData>,
+    build_id_range: std::ops::Range<usize>,
+) -> Result<blake3::Hash> {
     timing_phase!("Compute build ID");
-    blake3::Hasher::new()
-        .update_rayon(&sized_output.out)
-        .finalize()
+    sized_output
+        .out
+        .compute_while_preflushing(build_id_range, |bytes| {
+            blake3::Hasher::new().update_rayon(bytes).finalize()
+        })
 }
 
 fn write_file_contents<'data, A: Arch<Platform = Elf>>(

--- a/crates/reld-core/src/file_writer.rs
+++ b/crates/reld-core/src/file_writer.rs
@@ -27,6 +27,7 @@ use rayon::slice::ParallelSlice;
 use rayon::slice::ParallelSliceMut;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
@@ -81,6 +82,14 @@ impl<O: OutputFileData> OutputBuffer<O> {
 
     fn finish(self) -> Result {
         self.0.finish()
+    }
+
+    pub(crate) fn compute_while_preflushing<T>(
+        &mut self,
+        dirty_range: Range<usize>,
+        compute: impl FnOnce(&[u8]) -> T,
+    ) -> Result<T> {
+        self.0.compute_while_preflushing(dirty_range, compute)
     }
 }
 

--- a/crates/reld-core/src/file_writer.rs
+++ b/crates/reld-core/src/file_writer.rs
@@ -27,7 +27,6 @@ use rayon::slice::ParallelSlice;
 use rayon::slice::ParallelSliceMut;
 use std::ops::Deref;
 use std::ops::DerefMut;
-use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
@@ -82,14 +81,6 @@ impl<O: OutputFileData> OutputBuffer<O> {
 
     fn finish(self) -> Result {
         self.0.finish()
-    }
-
-    pub(crate) fn compute_while_preflushing<T>(
-        &mut self,
-        dirty_range: Range<usize>,
-        compute: impl FnOnce(&[u8]) -> T,
-    ) -> Result<T> {
-        self.0.compute_while_preflushing(dirty_range, compute)
     }
 }
 

--- a/crates/reld-core/src/file_writer.rs
+++ b/crates/reld-core/src/file_writer.rs
@@ -438,12 +438,30 @@ pub(crate) fn copy_section_data(data: &[u8], out: &mut [u8]) {
 
     if data.len() >= SECTION_PAR_COPY_SIZE_THRESHOLD {
         let threads = rayon::current_num_threads();
-        let chunk_size = (data.len() / threads).max(1);
+        let chunk_size = section_copy_chunk_size(data.len(), threads);
 
         data.par_chunks(chunk_size)
             .zip(out.par_chunks_mut(chunk_size))
             .for_each(|(src, dst)| dst.copy_from_slice(src));
     } else {
         out.copy_from_slice(data);
+    }
+}
+
+fn section_copy_chunk_size(data_len: usize, threads: usize) -> usize {
+    (data_len / threads).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::section_copy_chunk_size;
+
+    /// Issue #74: a retained 256 MiB section must expose enough work items for Rayon to
+    /// rebalance page-fault and output-write variance across four hosted-runner workers.
+    #[test]
+    fn large_section_copy_has_multiple_chunks_per_worker() {
+        let chunk_size = section_copy_chunk_size(256 * 1024 * 1024, 4);
+
+        assert!(chunk_size <= 8 * 1024 * 1024, "chunk size was {chunk_size}");
     }
 }

--- a/crates/reld-core/src/file_writer.rs
+++ b/crates/reld-core/src/file_writer.rs
@@ -39,6 +39,10 @@ pub(crate) const SECTION_PAR_COPY_SIZE_THRESHOLD: usize = 1_000_000;
 /// turning a large contiguous copy into thousands of tiny tasks.
 const SECTION_PAR_COPY_CHUNKS_PER_THREAD: usize = 8;
 
+/// Preserve the original one-range-per-worker scheduler for ordinary sections. Only retained
+/// sections large enough to dominate a link need the finer-grained rebalancing from issue #74.
+const LARGE_SECTION_PAR_REBALANCE_THRESHOLD: usize = 64 * 1024 * 1024;
+
 pub struct Output<F: FileSystem> {
     path: Arc<Path>,
     creator: FileCreator<F::Output>,
@@ -148,7 +152,7 @@ impl<F: FileSystem> Output<F> {
                 let file_system = Arc::clone(&self.file_system);
 
                 rayon::spawn(move || {
-                    verbose_timing_phase!("Create output file");
+                    timing_phase!("Create output file");
 
                     if output_config.file_replacement_mode == FileReplacementMode::UnlinkAndReplace
                     {
@@ -440,6 +444,11 @@ fn write_layout_to<'data, P: Platform>(
 /// Small sections are copied with a single `copy_from_slice` call. Large sections may be split
 /// into chunks and copied in parallel on multiple threads.
 pub(crate) fn copy_section_data(data: &[u8], out: &mut [u8]) {
+    assert_eq!(
+        data.len(),
+        out.len(),
+        "section input and output lengths differ"
+    );
     if data.len() >= SECTION_PAR_COPY_SIZE_THRESHOLD {
         let threads = rayon::current_num_threads();
         let chunk_size = section_copy_chunk_size(data.len(), threads);
@@ -455,6 +464,10 @@ pub(crate) fn copy_section_data(data: &[u8], out: &mut [u8]) {
 fn section_copy_chunk_size(data_len: usize, threads: usize) -> usize {
     if threads <= 1 {
         return data_len.max(1);
+    }
+
+    if data_len < LARGE_SECTION_PAR_REBALANCE_THRESHOLD {
+        return (data_len / threads).max(1);
     }
 
     let target_chunks = threads.saturating_mul(SECTION_PAR_COPY_CHUNKS_PER_THREAD);
@@ -479,11 +492,16 @@ mod tests {
     }
 
     #[test]
-    fn parallel_copy_chunks_are_never_smaller_than_the_parallel_threshold() {
+    fn rebalanced_large_section_chunks_are_never_smaller_than_the_parallel_threshold() {
         assert_eq!(
-            section_copy_chunk_size(SECTION_PAR_COPY_SIZE_THRESHOLD, 64),
+            section_copy_chunk_size(64 * 1024 * 1024, 64),
             SECTION_PAR_COPY_SIZE_THRESHOLD
         );
+    }
+
+    #[test]
+    fn ordinary_section_chunking_matches_the_original_scheduler() {
+        assert_eq!(section_copy_chunk_size(2 * 1024 * 1024, 4), 512 * 1024);
     }
 
     #[test]
@@ -508,5 +526,11 @@ mod tests {
         pool.install(|| copy_section_data(&data, &mut out));
 
         assert_eq!(out, data);
+    }
+
+    #[test]
+    #[should_panic(expected = "section input and output lengths differ")]
+    fn parallel_copy_rejects_mismatched_lengths() {
+        copy_section_data(&vec![1; SECTION_PAR_COPY_SIZE_THRESHOLD], &mut [0; 1]);
     }
 }

--- a/crates/reld-core/src/file_writer.rs
+++ b/crates/reld-core/src/file_writer.rs
@@ -32,6 +32,13 @@ use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
+/// Threshold size for using parallel copy for section data copying.
+pub(crate) const SECTION_PAR_COPY_SIZE_THRESHOLD: usize = 1_000_000;
+
+/// Give Rayon enough independent ranges to rebalance page-fault and writeback variance without
+/// turning a large contiguous copy into thousands of tiny tasks.
+const SECTION_PAR_COPY_CHUNKS_PER_THREAD: usize = 8;
+
 pub struct Output<F: FileSystem> {
     path: Arc<Path>,
     creator: FileCreator<F::Output>,
@@ -433,9 +440,6 @@ fn write_layout_to<'data, P: Platform>(
 /// Small sections are copied with a single `copy_from_slice` call. Large sections may be split
 /// into chunks and copied in parallel on multiple threads.
 pub(crate) fn copy_section_data(data: &[u8], out: &mut [u8]) {
-    /// Threshold size for using parallel copy for section data copying.
-    pub(crate) const SECTION_PAR_COPY_SIZE_THRESHOLD: usize = 1_000_000;
-
     if data.len() >= SECTION_PAR_COPY_SIZE_THRESHOLD {
         let threads = rayon::current_num_threads();
         let chunk_size = section_copy_chunk_size(data.len(), threads);
@@ -449,11 +453,20 @@ pub(crate) fn copy_section_data(data: &[u8], out: &mut [u8]) {
 }
 
 fn section_copy_chunk_size(data_len: usize, threads: usize) -> usize {
-    (data_len / threads).max(1)
+    if threads <= 1 {
+        return data_len.max(1);
+    }
+
+    let target_chunks = threads.saturating_mul(SECTION_PAR_COPY_CHUNKS_PER_THREAD);
+    data_len
+        .div_ceil(target_chunks)
+        .max(SECTION_PAR_COPY_SIZE_THRESHOLD)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::SECTION_PAR_COPY_SIZE_THRESHOLD;
+    use super::copy_section_data;
     use super::section_copy_chunk_size;
 
     /// Issue #74: a retained 256 MiB section must expose enough work items for Rayon to
@@ -463,5 +476,37 @@ mod tests {
         let chunk_size = section_copy_chunk_size(256 * 1024 * 1024, 4);
 
         assert!(chunk_size <= 8 * 1024 * 1024, "chunk size was {chunk_size}");
+    }
+
+    #[test]
+    fn parallel_copy_chunks_are_never_smaller_than_the_parallel_threshold() {
+        assert_eq!(
+            section_copy_chunk_size(SECTION_PAR_COPY_SIZE_THRESHOLD, 64),
+            SECTION_PAR_COPY_SIZE_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn single_thread_copy_remains_one_contiguous_range() {
+        assert_eq!(
+            section_copy_chunk_size(256 * 1024 * 1024, 1),
+            256 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn rebalanced_parallel_copy_preserves_every_byte() {
+        let data: Vec<u8> = (0..SECTION_PAR_COPY_SIZE_THRESHOLD * 2)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let mut out = vec![0; data.len()];
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap();
+
+        pool.install(|| copy_section_data(&data, &mut out));
+
+        assert_eq!(out, data);
     }
 }

--- a/crates/reld-core/src/fs.rs
+++ b/crates/reld-core/src/fs.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+const LARGE_BUFFERED_OUTPUT_THRESHOLD: u64 = 256 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileReplacementMode {
     /// The existing output file, if any, will be unlinked (deleted) and a new file with the same
@@ -355,6 +357,7 @@ pub struct OsOutputFile {
     buffer: OsOutputBuffer,
     path: Arc<Path>,
     preflushed_range: Option<Range<usize>>,
+    can_preflush: bool,
 }
 
 impl OutputFileData for OsOutputFile {
@@ -380,8 +383,13 @@ impl OutputFileData for OsOutputFile {
         let OsOutputBuffer::InMemory(bytes) = &self.buffer else {
             return Ok(compute(self.bytes()));
         };
+        if !self.can_preflush {
+            return Ok(compute(bytes));
+        }
 
-        let mut file = self.file.try_clone()?;
+        let Ok(mut file) = self.file.try_clone() else {
+            return Ok(compute(bytes));
+        };
         let result = std::thread::scope(|scope| -> Result<T> {
             let writer = scope.spawn(|| -> std::io::Result<()> {
                 file.seek(SeekFrom::Start(0))?;
@@ -568,12 +576,16 @@ impl FileSystem for OsFileSystem {
                 OsOutputBuffer::InMemory(vec![0; options.size as usize])
             }
         };
+        let can_preflush = file_write_mode == FileWriteMode::BufferThenWrite
+            && options.size >= LARGE_BUFFERED_OUTPUT_THRESHOLD
+            && file.metadata().is_ok_and(|metadata| metadata.is_file());
 
         Ok(OsOutputFile {
             file,
             buffer,
             path,
             preflushed_range: None,
+            can_preflush,
         })
     }
 
@@ -606,8 +618,6 @@ fn default_file_write_mode_for_filesystem_type(
     filesystem_type: Option<nix::sys::statfs::FsType>,
     output_size: u64,
 ) -> FileWriteMode {
-    const LARGE_EXT4_BUFFERED_OUTPUT_THRESHOLD: u64 = 256 * 1024 * 1024;
-
     match filesystem_type {
         // Preserve the existing Btrfs/vfat policy at every size.
         Some(nix::sys::statfs::BTRFS_SUPER_MAGIC | nix::sys::statfs::MSDOS_SUPER_MAGIC) => {
@@ -615,7 +625,7 @@ fn default_file_write_mode_for_filesystem_type(
         }
         #[cfg(target_os = "linux")]
         Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
-            if output_size >= LARGE_EXT4_BUFFERED_OUTPUT_THRESHOLD =>
+            if output_size >= LARGE_BUFFERED_OUTPUT_THRESHOLD =>
         {
             FileWriteMode::BufferThenWrite
         }
@@ -626,6 +636,7 @@ fn default_file_write_mode_for_filesystem_type(
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use std::io::Read as _;
 
     #[cfg(target_os = "linux")]
     #[test]
@@ -652,8 +663,6 @@ mod tests {
 
     #[test]
     fn buffered_preflush_patches_only_the_post_hash_range() {
-        use std::io::Read as _;
-
         let file = tempfile::tempfile().unwrap();
         let mut reader = file.try_clone().unwrap();
         let original: Vec<u8> = (0..64).collect();
@@ -662,6 +671,7 @@ mod tests {
             buffer: OsOutputBuffer::InMemory(original.clone()),
             path: Arc::from(Path::new("preflush-test")),
             preflushed_range: None,
+            can_preflush: true,
         };
 
         let sum = output
@@ -679,6 +689,31 @@ mod tests {
         expected[8..12].copy_from_slice(&[200, 201, 202, 203]);
         assert_eq!(actual, expected);
         assert_eq!(sum, (0_u64..64).sum());
+    }
+
+    #[test]
+    fn small_buffer_keeps_the_original_serial_finish_path() {
+        let file = tempfile::tempfile().unwrap();
+        let mut reader = file.try_clone().unwrap();
+        let bytes = vec![7; 64];
+        let mut output = OsOutputFile {
+            file,
+            buffer: OsOutputBuffer::InMemory(bytes.clone()),
+            path: Arc::from(Path::new("small-buffer-test")),
+            preflushed_range: None,
+            can_preflush: false,
+        };
+
+        output
+            .compute_while_preflushing(8..12, |data| assert_eq!(data, bytes))
+            .unwrap();
+        assert_eq!(reader.metadata().unwrap().len(), 0);
+        output.finish().unwrap();
+
+        reader.seek(SeekFrom::Start(0)).unwrap();
+        let mut actual = Vec::new();
+        reader.read_to_end(&mut actual).unwrap();
+        assert_eq!(actual, bytes);
     }
 }
 

--- a/crates/reld-core/src/fs.rs
+++ b/crates/reld-core/src/fs.rs
@@ -9,16 +9,14 @@ use memmap2::Mmap;
 use memmap2::MmapOptions;
 use std::fs::File;
 use std::io::ErrorKind;
-use std::io::Seek as _;
-use std::io::SeekFrom;
 use std::io::Write as _;
 use std::ops::Deref;
-use std::ops::Range;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-const LARGE_BUFFERED_OUTPUT_THRESHOLD: u64 = 256 * 1024 * 1024;
+#[cfg(target_os = "linux")]
+const LARGE_EXT4_OUTPUT_THRESHOLD: u64 = 256 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileReplacementMode {
@@ -73,17 +71,6 @@ pub trait OutputFileData: Send {
 
     /// Returns the output buffer for random-access writing.
     fn bytes_mut(&mut self) -> &mut [u8];
-
-    /// Compute from the completed output while, where supported, persisting all bytes that will
-    /// not be changed by the computation. `dirty_range` is written after the computation.
-    fn compute_while_preflushing<T>(
-        &mut self,
-        dirty_range: Range<usize>,
-        compute: impl FnOnce(&[u8]) -> T,
-    ) -> Result<T> {
-        let _ = dirty_range;
-        Ok(compute(self.bytes()))
-    }
 
     /// Persist the bytes and apply final file attributes.
     fn finish(self) -> Result;
@@ -356,8 +343,6 @@ pub struct OsOutputFile {
     file: File,
     buffer: OsOutputBuffer,
     path: Arc<Path>,
-    preflushed_range: Option<Range<usize>>,
-    can_preflush: bool,
 }
 
 impl OutputFileData for OsOutputFile {
@@ -375,45 +360,11 @@ impl OutputFileData for OsOutputFile {
         }
     }
 
-    fn compute_while_preflushing<T>(
-        &mut self,
-        dirty_range: Range<usize>,
-        compute: impl FnOnce(&[u8]) -> T,
-    ) -> Result<T> {
-        let OsOutputBuffer::InMemory(bytes) = &self.buffer else {
-            return Ok(compute(self.bytes()));
-        };
-        if !self.can_preflush {
-            return Ok(compute(bytes));
-        }
-
-        let Ok(mut file) = self.file.try_clone() else {
-            return Ok(compute(bytes));
-        };
-        let result = std::thread::scope(|scope| -> Result<T> {
-            let writer = scope.spawn(|| -> std::io::Result<()> {
-                file.seek(SeekFrom::Start(0))?;
-                file.write_all(bytes)
-            });
-            let result = compute(bytes);
-            writer.join().expect("preflush worker panicked")?;
-            Ok(result)
-        })?;
-        self.preflushed_range = Some(dirty_range);
-        Ok(result)
-    }
-
     fn finish(self) -> Result {
         if let OsOutputBuffer::InMemory(bytes) = &self.buffer {
-            let mut file = &self.file;
-            if let Some(range) = self.preflushed_range {
-                file.seek(SeekFrom::Start(range.start as u64))?;
-                file.write_all(&bytes[range])
-                    .with_context(|| format!("Failed to patch {}", self.path.display()))?;
-            } else {
-                file.write_all(bytes)
-                    .with_context(|| format!("Failed to write to {}", self.path.display()))?;
-            }
+            (&self.file)
+                .write_all(bytes)
+                .with_context(|| format!("Failed to write to {}", self.path.display()))?;
         }
 
         // Making the file executable is best-effort only. For example if we're writing to a pipe or
@@ -550,6 +501,8 @@ impl FileSystem for OsFileSystem {
             }
         };
 
+        let should_preallocate = options.write_mode.is_none()
+            && should_preallocate_large_ext4_output(&file, options.size);
         let file_write_mode = options
             .write_mode
             .unwrap_or_else(|| default_file_write_mode_for_file(&file, options.size));
@@ -559,6 +512,7 @@ impl FileSystem for OsFileSystem {
                 // For some types of output file (e.g. character devices) we can't mmap, so we try
                 // to mmap the file and if it fails, fall back to non-mmapped output.
                 if file.set_len(options.size).is_ok() {
+                    preallocate_output_file(&file, options.size, should_preallocate);
                     match unsafe { MmapOptions::new().map_mut(&file) } {
                         Ok(mmap) => OsOutputBuffer::Mmap(mmap),
                         Err(_) => OsOutputBuffer::InMemory(vec![0; options.size as usize]),
@@ -576,17 +530,7 @@ impl FileSystem for OsFileSystem {
                 OsOutputBuffer::InMemory(vec![0; options.size as usize])
             }
         };
-        let can_preflush = file_write_mode == FileWriteMode::BufferThenWrite
-            && options.size >= LARGE_BUFFERED_OUTPUT_THRESHOLD
-            && file.metadata().is_ok_and(|metadata| metadata.is_file());
-
-        Ok(OsOutputFile {
-            file,
-            buffer,
-            path,
-            preflushed_range: None,
-            can_preflush,
-        })
+        Ok(OsOutputFile { file, buffer, path })
     }
 
     fn write_auxiliary(&self, path: &Path, bytes: &[u8]) -> Result {
@@ -616,37 +560,73 @@ fn default_file_write_mode_for_file(file: &std::fs::File, output_size: u64) -> F
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn default_file_write_mode_for_filesystem_type(
     filesystem_type: Option<nix::sys::statfs::FsType>,
-    output_size: u64,
+    _output_size: u64,
 ) -> FileWriteMode {
-    match filesystem_type {
-        // Preserve the existing Btrfs/vfat policy at every size.
-        Some(nix::sys::statfs::BTRFS_SUPER_MAGIC | nix::sys::statfs::MSDOS_SUPER_MAGIC) => {
-            FileWriteMode::BufferThenWrite
-        }
-        #[cfg(target_os = "linux")]
-        Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
-            if output_size >= LARGE_BUFFERED_OUTPUT_THRESHOLD =>
-        {
-            FileWriteMode::BufferThenWrite
-        }
-        _ => FileWriteMode::Mmap,
+    // Preserve the existing Btrfs/vfat policy at every size.
+    if let Some(nix::sys::statfs::BTRFS_SUPER_MAGIC | nix::sys::statfs::MSDOS_SUPER_MAGIC) =
+        filesystem_type
+    {
+        FileWriteMode::BufferThenWrite
+    } else {
+        FileWriteMode::Mmap
     }
+}
+
+fn should_preallocate_large_ext4_output(file: &std::fs::File, output_size: u64) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        should_preallocate_large_ext4_output_for_filesystem_type(
+            nix::sys::statfs::fstatfs(file)
+                .map(|stat| stat.filesystem_type())
+                .ok(),
+            output_size,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (file, output_size);
+        false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_preallocate_large_ext4_output_for_filesystem_type(
+    filesystem_type: Option<nix::sys::statfs::FsType>,
+    output_size: u64,
+) -> bool {
+    filesystem_type == Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
+        && output_size >= LARGE_EXT4_OUTPUT_THRESHOLD
+}
+
+fn preallocate_output_file(file: &std::fs::File, output_size: u64, should_preallocate: bool) {
+    #[cfg(target_os = "linux")]
+    if should_preallocate {
+        // Reserving extents is substantially cheaper than faulting every output page up front and
+        // lets the existing parallel mmap writer avoid block allocation on its critical path.
+        let _ = nix::fcntl::fallocate(
+            file,
+            nix::fcntl::FallocateFlags::empty(),
+            0,
+            output_size as libc::off_t,
+        );
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = (file, output_size, should_preallocate);
 }
 
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::io::Read as _;
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn only_large_linux_ext4_outputs_use_the_measured_buffered_path() {
+    fn only_large_linux_ext4_outputs_are_preallocated() {
         assert_eq!(
             default_file_write_mode_for_filesystem_type(
                 Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
                 256 * 1024 * 1024,
             ),
-            FileWriteMode::BufferThenWrite
+            FileWriteMode::Mmap
         );
         assert_eq!(
             default_file_write_mode_for_filesystem_type(
@@ -655,65 +635,18 @@ mod tests {
             ),
             FileWriteMode::Mmap
         );
-        assert_eq!(
-            default_file_write_mode_for_filesystem_type(None, 256 * 1024 * 1024),
-            FileWriteMode::Mmap
-        );
-    }
-
-    #[test]
-    fn buffered_preflush_patches_only_the_post_hash_range() {
-        let file = tempfile::tempfile().unwrap();
-        let mut reader = file.try_clone().unwrap();
-        let original: Vec<u8> = (0..64).collect();
-        let mut output = OsOutputFile {
-            file,
-            buffer: OsOutputBuffer::InMemory(original.clone()),
-            path: Arc::from(Path::new("preflush-test")),
-            preflushed_range: None,
-            can_preflush: true,
-        };
-
-        let sum = output
-            .compute_while_preflushing(8..12, |bytes| {
-                bytes.iter().map(|byte| u64::from(*byte)).sum::<u64>()
-            })
-            .unwrap();
-        output.bytes_mut()[8..12].copy_from_slice(&[200, 201, 202, 203]);
-        output.finish().unwrap();
-
-        let mut actual = Vec::new();
-        reader.seek(SeekFrom::Start(0)).unwrap();
-        reader.read_to_end(&mut actual).unwrap();
-        let mut expected = original;
-        expected[8..12].copy_from_slice(&[200, 201, 202, 203]);
-        assert_eq!(actual, expected);
-        assert_eq!(sum, (0_u64..64).sum());
-    }
-
-    #[test]
-    fn small_buffer_keeps_the_original_serial_finish_path() {
-        let file = tempfile::tempfile().unwrap();
-        let mut reader = file.try_clone().unwrap();
-        let bytes = vec![7; 64];
-        let mut output = OsOutputFile {
-            file,
-            buffer: OsOutputBuffer::InMemory(bytes.clone()),
-            path: Arc::from(Path::new("small-buffer-test")),
-            preflushed_range: None,
-            can_preflush: false,
-        };
-
-        output
-            .compute_while_preflushing(8..12, |data| assert_eq!(data, bytes))
-            .unwrap();
-        assert_eq!(reader.metadata().unwrap().len(), 0);
-        output.finish().unwrap();
-
-        reader.seek(SeekFrom::Start(0)).unwrap();
-        let mut actual = Vec::new();
-        reader.read_to_end(&mut actual).unwrap();
-        assert_eq!(actual, bytes);
+        assert!(should_preallocate_large_ext4_output_for_filesystem_type(
+            Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
+            256 * 1024 * 1024,
+        ));
+        assert!(!should_preallocate_large_ext4_output_for_filesystem_type(
+            Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
+            64 * 1024 * 1024,
+        ));
+        assert!(!should_preallocate_large_ext4_output_for_filesystem_type(
+            None,
+            256 * 1024 * 1024,
+        ));
     }
 }
 

--- a/crates/reld-core/src/fs.rs
+++ b/crates/reld-core/src/fs.rs
@@ -9,8 +9,11 @@ use memmap2::Mmap;
 use memmap2::MmapOptions;
 use std::fs::File;
 use std::io::ErrorKind;
+use std::io::Seek as _;
+use std::io::SeekFrom;
 use std::io::Write as _;
 use std::ops::Deref;
+use std::ops::Range;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -68,6 +71,17 @@ pub trait OutputFileData: Send {
 
     /// Returns the output buffer for random-access writing.
     fn bytes_mut(&mut self) -> &mut [u8];
+
+    /// Compute from the completed output while, where supported, persisting all bytes that will
+    /// not be changed by the computation. `dirty_range` is written after the computation.
+    fn compute_while_preflushing<T>(
+        &mut self,
+        dirty_range: Range<usize>,
+        compute: impl FnOnce(&[u8]) -> T,
+    ) -> Result<T> {
+        let _ = dirty_range;
+        Ok(compute(self.bytes()))
+    }
 
     /// Persist the bytes and apply final file attributes.
     fn finish(self) -> Result;
@@ -340,6 +354,7 @@ pub struct OsOutputFile {
     file: File,
     buffer: OsOutputBuffer,
     path: Arc<Path>,
+    preflushed_range: Option<Range<usize>>,
 }
 
 impl OutputFileData for OsOutputFile {
@@ -357,11 +372,40 @@ impl OutputFileData for OsOutputFile {
         }
     }
 
+    fn compute_while_preflushing<T>(
+        &mut self,
+        dirty_range: Range<usize>,
+        compute: impl FnOnce(&[u8]) -> T,
+    ) -> Result<T> {
+        let OsOutputBuffer::InMemory(bytes) = &self.buffer else {
+            return Ok(compute(self.bytes()));
+        };
+
+        let mut file = self.file.try_clone()?;
+        let result = std::thread::scope(|scope| -> Result<T> {
+            let writer = scope.spawn(|| -> std::io::Result<()> {
+                file.seek(SeekFrom::Start(0))?;
+                file.write_all(bytes)
+            });
+            let result = compute(bytes);
+            writer.join().expect("preflush worker panicked")?;
+            Ok(result)
+        })?;
+        self.preflushed_range = Some(dirty_range);
+        Ok(result)
+    }
+
     fn finish(self) -> Result {
         if let OsOutputBuffer::InMemory(bytes) = &self.buffer {
-            (&self.file)
-                .write_all(bytes)
-                .with_context(|| format!("Failed to write to {}", self.path.display()))?;
+            let mut file = &self.file;
+            if let Some(range) = self.preflushed_range {
+                file.seek(SeekFrom::Start(range.start as u64))?;
+                file.write_all(&bytes[range])
+                    .with_context(|| format!("Failed to patch {}", self.path.display()))?;
+            } else {
+                file.write_all(bytes)
+                    .with_context(|| format!("Failed to write to {}", self.path.display()))?;
+            }
         }
 
         // Making the file executable is best-effort only. For example if we're writing to a pipe or
@@ -498,8 +542,6 @@ impl FileSystem for OsFileSystem {
             }
         };
 
-        let should_prefault_output = options.write_mode.is_none()
-            && should_prefault_output_mmap_for_file(&file, options.size);
         let file_write_mode = options
             .write_mode
             .unwrap_or_else(|| default_file_write_mode_for_file(&file, options.size));
@@ -510,10 +552,7 @@ impl FileSystem for OsFileSystem {
                 // to mmap the file and if it fails, fall back to non-mmapped output.
                 if file.set_len(options.size).is_ok() {
                     match unsafe { MmapOptions::new().map_mut(&file) } {
-                        Ok(mmap) => {
-                            prefault_output_mmap(&mmap, should_prefault_output);
-                            OsOutputBuffer::Mmap(mmap)
-                        }
+                        Ok(mmap) => OsOutputBuffer::Mmap(mmap),
                         Err(_) => OsOutputBuffer::InMemory(vec![0; options.size as usize]),
                     }
                 } else {
@@ -530,7 +569,12 @@ impl FileSystem for OsFileSystem {
             }
         };
 
-        Ok(OsOutputFile { file, buffer, path })
+        Ok(OsOutputFile {
+            file,
+            buffer,
+            path,
+            preflushed_range: None,
+        })
     }
 
     fn write_auxiliary(&self, path: &Path, bytes: &[u8]) -> Result {
@@ -560,75 +604,43 @@ fn default_file_write_mode_for_file(file: &std::fs::File, output_size: u64) -> F
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn default_file_write_mode_for_filesystem_type(
     filesystem_type: Option<nix::sys::statfs::FsType>,
-    _output_size: u64,
+    output_size: u64,
 ) -> FileWriteMode {
+    const LARGE_EXT4_BUFFERED_OUTPUT_THRESHOLD: u64 = 256 * 1024 * 1024;
+
     match filesystem_type {
         // Preserve the existing Btrfs/vfat policy at every size.
         Some(nix::sys::statfs::BTRFS_SUPER_MAGIC | nix::sys::statfs::MSDOS_SUPER_MAGIC) => {
+            FileWriteMode::BufferThenWrite
+        }
+        #[cfg(target_os = "linux")]
+        Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
+            if output_size >= LARGE_EXT4_BUFFERED_OUTPUT_THRESHOLD =>
+        {
             FileWriteMode::BufferThenWrite
         }
         _ => FileWriteMode::Mmap,
     }
 }
 
-fn should_prefault_output_mmap_for_file(file: &std::fs::File, output_size: u64) -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        should_prefault_output_mmap_for_filesystem_type(
-            nix::sys::statfs::fstatfs(file)
-                .map(|stat| stat.filesystem_type())
-                .ok(),
-            output_size,
-        )
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (file, output_size);
-        false
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn should_prefault_output_mmap_for_filesystem_type(
-    filesystem_type: Option<nix::sys::statfs::FsType>,
-    output_size: u64,
-) -> bool {
-    const EXT4_PREFAULT_THRESHOLD: u64 = 64 * 1024 * 1024;
-
-    filesystem_type == Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
-        && output_size >= EXT4_PREFAULT_THRESHOLD
-}
-
-fn prefault_output_mmap(mmap: &memmap2::MmapMut, should_prefault: bool) {
-    #[cfg(target_os = "linux")]
-    if should_prefault {
-        // Output creation runs on a background Rayon task, so this moves the unavoidable writable
-        // page faults off the writer's critical path and overlaps them with layout. Kernels older
-        // than 5.14 reject MADV_POPULATE_WRITE; in that case the normal fault-on-write path remains.
-        let _ = mmap.advise(memmap2::Advice::PopulateWrite);
-    }
-    #[cfg(not(target_os = "linux"))]
-    let _ = (mmap, should_prefault);
-}
-
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     #[test]
-    fn large_ext4_output_stays_mmap_for_background_prefaulting() {
+    fn only_large_linux_ext4_outputs_use_the_measured_buffered_path() {
         assert_eq!(
             default_file_write_mode_for_filesystem_type(
                 Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
                 256 * 1024 * 1024,
             ),
-            FileWriteMode::Mmap
+            FileWriteMode::BufferThenWrite
         );
         assert_eq!(
             default_file_write_mode_for_filesystem_type(
                 Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
-                1024 * 1024,
+                64 * 1024 * 1024,
             ),
             FileWriteMode::Mmap
         );
@@ -636,18 +648,37 @@ mod tests {
             default_file_write_mode_for_filesystem_type(None, 256 * 1024 * 1024),
             FileWriteMode::Mmap
         );
-        assert!(should_prefault_output_mmap_for_filesystem_type(
-            Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
-            256 * 1024 * 1024,
-        ));
-        assert!(!should_prefault_output_mmap_for_filesystem_type(
-            Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
-            1024 * 1024,
-        ));
-        assert!(!should_prefault_output_mmap_for_filesystem_type(
-            None,
-            256 * 1024 * 1024,
-        ));
+    }
+
+    #[test]
+    fn buffered_preflush_patches_only_the_post_hash_range() {
+        use std::io::Read as _;
+
+        let file = tempfile::tempfile().unwrap();
+        let mut reader = file.try_clone().unwrap();
+        let original: Vec<u8> = (0..64).collect();
+        let mut output = OsOutputFile {
+            file,
+            buffer: OsOutputBuffer::InMemory(original.clone()),
+            path: Arc::from(Path::new("preflush-test")),
+            preflushed_range: None,
+        };
+
+        let sum = output
+            .compute_while_preflushing(8..12, |bytes| {
+                bytes.iter().map(|byte| u64::from(*byte)).sum::<u64>()
+            })
+            .unwrap();
+        output.bytes_mut()[8..12].copy_from_slice(&[200, 201, 202, 203]);
+        output.finish().unwrap();
+
+        let mut actual = Vec::new();
+        reader.seek(SeekFrom::Start(0)).unwrap();
+        reader.read_to_end(&mut actual).unwrap();
+        let mut expected = original;
+        expected[8..12].copy_from_slice(&[200, 201, 202, 203]);
+        assert_eq!(actual, expected);
+        assert_eq!(sum, (0_u64..64).sum());
     }
 }
 

--- a/crates/reld-core/src/fs.rs
+++ b/crates/reld-core/src/fs.rs
@@ -7,6 +7,8 @@ use crate::error::Context as _;
 use crate::error::Result;
 use memmap2::Mmap;
 use memmap2::MmapOptions;
+#[cfg(unix)]
+use rayon::prelude::*;
 use std::fs::File;
 use std::io::ErrorKind;
 use std::io::Write as _;
@@ -31,7 +33,7 @@ pub enum FileReplacementMode {
     UpdateInPlaceWithFallback,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileWriteMode {
     Mmap,
     BufferThenWrite,
@@ -357,10 +359,9 @@ impl OutputFileData for OsOutputFile {
         }
     }
 
-    fn finish(mut self) -> Result {
+    fn finish(self) -> Result {
         if let OsOutputBuffer::InMemory(bytes) = &self.buffer {
-            self.file
-                .write_all(bytes)
+            write_buffer_to_file(&self.file, bytes)
                 .with_context(|| format!("Failed to write to {}", self.path.display()))?;
         }
 
@@ -381,6 +382,35 @@ impl OutputFileData for OsOutputFile {
         #[cfg(not(target_os = "macos"))]
         let _ = len;
     }
+}
+
+#[cfg(unix)]
+const PARALLEL_FILE_WRITE_SIZE_THRESHOLD: usize = 1_000_000;
+#[cfg(unix)]
+const PARALLEL_FILE_WRITE_CHUNKS_PER_THREAD: usize = 8;
+
+fn write_buffer_to_file(mut file: &File, bytes: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    if bytes.len() >= PARALLEL_FILE_WRITE_SIZE_THRESHOLD
+        && rayon::current_num_threads() > 1
+        && file.metadata().is_ok_and(|metadata| metadata.is_file())
+    {
+        use std::os::unix::fs::FileExt as _;
+
+        let target_chunks =
+            rayon::current_num_threads().saturating_mul(PARALLEL_FILE_WRITE_CHUNKS_PER_THREAD);
+        let chunk_size = bytes
+            .len()
+            .div_ceil(target_chunks)
+            .max(PARALLEL_FILE_WRITE_SIZE_THRESHOLD);
+        bytes
+            .par_chunks(chunk_size)
+            .enumerate()
+            .try_for_each(|(index, chunk)| file.write_all_at(chunk, (index * chunk_size) as u64))?;
+        return Ok(());
+    }
+
+    file.write_all(bytes)
 }
 
 impl FileSystem for OsFileSystem {
@@ -500,7 +530,7 @@ impl FileSystem for OsFileSystem {
 
         let file_write_mode = options
             .write_mode
-            .unwrap_or_else(|| default_file_write_mode_for_file(&file));
+            .unwrap_or_else(|| default_file_write_mode_for_file(&file, options.size));
 
         let buffer = match file_write_mode {
             FileWriteMode::Mmap => {
@@ -535,26 +565,96 @@ impl FileSystem for OsFileSystem {
     }
 }
 
-fn default_file_write_mode_for_file(file: &std::fs::File) -> FileWriteMode {
+fn default_file_write_mode_for_file(file: &std::fs::File, output_size: u64) -> FileWriteMode {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     {
-        match nix::sys::statfs::fstatfs(file)
-            .map(|stat| stat.filesystem_type())
-            .ok()
-        {
-            // Multi-threaded write performance with BTRFS is terrible. It's substantially faster to
-            // just buffer it all in memory then write it afterwards.
-            Some(nix::sys::statfs::BTRFS_SUPER_MAGIC) => FileWriteMode::BufferThenWrite,
-            // vfat isn't quite as bad as BTRFS in this regard, but it's still at least 4-10% faster
-            // if we avoid mmap.
-            Some(nix::sys::statfs::MSDOS_SUPER_MAGIC) => FileWriteMode::BufferThenWrite,
-            _ => FileWriteMode::Mmap,
-        }
+        default_file_write_mode_for_filesystem_type(
+            nix::sys::statfs::fstatfs(file)
+                .map(|stat| stat.filesystem_type())
+                .ok(),
+            output_size,
+        )
     }
     #[cfg(not(any(target_os = "android", target_os = "linux")))]
     {
-        let _ = file;
+        let _ = (file, output_size);
         FileWriteMode::Mmap
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+fn default_file_write_mode_for_filesystem_type(
+    filesystem_type: Option<nix::sys::statfs::FsType>,
+    output_size: u64,
+) -> FileWriteMode {
+    const EXT4_BUFFERED_OUTPUT_THRESHOLD: u64 = 64 * 1024 * 1024;
+
+    match filesystem_type {
+        // Preserve the existing Btrfs/vfat policy at every size.
+        Some(nix::sys::statfs::BTRFS_SUPER_MAGIC | nix::sys::statfs::MSDOS_SUPER_MAGIC) => {
+            FileWriteMode::BufferThenWrite
+        }
+        // ext4 was measured directly on GitHub's Linux runner in issue #74. Keep mmap for small
+        // outputs so ordinary link latency is unchanged; large outputs use parallel ranged writes.
+        Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
+            if output_size >= EXT4_BUFFERED_OUTPUT_THRESHOLD =>
+        {
+            FileWriteMode::BufferThenWrite
+        }
+        _ => FileWriteMode::Mmap,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn ext4_uses_measured_buffered_output_without_changing_unknown_filesystems() {
+        assert_eq!(
+            default_file_write_mode_for_filesystem_type(
+                Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
+                256 * 1024 * 1024,
+            ),
+            FileWriteMode::BufferThenWrite
+        );
+        assert_eq!(
+            default_file_write_mode_for_filesystem_type(
+                Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
+                1024 * 1024,
+            ),
+            FileWriteMode::Mmap
+        );
+        assert_eq!(
+            default_file_write_mode_for_filesystem_type(None, 256 * 1024 * 1024),
+            FileWriteMode::Mmap
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parallel_ranged_write_preserves_every_byte() {
+        use std::io::Read as _;
+        use std::io::Seek as _;
+
+        let mut file = tempfile::tempfile().unwrap();
+        let bytes: Vec<u8> = (0..PARALLEL_FILE_WRITE_SIZE_THRESHOLD * 2)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        file.set_len(bytes.len() as u64).unwrap();
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap();
+
+        pool.install(|| write_buffer_to_file(&file, &bytes))
+            .unwrap();
+
+        file.rewind().unwrap();
+        let mut actual = Vec::new();
+        file.read_to_end(&mut actual).unwrap();
+        assert_eq!(actual, bytes);
     }
 }
 

--- a/crates/reld-core/src/fs.rs
+++ b/crates/reld-core/src/fs.rs
@@ -7,8 +7,6 @@ use crate::error::Context as _;
 use crate::error::Result;
 use memmap2::Mmap;
 use memmap2::MmapOptions;
-#[cfg(unix)]
-use rayon::prelude::*;
 use std::fs::File;
 use std::io::ErrorKind;
 use std::io::Write as _;
@@ -361,7 +359,8 @@ impl OutputFileData for OsOutputFile {
 
     fn finish(self) -> Result {
         if let OsOutputBuffer::InMemory(bytes) = &self.buffer {
-            write_buffer_to_file(&self.file, bytes)
+            (&self.file)
+                .write_all(bytes)
                 .with_context(|| format!("Failed to write to {}", self.path.display()))?;
         }
 
@@ -382,35 +381,6 @@ impl OutputFileData for OsOutputFile {
         #[cfg(not(target_os = "macos"))]
         let _ = len;
     }
-}
-
-#[cfg(unix)]
-const PARALLEL_FILE_WRITE_SIZE_THRESHOLD: usize = 1_000_000;
-#[cfg(unix)]
-const PARALLEL_FILE_WRITE_CHUNKS_PER_THREAD: usize = 8;
-
-fn write_buffer_to_file(mut file: &File, bytes: &[u8]) -> std::io::Result<()> {
-    #[cfg(unix)]
-    if bytes.len() >= PARALLEL_FILE_WRITE_SIZE_THRESHOLD
-        && rayon::current_num_threads() > 1
-        && file.metadata().is_ok_and(|metadata| metadata.is_file())
-    {
-        use std::os::unix::fs::FileExt as _;
-
-        let target_chunks =
-            rayon::current_num_threads().saturating_mul(PARALLEL_FILE_WRITE_CHUNKS_PER_THREAD);
-        let chunk_size = bytes
-            .len()
-            .div_ceil(target_chunks)
-            .max(PARALLEL_FILE_WRITE_SIZE_THRESHOLD);
-        bytes
-            .par_chunks(chunk_size)
-            .enumerate()
-            .try_for_each(|(index, chunk)| file.write_all_at(chunk, (index * chunk_size) as u64))?;
-        return Ok(());
-    }
-
-    file.write_all(bytes)
 }
 
 impl FileSystem for OsFileSystem {
@@ -528,6 +498,8 @@ impl FileSystem for OsFileSystem {
             }
         };
 
+        let should_prefault_output = options.write_mode.is_none()
+            && should_prefault_output_mmap_for_file(&file, options.size);
         let file_write_mode = options
             .write_mode
             .unwrap_or_else(|| default_file_write_mode_for_file(&file, options.size));
@@ -538,7 +510,10 @@ impl FileSystem for OsFileSystem {
                 // to mmap the file and if it fails, fall back to non-mmapped output.
                 if file.set_len(options.size).is_ok() {
                     match unsafe { MmapOptions::new().map_mut(&file) } {
-                        Ok(mmap) => OsOutputBuffer::Mmap(mmap),
+                        Ok(mmap) => {
+                            prefault_output_mmap(&mmap, should_prefault_output);
+                            OsOutputBuffer::Mmap(mmap)
+                        }
                         Err(_) => OsOutputBuffer::InMemory(vec![0; options.size as usize]),
                     }
                 } else {
@@ -585,24 +560,55 @@ fn default_file_write_mode_for_file(file: &std::fs::File, output_size: u64) -> F
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn default_file_write_mode_for_filesystem_type(
     filesystem_type: Option<nix::sys::statfs::FsType>,
-    output_size: u64,
+    _output_size: u64,
 ) -> FileWriteMode {
-    const EXT4_BUFFERED_OUTPUT_THRESHOLD: u64 = 64 * 1024 * 1024;
-
     match filesystem_type {
         // Preserve the existing Btrfs/vfat policy at every size.
         Some(nix::sys::statfs::BTRFS_SUPER_MAGIC | nix::sys::statfs::MSDOS_SUPER_MAGIC) => {
             FileWriteMode::BufferThenWrite
         }
-        // ext4 was measured directly on GitHub's Linux runner in issue #74. Keep mmap for small
-        // outputs so ordinary link latency is unchanged; large outputs use parallel ranged writes.
-        Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
-            if output_size >= EXT4_BUFFERED_OUTPUT_THRESHOLD =>
-        {
-            FileWriteMode::BufferThenWrite
-        }
         _ => FileWriteMode::Mmap,
     }
+}
+
+fn should_prefault_output_mmap_for_file(file: &std::fs::File, output_size: u64) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        should_prefault_output_mmap_for_filesystem_type(
+            nix::sys::statfs::fstatfs(file)
+                .map(|stat| stat.filesystem_type())
+                .ok(),
+            output_size,
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (file, output_size);
+        false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_prefault_output_mmap_for_filesystem_type(
+    filesystem_type: Option<nix::sys::statfs::FsType>,
+    output_size: u64,
+) -> bool {
+    const EXT4_PREFAULT_THRESHOLD: u64 = 64 * 1024 * 1024;
+
+    filesystem_type == Some(nix::sys::statfs::EXT4_SUPER_MAGIC)
+        && output_size >= EXT4_PREFAULT_THRESHOLD
+}
+
+fn prefault_output_mmap(mmap: &memmap2::MmapMut, should_prefault: bool) {
+    #[cfg(target_os = "linux")]
+    if should_prefault {
+        // Output creation runs on a background Rayon task, so this moves the unavoidable writable
+        // page faults off the writer's critical path and overlaps them with layout. Kernels older
+        // than 5.14 reject MADV_POPULATE_WRITE; in that case the normal fault-on-write path remains.
+        let _ = mmap.advise(memmap2::Advice::PopulateWrite);
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = (mmap, should_prefault);
 }
 
 #[cfg(all(test, unix))]
@@ -630,31 +636,18 @@ mod tests {
             default_file_write_mode_for_filesystem_type(None, 256 * 1024 * 1024),
             FileWriteMode::Mmap
         );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn parallel_ranged_write_preserves_every_byte() {
-        use std::io::Read as _;
-        use std::io::Seek as _;
-
-        let mut file = tempfile::tempfile().unwrap();
-        let bytes: Vec<u8> = (0..PARALLEL_FILE_WRITE_SIZE_THRESHOLD * 2)
-            .map(|index| (index % 251) as u8)
-            .collect();
-        file.set_len(bytes.len() as u64).unwrap();
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(4)
-            .build()
-            .unwrap();
-
-        pool.install(|| write_buffer_to_file(&file, &bytes))
-            .unwrap();
-
-        file.rewind().unwrap();
-        let mut actual = Vec::new();
-        file.read_to_end(&mut actual).unwrap();
-        assert_eq!(actual, bytes);
+        assert!(should_prefault_output_mmap_for_filesystem_type(
+            Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
+            256 * 1024 * 1024,
+        ));
+        assert!(!should_prefault_output_mmap_for_filesystem_type(
+            Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
+            1024 * 1024,
+        ));
+        assert!(!should_prefault_output_mmap_for_filesystem_type(
+            None,
+            256 * 1024 * 1024,
+        ));
     }
 }
 

--- a/crates/reld-core/src/fs.rs
+++ b/crates/reld-core/src/fs.rs
@@ -611,13 +611,13 @@ mod tests {
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[test]
-    fn ext4_uses_measured_buffered_output_without_changing_unknown_filesystems() {
+    fn large_ext4_output_stays_mmap_for_background_prefaulting() {
         assert_eq!(
             default_file_write_mode_for_filesystem_type(
                 Some(nix::sys::statfs::EXT4_SUPER_MAGIC),
                 256 * 1024 * 1024,
             ),
-            FileWriteMode::BufferThenWrite
+            FileWriteMode::Mmap
         );
         assert_eq!(
             default_file_write_mode_for_filesystem_type(


### PR DESCRIPTION
## Summary

- add an exact-SHA, retained-large-output Linux benchmark gate with round-robin trials, phase diagnostics, filesystem metadata, and isolated history
- rebalance large section copy work and preallocate large ext4 mmap outputs without changing small-link or explicit output-mode behavior
- replace bare/fast ELF build-ID BLAKE3 hashing with full-content XXH3-128 while preserving explicit named-mode behavior
- keep the benchmark workflow Bash-only with one `uv sync --extra dev` and subsequent `uv run --no-sync ...` commands

## RED → GREEN evidence

Final exact-SHA all-platform workflow: https://github.com/zackees/reld/actions/runs/32853535193

Linux paired exact baseline (`be6a8cd032ea6dc788978264c860fe761d5090b6`) versus HEAD (`887e4275ec1bc4ff87e2c962ffb84a4e61390061`):

| Configuration | Baseline median | HEAD median | Improvement | Baseline build ID | HEAD build ID | Build-ID reduction |
|---|---:|---:|---:|---:|---:|---:|
| no-LTO | 468.91 ms | 385.24 ms | 17.84% | 61.50 ms | 24.33 ms | 60.44% |
| ThinLTO | 426.19 ms | 363.64 ms | 14.68% | 51.81 ms | 19.67 ms | 62.03% |
| full-LTO | 400.60 ms | 349.65 ms | 12.72% | 49.18 ms | 18.79 ms | 61.79% |

The published-link rows also put native reld ahead of Wild in all three configurations on this run. Startup remained separate and unsubtracted; the largest startup was 11.5 ms, below 3.3% of the Wild reference link in every row.

The Linux, macOS, Windows, graph rendering, README block, exact-SHA, history isolation, and freshness/schema jobs all passed.

## Small-link non-regression

A separate bosn Linux probe built the exact baseline and HEAD in release mode, compiled one `_start` input outside timing, replayed only the native final link with fixed `--no-fork --threads=4 --build-id` flags for 100 measured rounds per binary after four warmups, alternated order, and executed every output:

| Binary | Median | MAD |
|---|---:|---:|
| exact baseline | 4.320 ms | 0.367 ms |
| HEAD | 4.120 ms | 0.250 ms |

HEAD was 4.62% faster, satisfying the no-more-than-2% ordinary-link regression requirement.

## Validation

- `uv sync --extra dev`
- `uv run --no-sync pytest ci/tests -q` — 148 passed
- `bosn run -- cargo clippy -p reld-core --no-default-features`
- `bosn run -- bash -c 'cargo test -p reld-core --no-default-features -- --skip tidy_tests::check_sources_format --skip tidy_tests::check_toml_format'` — 157 passed, 2 environment-only tidy checks skipped because the existing image lacks `clang-format` and `taplo`
- `bosn smoke`
- real ELF build-ID smoke: all outputs executed; `readelf -n` recognized bare, fast, md5, and sha1 notes with preserved mode widths
- three clud-review cycles completed during implementation; all findings were addressed before the final candidate

Closes #74
Related: #75
