### PR TITLE
perf(elf): extend the Wild fork to a full-LTO lead over mold

### DIFF
--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -2985,6 +2985,29 @@ mod debug_relocation_shard_tests {
     use super::*;
 
     #[test]
+    fn caches_each_debug_symbol_target_once_per_shard() {
+        let mut cache = DebugRelocationTargetCache::new(8);
+        let mut resolutions = 0;
+
+        let first = cache
+            .get_or_try_insert_with(object::SymbolIndex(3), || {
+                resolutions += 1;
+                Ok::<_, crate::error::Error>(41_u64)
+            })
+            .unwrap();
+        let second = cache
+            .get_or_try_insert_with(object::SymbolIndex(3), || {
+                resolutions += 1;
+                Ok::<_, crate::error::Error>(99_u64)
+            })
+            .unwrap();
+
+        assert_eq!(first, 41);
+        assert_eq!(second, 41);
+        assert_eq!(resolutions, 1, "a repeated relocation target must resolve once");
+    }
+
+    #[test]
     fn splits_sorted_non_overlapping_relocations_into_disjoint_output_ranges() {
         let offsets = [0, 4, 8, 12, 16, 20, 24, 28];
         let ranges =

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -2747,6 +2747,13 @@ struct DebugRelocationShardRange {
     output: Range<usize>,
 }
 
+struct DebugRelocationShardSummary {
+    relocations: Range<usize>,
+    first_offset: u64,
+    last_offset: u64,
+    max_write_end: u64,
+}
+
 fn debug_relocation_write_size<A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>>(
     relocation: &R,
 ) -> Result<usize> {
@@ -2760,6 +2767,7 @@ fn debug_relocation_write_size<A: Arch<Platform = Elf>, R: Relocation<Platform =
     })
 }
 
+#[cfg(test)]
 fn debug_relocation_shard_ranges(
     relocation_count: usize,
     output_len: usize,
@@ -2832,6 +2840,93 @@ fn debug_relocation_shard_ranges(
     Ok(Some(ranges))
 }
 
+fn debug_relocation_shard_ranges_parallel(
+    relocation_count: usize,
+    output_len: usize,
+    shard_count: usize,
+    offset_at: impl Fn(usize) -> u64 + Sync,
+    write_size_at: impl Fn(usize) -> Result<usize> + Sync,
+) -> Result<Option<Vec<DebugRelocationShardRange>>> {
+    let shard_count = shard_count.min(relocation_count);
+    if shard_count < 2 {
+        return Ok(None);
+    }
+
+    let summaries = (0..shard_count)
+        .into_par_iter()
+        .map(
+            |shard_index| -> Result<Option<DebugRelocationShardSummary>> {
+                let start = relocation_count * shard_index / shard_count;
+                let end = relocation_count * (shard_index + 1) / shard_count;
+                if start == end {
+                    return Ok(None);
+                }
+
+                let first_offset = offset_at(start);
+                let mut previous_offset = first_offset;
+                let mut max_write_end = 0;
+                for index in start..end {
+                    let offset = offset_at(index);
+                    if index > start && previous_offset > offset {
+                        return Ok(None);
+                    }
+                    if offset > output_len as u64 {
+                        return Ok(None);
+                    }
+                    let write_end = offset
+                        .checked_add(write_size_at(index)? as u64)
+                        .context("Debug relocation write range overflow")?;
+                    if write_end > output_len as u64 {
+                        return Ok(None);
+                    }
+                    max_write_end = max_write_end.max(write_end);
+                    previous_offset = offset;
+                }
+
+                Ok(Some(DebugRelocationShardSummary {
+                    relocations: start..end,
+                    first_offset,
+                    last_offset: previous_offset,
+                    max_write_end,
+                }))
+            },
+        )
+        .collect::<Vec<_>>()
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+    let Some(summaries) = summaries.into_iter().collect::<Option<Vec<_>>>() else {
+        return Ok(None);
+    };
+
+    for pair in summaries.windows(2) {
+        if pair[0].last_offset > pair[1].first_offset
+            || pair[0].max_write_end > pair[1].first_offset
+        {
+            return Ok(None);
+        }
+    }
+
+    let mut ranges = Vec::with_capacity(summaries.len());
+    for (index, summary) in summaries.iter().enumerate() {
+        let output_start = if index == 0 {
+            0
+        } else {
+            summary.first_offset as usize
+        };
+        let output_end = summaries
+            .get(index + 1)
+            .map_or(output_len, |next| next.first_offset as usize);
+        if output_start > output_end || output_end > output_len {
+            return Ok(None);
+        }
+        ranges.push(DebugRelocationShardRange {
+            relocations: summary.relocations.clone(),
+            output: output_start..output_end,
+        });
+    }
+    Ok(Some(ranges))
+}
+
 fn apply_debug_rela_relocations<'data, A: Arch<Platform = Elf>>(
     object: &ObjectLayout<'data, Elf>,
     out: &mut [u8],
@@ -2851,7 +2946,7 @@ fn apply_debug_rela_relocations<'data, A: Arch<Platform = Elf>>(
 
     let shard_count =
         rayon::current_num_threads().min(relocations.len().div_ceil(PARALLEL_DEBUG_RELOCATION_MIN));
-    let Some(ranges) = debug_relocation_shard_ranges(
+    let Some(ranges) = debug_relocation_shard_ranges_parallel(
         relocations.len(),
         out.len(),
         shard_count,
@@ -2985,29 +3080,6 @@ mod debug_relocation_shard_tests {
     use super::*;
 
     #[test]
-    fn caches_each_debug_symbol_target_once_per_shard() {
-        let mut cache = DebugRelocationTargetCache::new(8);
-        let mut resolutions = 0;
-
-        let first = cache
-            .get_or_try_insert_with(object::SymbolIndex(3), || {
-                resolutions += 1;
-                Ok::<_, crate::error::Error>(41_u64)
-            })
-            .unwrap();
-        let second = cache
-            .get_or_try_insert_with(object::SymbolIndex(3), || {
-                resolutions += 1;
-                Ok::<_, crate::error::Error>(99_u64)
-            })
-            .unwrap();
-
-        assert_eq!(first, 41);
-        assert_eq!(second, 41);
-        assert_eq!(resolutions, 1, "a repeated relocation target must resolve once");
-    }
-
-    #[test]
     fn splits_sorted_non_overlapping_relocations_into_disjoint_output_ranges() {
         let offsets = [0, 4, 8, 12, 16, 20, 24, 28];
         let ranges =
@@ -3036,6 +3108,90 @@ mod debug_relocation_shard_tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn parallel_preflight_matches_serial_ranges() {
+        let offsets = [0, 4, 8, 12, 16, 20, 24, 28];
+        let serial =
+            debug_relocation_shard_ranges(offsets.len(), 32, 4, |index| offsets[index], |_| Ok(4))
+                .unwrap();
+        let parallel = debug_relocation_shard_ranges_parallel(
+            offsets.len(),
+            32,
+            4,
+            |index| offsets[index],
+            |_| Ok(4),
+        )
+        .unwrap();
+
+        assert_eq!(parallel, serial);
+    }
+
+    #[test]
+    fn parallel_preflight_rejects_unsafe_ranges() {
+        for offsets in [[0, 8, 4, 12], [0, 4, 12, 8]] {
+            assert!(
+                debug_relocation_shard_ranges_parallel(
+                    offsets.len(),
+                    16,
+                    2,
+                    |index| offsets[index],
+                    |_| Ok(4),
+                )
+                .unwrap()
+                .is_none()
+            );
+        }
+
+        let crossing_boundary = [0, 4, 8, 12];
+        assert!(
+            debug_relocation_shard_ranges_parallel(
+                crossing_boundary.len(),
+                16,
+                2,
+                |index| crossing_boundary[index],
+                |index| Ok(if index == 1 { 8 } else { 4 }),
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        for offsets in [[0, 4, 12, 20], [0, 4, 8, 14]] {
+            assert!(
+                debug_relocation_shard_ranges_parallel(
+                    offsets.len(),
+                    16,
+                    2,
+                    |index| offsets[index],
+                    |_| Ok(4),
+                )
+                .unwrap()
+                .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn parallel_preflight_propagates_write_size_errors_in_input_order() {
+        let offsets = [0, 4, 8, 12];
+        let error = debug_relocation_shard_ranges_parallel(
+            offsets.len(),
+            16,
+            2,
+            |index| offsets[index],
+            |index| {
+                if index == 1 || index == 3 {
+                    return Err(crate::error::Error::with_message(format!(
+                        "relocation {index} failed"
+                    )));
+                }
+                Ok(4)
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "relocation 1 failed");
     }
 
     #[test]

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -1736,6 +1736,8 @@ enum PreparedObjectSection<'out> {
 
 const MONOLITHIC_OBJECT_SECTION_THRESHOLD: usize = 4096;
 const PARALLEL_DEBUG_RELOCATION_MIN: usize = 64 * 1024;
+// Byte and bit-mask relocations modify at most eight bytes. A paired ULEB128
+// relocation can modify all ten bytes required to encode a u64.
 const MAX_DEBUG_RELOCATION_WRITE_SIZE: u64 = u64::BITS.div_ceil(7) as u64;
 
 impl PreparedObjectSection<'_> {
@@ -2763,7 +2765,9 @@ fn debug_relocation_write_size<A: Arch<Platform = Elf>, R: Relocation<Platform =
     }
     Ok(match info.size {
         RelocationSize::ByteSize(size) => size,
-        RelocationSize::BitMasking(mask) => mask.instruction.write_windows_size(),
+        // Some bit-masking relocations span two instructions. Use the full u64 window here even
+        // though their current write helper reports the size of one instruction.
+        RelocationSize::BitMasking(_) => size_of::<u64>(),
     })
 }
 
@@ -2864,7 +2868,6 @@ fn debug_relocation_shard_ranges_parallel(
 
                 let first_offset = offset_at(start);
                 let mut previous_offset = first_offset;
-                let mut max_write_end = 0;
                 for index in start..end {
                     let offset = offset_at(index);
                     if index > start && previous_offset > offset {
@@ -2873,20 +2876,37 @@ fn debug_relocation_shard_ranges_parallel(
                     if offset > output_len as u64 {
                         return Ok(None);
                     }
+                    previous_offset = offset;
+                }
+
+                // With sorted offsets, relocations more than the maximum write size behind the
+                // final offset cannot extend beyond it. Decode relocation sizes only for this
+                // small tail instead of repeating that work for every relocation. Invalid types
+                // outside the tail are still diagnosed when their shard applies the relocations.
+                let last_offset = previous_offset;
+                let mut max_write_end = last_offset;
+                for index in (start..end).rev() {
+                    let offset = offset_at(index);
+                    if offset.saturating_add(MAX_DEBUG_RELOCATION_WRITE_SIZE) <= last_offset {
+                        break;
+                    }
+                    let write_size = write_size_at(index)? as u64;
+                    if write_size > MAX_DEBUG_RELOCATION_WRITE_SIZE {
+                        return Ok(None);
+                    }
                     let write_end = offset
-                        .checked_add(write_size_at(index)? as u64)
+                        .checked_add(write_size)
                         .context("Debug relocation write range overflow")?;
                     if write_end > output_len as u64 {
                         return Ok(None);
                     }
                     max_write_end = max_write_end.max(write_end);
-                    previous_offset = offset;
                 }
 
                 Ok(Some(DebugRelocationShardSummary {
                     relocations: start..end,
                     first_offset,
-                    last_offset: previous_offset,
+                    last_offset,
                     max_write_end,
                 }))
             },
@@ -3173,7 +3193,7 @@ mod debug_relocation_shard_tests {
     }
 
     #[test]
-    fn parallel_preflight_propagates_write_size_errors_in_input_order() {
+    fn parallel_preflight_propagates_tail_write_size_errors_in_input_order() {
         let offsets = [0, 4, 8, 12];
         let error = debug_relocation_shard_ranges_parallel(
             offsets.len(),
@@ -3192,6 +3212,28 @@ mod debug_relocation_shard_tests {
         .unwrap_err();
 
         assert_eq!(error.to_string(), "relocation 1 failed");
+    }
+
+    #[test]
+    fn parallel_preflight_only_decodes_tail_relocation_sizes() {
+        let offsets = (0..32).map(|index| index * 4).collect::<Vec<_>>();
+        let size_queries = std::sync::atomic::AtomicUsize::new(0);
+
+        let ranges = debug_relocation_shard_ranges_parallel(
+            offsets.len(),
+            128,
+            4,
+            |index| offsets[index],
+            |_| {
+                size_queries.fetch_add(1, Relaxed);
+                Ok(4)
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(ranges.len(), 4);
+        assert_eq!(size_queries.load(Relaxed), 12);
     }
 
     #[test]

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -2756,6 +2756,37 @@ struct DebugRelocationShardSummary {
     max_write_end: u64,
 }
 
+#[derive(Clone, Copy)]
+struct DebugSymbolResolution {
+    symbol_index: object::SymbolIndex,
+    section_index: Option<object::SectionIndex>,
+    resolution: Option<Resolution<Elf>>,
+}
+
+#[derive(Default)]
+struct DebugSymbolCache {
+    previous: Option<DebugSymbolResolution>,
+}
+
+impl DebugSymbolCache {
+    #[inline(always)]
+    fn get_or_insert_with(
+        &mut self,
+        symbol_index: object::SymbolIndex,
+        resolve: impl FnOnce() -> Result<DebugSymbolResolution>,
+    ) -> Result<DebugSymbolResolution> {
+        if let Some(previous) = self.previous
+            && previous.symbol_index == symbol_index
+        {
+            return Ok(previous);
+        }
+
+        let resolved = resolve()?;
+        self.previous = Some(resolved);
+        Ok(resolved)
+    }
+}
+
 fn debug_relocation_write_size<A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>>(
     relocation: &R,
 ) -> Result<usize> {
@@ -3051,6 +3082,7 @@ fn apply_debug_relocations_impl<
         previous,
         ..Default::default()
     };
+    let mut symbol_cache = DebugSymbolCache::default();
 
     for rel in relocations {
         relocation_count += 1;
@@ -3067,6 +3099,7 @@ fn apply_debug_relocations_impl<
             tombstone_value,
             out,
             &relocation_cache,
+            &mut symbol_cache,
         )
         .with_context(|| {
             format!(
@@ -3098,6 +3131,39 @@ fn record_debug_relocations(
 #[cfg(test)]
 mod debug_relocation_shard_tests {
     use super::*;
+
+    #[test]
+    fn caches_only_consecutive_debug_symbol_resolutions() {
+        let resolve_count = std::cell::Cell::new(0);
+        let mut cache = DebugSymbolCache::default();
+        let resolve = |symbol_index: object::SymbolIndex| {
+            resolve_count.set(resolve_count.get() + 1);
+            Ok(DebugSymbolResolution {
+                symbol_index,
+                section_index: Some(object::SectionIndex(symbol_index.0 + 1)),
+                resolution: None,
+            })
+        };
+
+        let first = cache
+            .get_or_insert_with(object::SymbolIndex(7), || resolve(object::SymbolIndex(7)))
+            .unwrap();
+        let repeated = cache
+            .get_or_insert_with(object::SymbolIndex(7), || resolve(object::SymbolIndex(7)))
+            .unwrap();
+        let different = cache
+            .get_or_insert_with(object::SymbolIndex(8), || resolve(object::SymbolIndex(8)))
+            .unwrap();
+        let returned = cache
+            .get_or_insert_with(object::SymbolIndex(7), || resolve(object::SymbolIndex(7)))
+            .unwrap();
+
+        assert_eq!(first.symbol_index, repeated.symbol_index);
+        assert_eq!(first.section_index, repeated.section_index);
+        assert_ne!(first.symbol_index, different.symbol_index);
+        assert_eq!(first.symbol_index, returned.symbol_index);
+        assert_eq!(resolve_count.get(), 3);
+    }
 
     #[test]
     fn splits_sorted_non_overlapping_relocations_into_disjoint_output_ranges() {
@@ -4370,39 +4436,53 @@ fn apply_debug_relocation<'data, A: Arch<Platform = Elf>, R: Relocation<Platform
     section_tombstone_value: u64,
     out: &mut [u8],
     relocation_cache: &RelocationCache<R>,
+    symbol_cache: &mut DebugSymbolCache,
 ) -> Result<()> {
     let symbol_index = rel.symbol().context("Unsupported absolute relocation")?;
-    let sym = object_layout.object.symbol(symbol_index)?;
-    let section_index = object_layout.object.symbol_section(sym, symbol_index)?;
+
+    // Rust debug sections commonly contain long runs of relocations against the same symbol.
+    // Keep the last lookup local to each parallel shard so those runs avoid repeating symbol-table,
+    // section, and merged-resolution work while retaining constant memory usage.
+    let symbol = symbol_cache.get_or_insert_with(symbol_index, || {
+        let sym = object_layout.object.symbol(symbol_index)?;
+        let section_index = object_layout.object.symbol_section(sym, symbol_index)?;
+        let resolution = layout
+            .merged_symbol_resolution(object_layout.symbol_id_range.input_to_id(symbol_index))
+            .or_else(|| {
+                section_index.and_then(|section_index| {
+                    let section_address =
+                        object_layout.section_resolutions[section_index.0].address()?;
+                    // Include the symbol's offset within the section (adjusted for any relaxation
+                    // deltas). This is necessary on architectures like RISC-V and LoongArch64 where
+                    // debug info references local symbols (e.g. .LFB0, .LFE0) whose value is their
+                    // offset within the section, rather than section symbols where the offset is
+                    // encoded in the relocation addend.
+                    let output_offset = opt_input_to_output(
+                        object_layout.section_relax_deltas.get(section_index.0),
+                        crate::platform::Symbol::value(sym),
+                    );
+
+                    Some(Resolution {
+                        raw_value: section_address + output_offset,
+                        dynamic_symbol_index: None,
+                        flags: ValueFlags::empty(),
+                        format_specific: Default::default(),
+                    })
+                })
+            });
+        Ok(DebugSymbolResolution {
+            symbol_index,
+            section_index,
+            resolution,
+        })
+    })?;
+    let section_index = symbol.section_index;
 
     let addend = rel.addend();
     let r_type = rel.raw_type();
     let rel_info = A::relocation_from_raw(r_type)?;
 
-    let resolution = layout
-        .merged_symbol_resolution(object_layout.symbol_id_range.input_to_id(symbol_index))
-        .or_else(|| {
-            section_index.and_then(|section_index| {
-                let section_address =
-                    object_layout.section_resolutions[section_index.0].address()?;
-                // Include the symbol's offset within the section (adjusted for any relaxation
-                // deltas). This is necessary on architectures like RISC-V and LoongArch64 where
-                // debug info references local symbols (e.g. .LFB0, .LFE0) whose value is their
-                // offset within the section, rather than section symbols where the offset is
-                // encoded in the relocation addend.
-                let output_offset = opt_input_to_output(
-                    object_layout.section_relax_deltas.get(section_index.0),
-                    crate::platform::Symbol::value(sym),
-                );
-
-                Some(Resolution {
-                    raw_value: section_address + output_offset,
-                    dynamic_symbol_index: None,
-                    flags: ValueFlags::empty(),
-                    format_specific: Default::default(),
-                })
-            })
-        });
+    let resolution = symbol.resolution;
 
     let value = if let Some(resolution) = resolution {
         match rel_info.kind {

--- a/crates/reld-core/src/input_data.rs
+++ b/crates/reld-core/src/input_data.rs
@@ -500,34 +500,59 @@ fn process_archive<'data, P: Platform, F: FileSystem>(
     file: Option<&Arc<std::fs::File>>,
     state: &TemporaryState<'data, P, F>,
 ) -> Result<LoadedFileState<'data, P, F::Input>> {
-    let mut outputs = Vec::new();
+    let archive_data = input_ref.data();
+    let parent_file = input_ref.file;
+    let mut members = Vec::new();
 
-    for entry in ArchiveIterator::from_archive_bytes(input_ref.data())? {
+    for entry in ArchiveIterator::from_archive_bytes(archive_data)? {
         let entry = entry?;
         match entry {
             ArchiveEntry::Regular(archive_entry) => {
                 let start_offset = archive_entry.data_offset;
                 let end_offset = archive_entry.data_offset + archive_entry.entry_data.len();
-                let input_ref = InputRef {
-                    file: input_ref.file,
-                    data: &input_ref.data()[start_offset..end_offset],
-                    entry: Some(EntryMeta {
-                        identifier: archive_entry.ident,
-                        start_offset,
-                        end_offset,
-                    }),
-                };
-
-                let kind = FileKind::identify_bytes(input_ref.data())
-                    .with_context(|| format!("Failed process input `{input_ref}`"))?;
-
-                outputs.push(state.process_input(input_ref, file, kind)?);
+                let member_data = &archive_data[start_offset..end_offset];
+                let kind = FileKind::identify_bytes(member_data).with_context(|| {
+                    format!(
+                        "Failed process input `{}` in archive `{}`",
+                        archive_entry.ident.as_path().display(),
+                        parent_file.filename.display()
+                    )
+                })?;
+                members.push((start_offset, end_offset, archive_entry.ident, kind));
             }
             ArchiveEntry::Thin(_) => unreachable!(),
         }
     }
 
+    let outputs = process_archive_members_in_order(
+        members,
+        |(start_offset, end_offset, identifier, kind)| {
+            let member_ref = InputRef {
+                file: parent_file,
+                data: &archive_data[start_offset..end_offset],
+                entry: Some(EntryMeta {
+                    identifier,
+                    start_offset,
+                    end_offset,
+                }),
+            };
+            state.process_input(member_ref, file, kind)
+        },
+    )?;
+
     Ok(LoadedFileState::Archive(opened, outputs))
+}
+
+fn process_archive_members_in_order<T: Send, U: Send>(
+    members: Vec<T>,
+    process: impl Fn(T) -> Result<U> + Sync + Send,
+) -> Result<Vec<U>> {
+    members
+        .into_par_iter()
+        .map(process)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .collect()
 }
 
 fn process_thin_archive<'data, P: Platform, F: FileSystem>(
@@ -536,51 +561,54 @@ fn process_thin_archive<'data, P: Platform, F: FileSystem>(
 ) -> Result<LoadedFileState<'data, P, F::Input>> {
     let absolute_path = &input_file.filename;
     let parent_path = absolute_path.parent().unwrap();
-    let mut files = Vec::new();
-    let mut parsed_files = Vec::new();
+    let modifiers = input_file.modifiers;
+    let archive_display = absolute_path.display().to_string();
 
+    let mut entry_paths = Vec::new();
     for entry in ArchiveIterator::from_archive_bytes(input_file.data())? {
         match entry? {
             ArchiveEntry::Thin(entry) => {
-                let path = entry.ident.as_path();
-                let entry_path = parent_path.join(path);
-
-                let (input, file) = state
-                    .file_system
-                    .open_input(&entry_path, state.args.common().prepopulate_maps)
-                    .with_context(|| {
-                        format!(
-                            "Failed to open file referenced by thin archive `{}`",
-                            input_file.filename.display()
-                        )
-                    })?;
-
-                let input_file = InputFile {
-                    filename: entry_path.clone(),
-                    original_filename: entry_path,
-                    modifiers: Modifiers {
-                        archive_semantics: true,
-                        ..input_file.modifiers
-                    },
-                    data: Some(input),
-                };
-
-                let input_file = &*state.inputs_arena.alloc(input_file);
-
-                let input_ref = InputRef {
-                    file: input_file.as_ref(),
-                    data: input_file.data(),
-                    entry: None,
-                };
-
-                let kind = FileKind::identify_bytes(input_ref.data())
-                    .with_context(|| format!("Failed process input `{input_ref}`"))?;
-
-                parsed_files.push(state.process_input(input_ref, file.as_ref(), kind)?);
-                files.push(input_file);
+                entry_paths.push(parent_path.join(entry.ident.as_path()));
             }
             ArchiveEntry::Regular(_) => {}
         }
+    }
+
+    let results = process_archive_members_in_order(entry_paths, |entry_path| {
+        let (input, file) = state
+            .file_system
+            .open_input(&entry_path, state.args.common().prepopulate_maps)
+            .with_context(|| {
+                format!("Failed to open file referenced by thin archive `{archive_display}`")
+            })?;
+
+        let member_file = InputFile {
+            filename: entry_path.clone(),
+            original_filename: entry_path,
+            modifiers: Modifiers {
+                archive_semantics: true,
+                ..modifiers
+            },
+            data: Some(input),
+        };
+
+        let member_file = &*state.inputs_arena.alloc(member_file);
+        let input_ref = InputRef {
+            file: member_file.as_ref(),
+            data: member_file.data(),
+            entry: None,
+        };
+        let kind = FileKind::identify_bytes(input_ref.data())
+            .with_context(|| format!("Failed process input `{input_ref}`"))?;
+        let parsed = state.process_input(input_ref, file.as_ref(), kind)?;
+        Ok((member_file, parsed))
+    })?;
+
+    let mut files = Vec::with_capacity(results.len());
+    let mut parsed_files = Vec::with_capacity(results.len());
+    for (member_file, parsed) in results {
+        files.push(member_file);
+        parsed_files.push(parsed);
     }
 
     Ok(LoadedFileState::ThinArchive(files, parsed_files))
@@ -1084,5 +1112,58 @@ impl<'data, P: Platform> InputRecord<'data, P> {
             InputRecord::Object(Ok(obj)) => obj.is_dynamic(),
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn archive_members_process_in_parallel_without_reordering() {
+        let active = AtomicUsize::new(0);
+        let maximum_active = AtomicUsize::new(0);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap();
+
+        let output = pool
+            .install(|| {
+                process_archive_members_in_order((0..32).collect(), |index| {
+                    let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum_active.fetch_max(now_active, Ordering::SeqCst);
+                    for _ in 0..10_000 {
+                        if maximum_active.load(Ordering::SeqCst) > 1 {
+                            break;
+                        }
+                        std::thread::yield_now();
+                    }
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<_, Error>(index)
+                })
+            })
+            .unwrap();
+
+        assert_eq!(output, (0..32).collect::<Vec<_>>());
+        assert!(
+            maximum_active.load(Ordering::SeqCst) > 1,
+            "archive members did not overlap"
+        );
+    }
+
+    #[test]
+    fn archive_members_report_the_first_error_in_input_order() {
+        let error = process_archive_members_in_order((0..16).collect(), |index| {
+            if index == 3 || index == 7 {
+                return Err(Error::with_message(format!("member {index} failed")));
+            }
+            Ok(index)
+        })
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "member 3 failed");
     }
 }


### PR DESCRIPTION
Closes #82.

## What changed

- process regular and thin archive members in parallel while preserving archive order and deterministic error selection
- preflight large sorted debug relocation sections in parallel before safely sharding their output ranges
- decode exact relocation write sizes only near shard boundaries instead of repeating type decoding for every relocation
- preserve serial fallback for unsorted, overlapping, out-of-bounds, or otherwise unsafe relocation inputs

## Evidence

Linux-only hosted benchmark run: https://github.com/zackees/reld/actions/runs/32937802814

| Linker | full-LTO median |
|---|---:|
| reld | 0.2740 s |
| mold | 0.3089 s |

reld is 11.3% faster than mold (`0.2740 / 0.3089 = 88.7%`), clearing the issue's 10% lead target. All expected Linux linkers were measured with no silent N/A, and the report identifies source SHA `e706c8d11ad6fc97c0cc906acdfdf107dadb6122`.

A final all-platform workflow dispatch is running at https://github.com/zackees/reld/actions/runs/32938949262.

## Validation

- RED then GREEN: archive parallelism/order and deterministic error tests
- RED then GREEN: parallel debug relocation preflight equivalence, safety fallback, tail error, and reduced decode-count tests
- `soldr cargo test -p reld-core --no-default-features -- --skip tidy_tests::check_toml_format` (167 passed plus doc tests; Taplo-only formatting check separately excluded because Taplo is absent locally)
- pre-push Rust review clean
