### PR TITLE
fix(bench): validate benchmark links against Cargo oracle

### DIFF
--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -65,6 +65,12 @@ class Linker:
     driver_arguments: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class ExecutableOracle:
+    stdout: str
+    stderr: str
+
+
 _QUOTED_ARGUMENT = re.compile(r'"(?:\\.|[^"\\])*"')
 _LINK_DRIVER_NAMES = {
     "cc",
@@ -456,10 +462,10 @@ def _run_link(command: list[str], *, cwd: Path, environment: dict[str, str]) -> 
     )
 
 
-def _validate_executable(output: Path, *, cwd: Path, environment: dict[str, str]) -> None:
+def _run_executable(output: Path, *, cwd: Path, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
     if not output.is_file() or output.stat().st_size == 0:
         raise BenchmarkError(f"linked output is missing or empty: {output}")
-    completed = subprocess.run(
+    return subprocess.run(
         [output],
         cwd=cwd,
         env=environment,
@@ -469,8 +475,32 @@ def _validate_executable(output: Path, *, cwd: Path, environment: dict[str, str]
         errors="replace",
         check=False,
     )
-    if completed.returncode or "OK" not in completed.stdout:
-        raise BenchmarkError(f"linked output failed its OK oracle ({completed.returncode}):\n{completed.stdout}{completed.stderr}")
+
+
+def capture_executable_oracle(output: Path, *, cwd: Path, environment: dict[str, str]) -> ExecutableOracle:
+    """Capture exact behavior from Cargo's target-native reference executable."""
+    completed = _run_executable(output, cwd=cwd, environment=environment)
+    if completed.returncode or not completed.stdout.startswith("OK "):
+        raise BenchmarkError(f"captured reference failed its OK oracle ({completed.returncode}):\n{completed.stdout}{completed.stderr}")
+    return ExecutableOracle(stdout=completed.stdout, stderr=completed.stderr)
+
+
+def _validate_executable(
+    output: Path,
+    *,
+    oracle: ExecutableOracle,
+    cwd: Path,
+    environment: dict[str, str],
+) -> None:
+    completed = _run_executable(output, cwd=cwd, environment=environment)
+    if completed.returncode:
+        raise BenchmarkError(f"linked output failed its executable oracle ({completed.returncode}):\n{completed.stdout}{completed.stderr}")
+    if completed.stdout != oracle.stdout or completed.stderr != oracle.stderr:
+        raise BenchmarkError(
+            "linked output differed from Cargo's reference executable:\n"
+            f"expected stdout: {oracle.stdout!r}\nactual stdout: {completed.stdout!r}\n"
+            f"expected stderr: {oracle.stderr!r}\nactual stderr: {completed.stderr!r}"
+        )
 
 
 def _discard_verified_output(output: Path) -> Path | None:
@@ -518,6 +548,7 @@ def benchmark_replay(
     captured: LinkCommand,
     linker: Linker,
     *,
+    oracle: ExecutableOracle,
     output_dir: Path,
     cwd: Path,
     environment: dict[str, str],
@@ -564,7 +595,7 @@ def benchmark_replay(
             completed = _run_link(command, cwd=cwd, environment=environment)
             if completed.returncode:
                 raise BenchmarkError(f"{linker.label} warmup link failed:\n{completed.stdout}{completed.stderr}")
-            _validate_executable(output, cwd=cwd, environment=environment)
+            _validate_executable(output, oracle=oracle, cwd=cwd, environment=environment)
             if quarantine := _discard_verified_output(output):
                 quarantines.append(quarantine)
 
@@ -579,7 +610,7 @@ def benchmark_replay(
             samples.append(elapsed)
             # The oracle runs after the timer stops, once for every produced executable. A bad
             # early trial therefore cannot enter the median and then be hidden by an overwrite.
-            _validate_executable(output, cwd=cwd, environment=environment)
+            _validate_executable(output, oracle=oracle, cwd=cwd, environment=environment)
             if output_size_sink is not None:
                 output_size_sink.append(output.stat().st_size)
             if quarantine := _discard_verified_output(output):
@@ -605,6 +636,7 @@ def benchmark_linkers_round_robin(
     captured: LinkCommand,
     linkers: tuple[Linker, ...],
     *,
+    oracle: ExecutableOracle,
     output_dir: Path,
     cwd: Path,
     environment: dict[str, str],
@@ -629,6 +661,7 @@ def benchmark_linkers_round_robin(
             benchmark_replay(
                 captured,
                 linker,
+                oracle=oracle,
                 output_dir=output_dir / linker.label.replace("/", "-"),
                 cwd=cwd,
                 environment=environment,
@@ -705,6 +738,7 @@ def capture_reld_phase_trace(
     captured: LinkCommand,
     linker: Linker,
     *,
+    oracle: ExecutableOracle,
     output_dir: Path,
     cwd: Path,
     environment: dict[str, str],
@@ -735,7 +769,7 @@ def capture_reld_phase_trace(
     completed = _run_link(command, cwd=cwd, environment=environment)
     if completed.returncode:
         raise BenchmarkError(f"reld phase trace failed:\n{completed.stdout}{completed.stderr}")
-    _validate_executable(output, cwd=cwd, environment=environment)
+    _validate_executable(output, oracle=oracle, cwd=cwd, environment=environment)
     output_size = output.stat().st_size
     combined_output = completed.stdout + completed.stderr
     phases = _parse_phase_timings(combined_output, require_creation=require_creation)
@@ -800,6 +834,17 @@ def run_benchmark(
             # without manufacturing a plugin request.
             linker="clang" if use_driver_shim else None,
         )
+        oracle = capture_executable_oracle(
+            captured.output,
+            cwd=manifest.parent,
+            environment=environment,
+        )
+        print(
+            f"captured executable oracle for {configuration.label}: "
+            f"stdout={oracle.stdout.strip()!r}, stderr_bytes={len(oracle.stderr.encode('utf-8'))}",
+            file=log,
+            flush=True,
+        )
         prune_capture_artifacts(
             captured,
             profile_dir=target_dir / configuration.profile,
@@ -821,6 +866,7 @@ def run_benchmark(
             medians, _samples, _sizes, _orders = benchmark_linkers_round_robin(
                 captured,
                 linkers,
+                oracle=oracle,
                 output_dir=workdir / configuration.profile / "published",
                 cwd=manifest.parent,
                 environment=environment,
@@ -841,6 +887,7 @@ def run_benchmark(
                 _, mode_samples, mode_sizes, mode_orders = benchmark_linkers_round_robin(
                     captured,
                     modes,
+                    oracle=oracle,
                     output_dir=workdir / configuration.profile / "output-modes",
                     cwd=manifest.parent,
                     environment=environment,
@@ -862,6 +909,7 @@ def run_benchmark(
                     phases, phase_output_size, phase_trace = capture_reld_phase_trace(
                         captured,
                         mode,
+                        oracle=oracle,
                         output_dir=workdir / configuration.profile / "phase-traces" / mode.label,
                         cwd=manifest.parent,
                         environment=environment,

--- a/ci/e2e/link-workload/README.md
+++ b/ci/e2e/link-workload/README.md
@@ -14,3 +14,8 @@ for one configuration and releases those retained inputs before compiling the ne
 so the three large LTO captures never accumulate on a hosted runner. Compilation, Rust LTO
 preparation, capture cleanup, and executable validation are never included in measured final-link
 latency.
+
+The workload data is deterministic. Before replaying a captured link, the benchmark executes
+Cargo's target-native output and records its exact stdout and stderr as the configuration oracle.
+Every warmup, timed linker trial, and diagnostic replay must exit successfully and reproduce that
+behavior byte-for-byte after timing stops; a merely runnable or `OK`-printing corrupt output fails.

--- a/ci/e2e/link-workload/crates/app/src/audit.rs
+++ b/ci/e2e/link-workload/crates/app/src/audit.rs
@@ -41,13 +41,15 @@ fn artifacts(copies: usize) -> Result<Vec<Artifact>> {
         .context("valid fixture timestamp")?;
     let mut artifacts = Vec::with_capacity(rows.len() * copies);
     for copy in 0..copies {
-        for row in &rows {
+        for (row_index, row) in rows.iter().enumerate() {
             let path = format!("copy-{copy}/{}", &row[0]);
             let mut labels = IndexMap::new();
             labels.insert("copy".to_owned(), copy.to_string());
             labels.insert("source".to_owned(), "benchmark-fixture".to_owned());
             artifacts.push(Artifact {
-                id: Uuid::new_v4(),
+                // Stable IDs make Cargo's reference executable a byte-for-byte behavioral oracle
+                // for every linker replay on this target.
+                id: Uuid::from_u128(((copy as u128) << 64) | (row_index as u128 + 1)),
                 path,
                 kind: row[1].to_owned(),
                 bytes: row[2].as_bytes().repeat(64 + copy),

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -12,10 +12,12 @@ from ci.benchmark_runner import (
     CONFIGURATIONS,
     DEFAULT_MANIFEST,
     BenchmarkError,
+    ExecutableOracle,
     LinkCommand,
     Linker,
     _discard_verified_output,
     _parse_phase_timings,
+    _validate_executable,
     assert_output_mode_improvement,
     assert_significant_workload,
     benchmark_environment,
@@ -99,7 +101,13 @@ def test_each_configuration_is_replayed_then_released_before_the_next_capture(tm
         return LinkCommand("cc", ("input.o", "-o", str(output)), output, False)
 
     def fake_prune(captured, *, profile_dir, log):
-        del captured, profile_dir, log
+        del captured, log
+        events.append(f"prune:{profile_dir.name}")
+
+    def fake_oracle(output, **kwargs):
+        del kwargs
+        events.append(f"oracle:{output.parent.name}")
+        return ExecutableOracle("OK reference\n", "")
 
     def fake_startup(*args, **kwargs):
         del args, kwargs
@@ -121,6 +129,7 @@ def test_each_configuration_is_replayed_then_released_before_the_next_capture(tm
     monkeypatch.setattr(runner_module, "linkers_for_target", lambda target, reld: (linker,))
     monkeypatch.setattr(runner_module, "benchmark_environment", lambda: {})
     monkeypatch.setattr(runner_module, "capture_final_link", fake_capture)
+    monkeypatch.setattr(runner_module, "capture_executable_oracle", fake_oracle)
     monkeypatch.setattr(runner_module, "prune_capture_artifacts", fake_prune)
     monkeypatch.setattr(runner_module, "benchmark_startup", fake_startup)
     monkeypatch.setattr(runner_module, "benchmark_replay", fake_replay)
@@ -140,6 +149,8 @@ def test_each_configuration_is_replayed_then_released_before_the_next_capture(tm
 
     assert events == [
         "capture:no-LTO",
+        "oracle:linkbench-no-lto",
+        "prune:linkbench-no-lto",
         "startup",
         "replay:wild",
         "replay:wild",
@@ -147,12 +158,16 @@ def test_each_configuration_is_replayed_then_released_before_the_next_capture(tm
         "replay:wild",
         "release:linkbench-no-lto",
         "capture:ThinLTO",
+        "oracle:linkbench-thin-lto",
+        "prune:linkbench-thin-lto",
         "replay:wild",
         "replay:wild",
         "replay:wild",
         "replay:wild",
         "release:linkbench-thin-lto",
         "capture:full-LTO",
+        "oracle:linkbench-full-lto",
+        "prune:linkbench-full-lto",
         "replay:wild",
         "replay:wild",
         "replay:wild",
@@ -178,6 +193,7 @@ def test_linker_trials_rotate_order_and_preserve_every_sample(tmp_path: Path, mo
     medians, samples, sizes, orders = benchmark_linkers_round_robin(
         captured,
         linkers,
+        oracle=ExecutableOracle("OK reference\n", ""),
         output_dir=tmp_path / "out",
         cwd=tmp_path,
         environment={},
@@ -225,6 +241,7 @@ def test_four_diagnostic_contenders_each_occupy_every_round_position(tmp_path: P
     _, _, _, orders = benchmark_linkers_round_robin(
         captured,
         linkers,
+        oracle=ExecutableOracle("OK reference\n", ""),
         output_dir=tmp_path / "out",
         cwd=tmp_path,
         environment={},
@@ -260,6 +277,11 @@ def test_linux_output_mode_report_retains_metadata_samples_sizes_and_phases(tmp_
     monkeypatch.setattr(runner_module, "benchmark_environment", lambda: {})
     monkeypatch.setattr(runner_module, "_linux_filesystem_type", lambda path, environment: "ext4")
     monkeypatch.setattr(runner_module, "capture_final_link", fake_capture)
+    monkeypatch.setattr(
+        runner_module,
+        "capture_executable_oracle",
+        lambda *args, **kwargs: ExecutableOracle("OK reference\n", ""),
+    )
     monkeypatch.setattr(runner_module, "prune_capture_artifacts", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner_module, "release_capture_artifacts", lambda **kwargs: None)
     monkeypatch.setattr(runner_module, "benchmark_startup", lambda *args, **kwargs: 0.01)
@@ -348,6 +370,14 @@ def test_release_capture_artifacts_rejects_outside_directory(tmp_path: Path):
 def test_default_workload_replaces_startup_dominated_sqlite_bridge():
     assert DEFAULT_MANIFEST.as_posix().endswith("ci/e2e/link-workload/Cargo.toml")
     assert BENCHMARK_PACKAGE == "linkbench-app"
+
+
+def test_workload_is_deterministic_for_exact_executable_oracles():
+    audit = DEFAULT_MANIFEST.parent / "crates" / "app" / "src" / "audit.rs"
+    source = audit.read_text(encoding="utf-8")
+
+    assert "Uuid::from_u128" in source
+    assert "Uuid::new_v4" not in source
 
 
 def test_compiled_policy_is_target_calibrated_for_significant_final_links():
@@ -468,8 +498,11 @@ def test_every_warmup_and_trial_executable_is_verified_outside_timing(tmp_path: 
         output.write_bytes(b"executable")
         return runner_module.subprocess.CompletedProcess([], 0, "", "")
 
-    def fake_validate(output, *, cwd, environment):
+    oracle = ExecutableOracle("OK reference\n", "")
+
+    def fake_validate(output, *, oracle: ExecutableOracle, cwd, environment):
         del cwd, environment
+        assert oracle == ExecutableOracle("OK reference\n", "")
         assert output.is_file()
         validations.append(output)
 
@@ -479,6 +512,7 @@ def test_every_warmup_and_trial_executable_is_verified_outside_timing(tmp_path: 
     benchmark_replay(
         captured,
         Linker("test", tmp_path / "ld.test"),
+        oracle=oracle,
         output_dir=output_dir,
         cwd=tmp_path,
         environment={},
@@ -495,6 +529,24 @@ def test_every_warmup_and_trial_executable_is_verified_outside_timing(tmp_path: 
         "app-test-trial-2",
     ]
     assert all(not path.exists() for path in validations)
+
+
+def test_executable_oracle_requires_exact_reference_behavior(tmp_path: Path, monkeypatch):
+    output = tmp_path / "linked-output"
+    output.write_bytes(b"executable")
+    oracle = ExecutableOracle("OK trusted-fingerprint\n", "")
+    responses = iter(
+        [
+            runner_module.subprocess.CompletedProcess([], 0, oracle.stdout, oracle.stderr),
+            runner_module.subprocess.CompletedProcess([], 0, "OK but-wrong\n", ""),
+        ]
+    )
+
+    monkeypatch.setattr(runner_module, "_run_executable", lambda *args, **kwargs: next(responses))
+
+    _validate_executable(output, oracle=oracle, cwd=tmp_path, environment={})
+    with pytest.raises(BenchmarkError, match="differed from Cargo's reference"):
+        _validate_executable(output, oracle=oracle, cwd=tmp_path, environment={})
 
 
 def test_locked_windows_output_is_quarantined_without_delete_retries(tmp_path: Path, monkeypatch):
@@ -535,8 +587,8 @@ def test_quarantine_cleanup_runs_after_all_timed_links(tmp_path: Path, monkeypat
         events.append(f"link:{output.name}")
         return runner_module.subprocess.CompletedProcess([], 0, "", "")
 
-    def fake_validate(output, *, cwd, environment):
-        del cwd, environment
+    def fake_validate(output, *, oracle, cwd, environment):
+        del oracle, cwd, environment
         events.append(f"validate:{output.name}")
 
     def fake_discard(output):
@@ -554,6 +606,7 @@ def test_quarantine_cleanup_runs_after_all_timed_links(tmp_path: Path, monkeypat
     benchmark_replay(
         captured,
         Linker("reld", tmp_path / "reld-link.exe"),
+        oracle=ExecutableOracle("OK reference\n", ""),
         output_dir=tmp_path / "replays",
         cwd=tmp_path,
         environment={},


### PR DESCRIPTION
## Summary
- validate each replayed benchmark output against the executable produced by Cargo's captured linker command
- preserve the reference exit-code oracle and compare output behavior when applicable
- cover executable resolution and mismatch failures with targeted tests

## Verification
- uv run --no-sync pytest ci/tests/test_benchmark_runner.py