### PR TITLE
test: verify real linker consumer artifacts

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           toolset: "14.44"
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Free Linux runner disk for retained linker inputs
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_COMMAND: cargo
-  RUST_VERSION: 1.94.1
+  RUST_VERSION: 1.95.0
   NIGHTLY_TOOLCHAIN: nightly-2026-08-01
   CLANG_VERSION: 22.1.8
   CLANG_PACKAGE_VERSION: "1:22.1.8~++20260714014902+ca7933e47d3a-1~exp1~20260714135019.80"
@@ -38,7 +38,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: rustfmt, clippy
       - uses: taiki-e/install-action@8261f1f64137bdbc4bc1035170d52408e108cbd4 # cargo-deny
@@ -105,7 +105,7 @@ jobs:
         with:
           version: 18.1.8
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.target }}
 
@@ -378,7 +378,7 @@ jobs:
           # rustc's default flavor for aarch64-apple-darwin is the cc-wrapped "darwin-cc" (clang
           # driver args). To hand reld raw ld64-native argv (which it forwards straight to
           # ld64.lld, per the BR-3 bridge), select the direct/non-cc "ld64.lld" flavor. That
-          # string is a valid rustc 1.94 -C linker-flavor value (verified against the compiler's
+          # string is a valid rustc 1.95 -C linker-flavor value (verified against the compiler's
           # own accepted list) and emits Mach-O/ld64 args (-syslibroot/-lSystem/-arch/-platform_version).
           export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$reld"
           export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-Clinker-flavor=ld64.lld"
@@ -496,7 +496,7 @@ jobs:
           sudo apt-get "${APT_OPTIONS[@]}" update
           sudo apt-get "${APT_OPTIONS[@]}" install -y gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/linker-artifacts.yml
+++ b/.github/workflows/linker-artifacts.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build / ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -21,31 +22,50 @@ jobs:
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             artifact: reld-link-linux-x86_64
-            executable: reld-link
+            binary: reld
+            executable: reld
           - name: macos
             runner: macos-14
             target: aarch64-apple-darwin
             artifact: reld-link-macos-arm64
-            executable: reld-link
+            binary: reld
+            executable: reld
           - name: windows
             runner: windows-2022
             target: x86_64-pc-windows-msvc
             artifact: reld-link-windows-x86_64
+            binary: reld-link
             executable: reld-link.exe
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+
       - name: Setup Soldr target lifecycle
         id: setup
-        uses: zackees/setup-soldr@main
+        uses: zackees/setup-soldr@61dbee94deb0b7240a9a006a74ed04989a920303 # main
         with:
           version: 0.9.10
           cross-targets: ${{ matrix.target }}
           cache: false
           prebuild-deps: none
           linker: fast
+
+      - name: Configure MSVC environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        with:
+          toolset: "14.44"
+
+      - name: Install Windows LLVM
+        if: runner.os == 'Windows'
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
+        with:
+          version: 18.1.8
 
       - name: Assert target contract
         shell: bash
@@ -54,7 +74,7 @@ jobs:
           CAPABILITIES: ${{ steps.setup.outputs.target-capabilities-json }}
         run: |
           set -euo pipefail
-          python -c 'import json, os; p=json.loads(os.environ["CAPABILITIES"]); assert p["canonicalTarget"] == os.environ["TARGET"]; assert "build" in p["supportedOperations"]'
+          uv run --no-project python -c 'import json, os; p=json.loads(os.environ["CAPABILITIES"]); assert p["canonicalTarget"] == os.environ["TARGET"]; assert "build" in p["supportedOperations"]'
 
       - name: Normalize MSVC compiler drivers
         if: runner.os == 'Windows'
@@ -63,7 +83,9 @@ jobs:
           set -euo pipefail
           echo 'CC_x86_64_pc_windows_msvc=' >> "$GITHUB_ENV"
           echo 'CXX_x86_64_pc_windows_msvc=' >> "$GITHUB_ENV"
-          echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=link.exe' >> "$GITHUB_ENV"
+          msvc_link="${VCToolsInstallDir}bin/Hostx64/x64/link.exe"
+          test -x "$msvc_link"
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$msvc_link" >> "$GITHUB_ENV"
           echo 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS=' >> "$GITHUB_ENV"
 
       - name: Clear cross-target linker overrides for native host build
@@ -89,10 +111,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          soldr cargo build --locked --release --package reld --bin reld-link
+          soldr cargo build --locked --release --target "${{ matrix.target }}" --package reld --bin "${{ matrix.binary }}"
           mkdir -p package
-          built="$(find target -type f \( -name 'reld-link' -o -name 'reld-link.exe' \) -print -quit)"
-          test -n "$built"
+          built="target/${{ matrix.target }}/release/${{ matrix.executable }}"
+          test -f "$built"
           cp "$built" "package/${{ matrix.executable }}"
 
       - name: Smoke build artifact
@@ -100,9 +122,29 @@ jobs:
         run: |
           set -euo pipefail
           test -s "package/${{ matrix.executable }}"
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            chmod +x "package/${{ matrix.executable }}"
+          fi
           "package/${{ matrix.executable }}" --version
 
-      - uses: actions/upload-artifact@v4
+      - name: Link and run pinned Rust, C, and C++ consumers
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-project python -m ci.consumer_acceptance \
+            --platform "${{ matrix.name }}" \
+            --linker "package/${{ matrix.executable }}" \
+            --work-dir "${RUNNER_TEMP}/reld-consumer-acceptance"
+
+      - name: Upload linker invocation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: consumer-invocations-${{ matrix.name }}
+          path: ${{ runner.temp }}/reld-consumer-acceptance/*-invocations.jsonl
+          if-no-files-found: ignore
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: package/${{ matrix.executable }}
@@ -119,17 +161,17 @@ jobs:
           - name: linux
             runner: ubuntu-24.04
             artifact: reld-link-linux-x86_64
-            executable: reld-link
+            executable: reld
           - name: macos
             runner: macos-14
             artifact: reld-link-macos-arm64
-            executable: reld-link
+            executable: reld
           - name: windows
             runner: windows-2022
             artifact: reld-link-windows-x86_64
             executable: reld-link.exe
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ matrix.artifact }}
           path: package

--- a/.github/workflows/linker-modes.yml
+++ b/.github/workflows/linker-modes.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.3"
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - if: matrix.install_llvm
         uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
         with:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: choco install llvm --no-progress -y
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Build stress harness
         run: cargo build --release --bin reld-stress

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,19 @@ Across every platform:
 - Intentional artifact changes must be declared and structurally tested.
 - Update the relevant platform guide when a platform's engine, reference linker, artifact format,
   or validation command changes.
+
+## Dependency approval
+
+The linker's existing dependency graph is a fixed budget. Do not add a direct, development,
+build, target-specific, feature-gated, or transitive crate without explicit developer approval
+obtained before the dependency is added. An agent cannot grant that approval, infer it from a
+feature request, or update a dependency baseline to approve its own change. Implement logging and
+other support features with the standard library or already-approved crates.
+
+When a dependency check fails, preserve this actionable guidance in its diagnostic:
+
+> Adding crates to the reld linker requires explicit developer approval. Agents must not update
+> the dependency baseline to bypass this check. Use the standard library or an already-approved
+> dependency, or obtain developer approval and update the baseline in the same reviewed change.
+
+Automated enforcement is tracked by [issue #88](https://github.com/zackees/reld/issues/88).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/zackees/reld"
 license = "MIT OR Apache-2.0"
 version = "0.0.0"
 readme = "README.md"
-rust-version = "1.94"
+rust-version = "1.95"
 edition = "2024"
 authors = ["zackees"]
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -276,6 +276,34 @@ not by forking a new routing path per engine; see
 | `--engine=` / `RELD_ENGINE` override | Shipped |
 | Per-decision routing log | Shipped |
 
+### 4.6 Acceptance proof and dependency budget
+
+Consumer acceptance uses two independent layers. First, setting `RELD_INVOCATION_LOG` to an
+optional log path makes the linker append a JSONL record only after a successful link. The test
+must read that log and match the exact expected output artifact and selected engine; merely putting
+`reld-link` on `PATH` or configuring a compiler linker variable does not prove that it was invoked.
+Second, the test must execute the linked Rust/C/C++ program or its complete test suite with exact
+success expectations. Invocation evidence proves which linker handled the artifact; execution
+evidence proves that the resulting program works at the exercised boundary. Neither layer replaces
+the artifact-equivalence requirements in §3.1. The consumer gate therefore also compiles one object
+once, links the same output path twice each with invocation logging disabled and enabled under
+platform-specific deterministic options, requires self-determinism and raw byte identity across
+the modes, then executes it. This focused check prevents audit instrumentation from changing the
+artifact and exercises native ELF's parent-success path as well as the platform bridges.
+
+The linker's existing dependency graph is a fixed budget. Logging, routing, diagnostics, and other
+features must use the standard library or crates already approved in the graph. Adding any direct,
+development, build, target-specific, feature-gated, or transitive crate requires explicit developer
+approval before the manifest or lockfile is changed. Agents cannot self-approve a crate, infer
+approval from the requested feature, or update a dependency baseline to bypass the rule. The
+planned automated gate is tracked by [issue #88](https://github.com/zackees/reld/issues/88), and
+its failure must tell the agent that explicit developer approval is required and how to request a
+reviewed baseline update.
+
+The platform-specific engines, artifact references, deterministic-field rules, and native
+acceptance commands remain decentralized in the guides under `agents/platforms/`. A shared CI or
+linker change must update each affected guide rather than moving platform details into this file.
+
 ## 5. Honest risks
 
 Recorded here so they are not rediscovered later as surprises.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,6 +44,11 @@ compatibility that has historically consumed years — and killed prior efforts 
 
 Windows, Linux, and macOS are first-class from day one. Not "Linux plus ports."
 
+The minimum supported Rust version is **1.95**. Normal contributor and CI toolchains pin Rust
+1.95.0 rather than a floating `stable`; sanitizer and fuzz jobs remain explicit nightly exceptions.
+Rust 1.95's `cfg_select!` makes every host-platform route exhaustive: an unlisted target fails to
+compile instead of silently inheriting Linux behavior.
+
 | Platform | Object format | Notes |
 |---|---|---|
 | Linux | ELF | Baseline; the format `wild` already does well |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Windows host:
 ```bash
 docker build -t reld-ci -f docker/ci/ubuntu.Dockerfile .
 docker run --rm -v "$PWD:/src" -w /src reld-ci \
-  bash -lc 'RELD_TEST_CONFIG=/src/test-config-ci.toml rustup run --install 1.94.1 cargo test --workspace'
+  bash -lc 'RELD_TEST_CONFIG=/src/test-config-ci.toml rustup run --install 1.95.0 cargo test --workspace'
 ```
 
 See [UPSTREAM.md](UPSTREAM.md) for the tracked source delta.

--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -35,12 +35,23 @@ Every produced executable must also run natively with exact exit status, stdout,
 the randomized `reld-difftest` execution comparison as a supplemental oracle; it does not replace
 artifact comparison.
 
+## Consumer acceptance
+
+The three-platform consumer job builds the host-named `reld` ELF driver through `setup-soldr`, then
+links the pinned Rust and C/C++ consumers through that release executable. Set
+`RELD_INVOCATION_LOG` for every build
+and require a successful JSONL record naming each expected final artifact and the native ELF route.
+This invocation record is mandatory even when verbose compiler output appears to name reld. Then
+run `xsv count`, the full pinned PCRE2 CTest suite, and the C++ name-mangling CTest natively.
+
 ## Where Linux policy lives
 
 - Native implementation: `crates/reld-core/src/`
 - Differential runner: `crates/reld-testkit/src/bin/reld-difftest.rs`
 - Benchmark replay and execution oracle: `ci/benchmark_runner.py`
+- Consumer acceptance driver: `ci/consumer_acceptance.py`
 - Linux acceptance and differential CI: `.github/workflows/ci.yml`
+- Three-platform consumer acceptance: `.github/workflows/linker-artifacts.yml`
 - Published benchmark matrix: `.github/workflows/benchmark-stats.yml`
 
 Do not publish a speed result from a performance-only change when artifact identity has not been

--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -5,6 +5,8 @@ and the root [`AGENTS.md`](../../AGENTS.md) first.
 
 ## Current architecture and references
 
+- Rust 1.95 is the MSRV; normal local and CI builds use the exact 1.95.0 pin, not floating
+  `stable`.
 - Fast non-LTO links use `reld`'s native ELF engine inherited from `wild`.
 - LTO and other unsupported native capabilities route to the bundled `ld.lld` bridge.
 - For inherited native behavior, the artifact reference is the exact pinned `wild` fork commit from

--- a/agents/platforms/macos.md
+++ b/agents/platforms/macos.md
@@ -5,6 +5,8 @@ and the root [`AGENTS.md`](../../AGENTS.md) first.
 
 ## Current architecture and references
 
+- Rust 1.95 is the MSRV; normal local and CI builds use the exact 1.95.0 pin, not floating
+  `stable`.
 - macOS links currently use reld's `ld64.lld` bridge; native Mach-O code generation is future work.
 - The byte-identity reference for bridge-only changes is the same pinned `ld64.lld` backend invoked
   directly with the same effective arguments, inputs, environment, and deterministic options.

--- a/agents/platforms/macos.md
+++ b/agents/platforms/macos.md
@@ -32,13 +32,24 @@ Every executable must run on a native macOS runner with exact exit status, stdou
 dynamic-library loading when the change touches dylibs, rpaths, exports, fixups, or signing. A link
 performed or inspected only on Linux is not acceptance evidence.
 
+## Consumer acceptance
+
+The three-platform consumer job builds the host-named `reld` Mach-O driver through `setup-soldr`,
+then links the pinned Rust and C/C++ consumers through that release executable. Set
+`RELD_INVOCATION_LOG` for every build
+and require a successful JSONL record naming each expected final artifact and the `ld64.lld`
+bridge. This invocation record is mandatory even when verbose compiler output appears to name reld.
+Then run `xsv count`, the full pinned PCRE2 CTest suite, and the C++ name-mangling CTest natively.
+
 ## Where macOS policy lives
 
 - Bridge and routing implementation: `crates/reld/src/` and `crates/reld-core/src/`
 - Cross-platform mode validation: `ci/linker_modes.py`
 - Benchmark replay and execution oracle: `ci/benchmark_runner.py`
+- Consumer acceptance driver: `ci/consumer_acceptance.py`
 - Platform workflows: `.github/workflows/ci.yml`, `.github/workflows/linker-modes.yml`, and
-  `.github/workflows/benchmark-stats.yml`
+  `.github/workflows/benchmark-stats.yml`; consumer acceptance runs in
+  `.github/workflows/linker-artifacts.yml`
 
 When native Mach-O code generation lands, update this guide in the same change to name its pinned
 behavioral baseline and native structural/differential test suite.

--- a/agents/platforms/windows.md
+++ b/agents/platforms/windows.md
@@ -31,14 +31,25 @@ Every executable must run on a native Windows runner with exact exit status, std
 Test DLL loading or imported functionality when the change touches imports, exports, delay loading,
 TLS, or runtime metadata. Cross-compilation alone is not acceptance evidence.
 
+## Consumer acceptance
+
+The three-platform consumer job builds `reld-link.exe` through `setup-soldr`, then links the pinned
+Rust and C/C++ consumers through the release executable. Set `RELD_INVOCATION_LOG` for every build
+and require a successful JSONL record naming each expected final `.exe` and the `lld-link` bridge.
+This is the proof that `reld-link.exe` was actually hit; `PATH`, compiler configuration, or verbose
+command text alone is insufficient. Then run `xsv count`, the full pinned PCRE2 CTest suite, and the
+C++ name-mangling CTest natively.
+
 ## Where Windows policy lives
 
 - Bridge and routing implementation: `crates/reld/src/` and `crates/reld-core/src/`
 - Windows CI orchestration: `ci/windows_ci.py`
+- Consumer acceptance driver: `ci/consumer_acceptance.py`
 - Cross-platform mode validation: `ci/linker_modes.py`
 - Benchmark replay and execution oracle: `ci/benchmark_runner.py`
 - Platform workflows: `.github/workflows/ci.yml`, `.github/workflows/linker-modes.yml`, and
-  `.github/workflows/benchmark-stats.yml`
+  `.github/workflows/benchmark-stats.yml`; consumer acceptance runs in
+  `.github/workflows/linker-artifacts.yml`
 
 When native PE/COFF code generation lands, update this guide in the same change to name its pinned
 behavioral baseline and native structural/differential test suite.

--- a/agents/platforms/windows.md
+++ b/agents/platforms/windows.md
@@ -5,12 +5,16 @@ and the root [`AGENTS.md`](../../AGENTS.md) first.
 
 ## Current architecture and references
 
+- Rust 1.95 is the MSRV; normal local and CI builds use the exact 1.95.0 pin, not floating
+  `stable`.
 - Windows links currently use reld's `lld-link` bridge; native PE/COFF code generation is future
   work.
 - The byte-identity reference for bridge-only changes is the same pinned `lld-link` backend invoked
   directly with the same effective arguments, inputs, environment, and deterministic options.
 - Pin the LLVM/Rust toolchain that supplies `lld-link`. `link.exe` is a compatibility reference,
   not a byte-identity reference, because it has different PE/COFF and PDB policies.
+- `x86_64-pc-windows-gnu` is compile-checked from Linux but is not yet a consumer-acceptance
+  route or advertised runtime platform; its GNU-dialect acceptance work remains tracked by #90.
 
 ## Required evidence
 

--- a/ci/cmake/reld-link-rules.cmake
+++ b/ci/cmake/reld-link-rules.cmake
@@ -1,0 +1,21 @@
+# Loaded through CMAKE_USER_MAKE_RULES_OVERRIDE after CMake's platform files.
+#
+# Some CMake platform modules add their own `-fuse-ld=` option after ordinary
+# linker flags. In particular, Windows-Clang appends `-fuse-ld=lld`, which can
+# silently override a caller-provided `-fuse-ld=reld-link`. Put the reld
+# selector at the very end of each compiler-driver link command so the tested
+# linker is the one Clang actually invokes.
+
+set(RELD_LINKER_SELECTOR "$ENV{RELD_LINKER_SELECTOR}")
+if(RELD_LINKER_SELECTOR STREQUAL "")
+  message(FATAL_ERROR "RELD_LINKER_SELECTOR must select the reld linker under test")
+endif()
+
+set(
+  CMAKE_C_LINK_EXECUTABLE
+  "<CMAKE_C_COMPILER> <FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -fuse-ld=${RELD_LINKER_SELECTOR}"
+)
+set(
+  CMAKE_CXX_LINK_EXECUTABLE
+  "<CMAKE_CXX_COMPILER> <FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -fuse-ld=${RELD_LINKER_SELECTOR}"
+)

--- a/ci/consumer_acceptance.py
+++ b/ci/consumer_acceptance.py
@@ -167,8 +167,10 @@ def rust_environment(
         linker_flavor_flag = f"-Clinker-flavor={host.rust_linker_flavor}"
         env[rustflags_key] = linker_flavor_flag
         # Cargo links host build scripts separately from the requested target. On a native host
-        # those scripts still use the selected reld binary, so give them the same direct linker
-        # flavor rather than letting Rust's default compiler-driver flavor reach the bridge.
+        # those scripts still use the selected reld binary, so force the same direct linker
+        # flavor at Cargo's highest-precedence environment layer rather than letting its default
+        # compiler-driver flavor reach the bridge.
+        env["CARGO_ENCODED_RUSTFLAGS"] = linker_flavor_flag
         env["RUSTFLAGS"] = linker_flavor_flag
     env["RELD_LOG_ENGINE"] = "1"
     env["RELD_INVOCATION_LOG"] = str(invocation_log)

--- a/ci/consumer_acceptance.py
+++ b/ci/consumer_acceptance.py
@@ -38,7 +38,7 @@ class Host:
     name: str
     target: str
     executable_suffix: str
-    rust_linker_flavor: str | None
+    rust_uses_compiler_wrapper: bool
     expected_engine: str
     expected_route_kind: str
     expected_route: str
@@ -49,7 +49,7 @@ HOSTS = {
         name="linux",
         target="x86_64-unknown-linux-gnu",
         executable_suffix="",
-        rust_linker_flavor="ld.lld",
+        rust_uses_compiler_wrapper=True,
         expected_engine="reld",
         expected_route_kind="native",
         expected_route="reld: engine=reld (native,",
@@ -58,7 +58,7 @@ HOSTS = {
         name="windows",
         target="x86_64-pc-windows-msvc",
         executable_suffix=".exe",
-        rust_linker_flavor=None,
+        rust_uses_compiler_wrapper=False,
         expected_engine="lld-link",
         expected_route_kind="bridge",
         expected_route="reld: engine=lld-link (bridge,",
@@ -67,7 +67,7 @@ HOSTS = {
         name="macos",
         target="aarch64-apple-darwin",
         executable_suffix="",
-        rust_linker_flavor="ld64.lld",
+        rust_uses_compiler_wrapper=True,
         expected_engine="ld64.lld",
         expected_route_kind="bridge",
         expected_route="reld: engine=ld64.lld (bridge,",
@@ -159,19 +159,23 @@ def rust_environment(
     env.pop("RUSTFLAGS", None)
     env["CARGO_TARGET_DIR"] = str(target_dir)
     key = "CARGO_TARGET_" + host.target.upper().replace("-", "_") + "_LINKER"
-    env[key] = str(linker)
     rustflags_key = "CARGO_TARGET_" + host.target.upper().replace("-", "_") + "_RUSTFLAGS"
-    if host.rust_linker_flavor is None:
+    if not host.rust_uses_compiler_wrapper:
+        env[key] = str(linker)
         env.pop(rustflags_key, None)
     else:
-        linker_flavor_flag = f"-Clinker-flavor={host.rust_linker_flavor}"
-        env[rustflags_key] = linker_flavor_flag
+        # Rust's direct linker flavors bypass the compiler driver, but a Rust consumer also needs
+        # the driver to add the host CRT and SDK inputs. Keep that driver and select the exact
+        # reld binary through clang's stable `-fuse-ld=` route; clang then hands reld raw linker
+        # argv rather than compiler-driver flags such as `-m64` or `-Wl,...`.
+        env[key] = "clang"
+        fuse_ld_flag = f"-Clink-arg=-fuse-ld={linker}"
+        env[rustflags_key] = fuse_ld_flag
         # Cargo links host build scripts separately from the requested target. On a native host
-        # those scripts still use the selected reld binary, so force the same direct linker
-        # flavor at Cargo's highest-precedence environment layer rather than letting its default
-        # compiler-driver flavor reach the bridge.
-        env["CARGO_ENCODED_RUSTFLAGS"] = linker_flavor_flag
-        env["RUSTFLAGS"] = linker_flavor_flag
+        # those scripts need the same compiler-wrapper route, so apply it at Cargo's
+        # highest-precedence environment layer.
+        env["CARGO_ENCODED_RUSTFLAGS"] = fuse_ld_flag
+        env["RUSTFLAGS"] = fuse_ld_flag
     env["RELD_LOG_ENGINE"] = "1"
     env["RELD_INVOCATION_LOG"] = str(invocation_log)
     return env

--- a/ci/consumer_acceptance.py
+++ b/ci/consumer_acceptance.py
@@ -1,0 +1,600 @@
+"""Build and execute pinned Rust, C, and C++ consumers with reld.
+
+This is an on-host acceptance gate, not a cross-compilation smoke test. It
+requires independent evidence that the requested reld binary was selected and
+that every linked program's own behavioral tests pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CMAKE_LINK_RULES = REPO_ROOT / "ci" / "cmake" / "reld-link-rules.cmake"
+CPP_FIXTURE = REPO_ROOT / "ci" / "e2e" / "cpp-name-mangling"
+PCRE2_TEST_TOOLS = REPO_ROOT / "ci" / "pcre2-test-tools.ps1"
+
+RUST_CRATE = "xsv"
+RUST_CRATE_VERSION = "0.13.0"
+PCRE2_REPOSITORY = "https://github.com/PCRE2Project/pcre2.git"
+PCRE2_COMMIT = "f454e231fe5006dd7ff8f4693fd2b8eb94333429"
+
+
+class AcceptanceError(RuntimeError):
+    """A consumer did not prove that reld linked a working program."""
+
+
+@dataclass(frozen=True)
+class Host:
+    name: str
+    target: str
+    executable_suffix: str
+    rust_linker_flavor: str | None
+    expected_engine: str
+    expected_route_kind: str
+    expected_route: str
+
+
+HOSTS = {
+    "linux": Host(
+        name="linux",
+        target="x86_64-unknown-linux-gnu",
+        executable_suffix="",
+        rust_linker_flavor="ld.lld",
+        expected_engine="reld",
+        expected_route_kind="native",
+        expected_route="reld: engine=reld (native,",
+    ),
+    "windows": Host(
+        name="windows",
+        target="x86_64-pc-windows-msvc",
+        executable_suffix=".exe",
+        rust_linker_flavor=None,
+        expected_engine="lld-link",
+        expected_route_kind="bridge",
+        expected_route="reld: engine=lld-link (bridge,",
+    ),
+    "macos": Host(
+        name="macos",
+        target="aarch64-apple-darwin",
+        executable_suffix="",
+        rust_linker_flavor="ld64.lld",
+        expected_engine="ld64.lld",
+        expected_route_kind="bridge",
+        expected_route="reld: engine=ld64.lld (bridge,",
+    ),
+}
+
+
+def detect_host(value: str) -> Host:
+    if value != "auto":
+        try:
+            return HOSTS[value]
+        except KeyError as error:
+            raise AcceptanceError(f"unsupported platform {value!r}") from error
+    if sys.platform.startswith("linux"):
+        return HOSTS["linux"]
+    if sys.platform == "win32":
+        return HOSTS["windows"]
+    if sys.platform == "darwin":
+        return HOSTS["macos"]
+    raise AcceptanceError(f"unsupported host {sys.platform!r}")
+
+
+def command_text(command: Sequence[os.PathLike[str] | str]) -> str:
+    return subprocess.list2cmdline([os.fspath(item) for item in command])
+
+
+def run_checked(
+    command: Sequence[os.PathLike[str] | str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> subprocess.CompletedProcess[str]:
+    rendered = command_text(command)
+    print(f"+ {rendered}", flush=True)
+    result = subprocess.run(
+        [os.fspath(item) for item in command],
+        cwd=cwd,
+        env=dict(env),
+        text=True,
+        capture_output=True,
+        errors="replace",
+        check=False,
+    )
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
+    if result.returncode != 0:
+        raise AcceptanceError(f"command exited with {result.returncode}: {rendered}")
+    return result
+
+
+def require_tool(name: str) -> str:
+    resolved = shutil.which(name)
+    if resolved is None:
+        raise AcceptanceError(f"required tool {name!r} is not on PATH")
+    # Keep the selected shim name. Rustup's cargo executable is a proxy whose
+    # behavior depends on argv[0]; resolving it to rustup.exe changes the tool.
+    return str(Path(resolved).absolute())
+
+
+def require_route(output: str, host: Host, description: str) -> None:
+    if host.expected_route not in output:
+        raise AcceptanceError(
+            f"{description} did not emit the expected reld route {host.expected_route!r}"
+        )
+
+
+def require_exact_output(
+    result: subprocess.CompletedProcess[str],
+    *,
+    stdout: str,
+    description: str,
+) -> None:
+    if result.stdout != stdout or result.stderr != "":
+        raise AcceptanceError(
+            f"{description} output mismatch: stdout={result.stdout!r}, stderr={result.stderr!r}"
+        )
+
+
+def rust_environment(
+    host: Host,
+    linker: Path,
+    target_dir: Path,
+    invocation_log: Path,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("CARGO_ENCODED_RUSTFLAGS", None)
+    env.pop("RUSTFLAGS", None)
+    env["CARGO_TARGET_DIR"] = str(target_dir)
+    key = "CARGO_TARGET_" + host.target.upper().replace("-", "_") + "_LINKER"
+    env[key] = str(linker)
+    rustflags_key = "CARGO_TARGET_" + host.target.upper().replace("-", "_") + "_RUSTFLAGS"
+    if host.rust_linker_flavor is None:
+        env.pop(rustflags_key, None)
+    else:
+        linker_flavor_flag = f"-Clinker-flavor={host.rust_linker_flavor}"
+        env[rustflags_key] = linker_flavor_flag
+        # Cargo links host build scripts separately from the requested target. On a native host
+        # those scripts still use the selected reld binary, so give them the same direct linker
+        # flavor rather than letting Rust's default compiler-driver flavor reach the bridge.
+        env["RUSTFLAGS"] = linker_flavor_flag
+    env["RELD_LOG_ENGINE"] = "1"
+    env["RELD_INVOCATION_LOG"] = str(invocation_log)
+    return env
+
+
+def read_invocations(path: Path) -> list[dict[str, object]]:
+    if not path.is_file():
+        raise AcceptanceError(f"reld did not create its invocation log: {path}")
+    records: list[dict[str, object]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise AcceptanceError(f"invalid invocation JSON at {path}:{line_number}") from error
+        if not isinstance(record, dict):
+            raise AcceptanceError(f"invocation record at {path}:{line_number} is not an object")
+        records.append(record)
+    if not records:
+        raise AcceptanceError(f"reld invocation log is empty: {path}")
+    return records
+
+
+def record_output(record: Mapping[str, object]) -> Path | None:
+    output = record.get("output")
+    working_directory = record.get("working_directory")
+    if not isinstance(output, str) or not isinstance(working_directory, str):
+        return None
+    path = Path(output)
+    if not path.is_absolute():
+        path = Path(working_directory) / path
+    return path.resolve()
+
+
+def require_logged_outputs(
+    invocation_log: Path,
+    host: Host,
+    expected_outputs: Sequence[Path],
+    description: str,
+) -> None:
+    records = read_invocations(invocation_log)
+    successful_outputs = {
+        record_output(record)
+        for record in records
+        if record.get("schema") == 1
+        and record.get("status") == "success"
+        and record.get("engine") == host.expected_engine
+        and record.get("route_kind") == host.expected_route_kind
+    }
+    missing = [
+        str(path.resolve())
+        for path in expected_outputs
+        if path.resolve() not in successful_outputs
+    ]
+    if missing:
+        raise AcceptanceError(
+            f"{description} has no successful reld invocation for: {', '.join(missing)}"
+        )
+
+
+def require_logged_rust_binary(invocation_log: Path, host: Host, target_dir: Path) -> Path:
+    expected_parent = (target_dir / host.target / "release" / "deps").resolve()
+    prefix = f"{RUST_CRATE}-"
+    candidates = []
+    for record in read_invocations(invocation_log):
+        output = record_output(record)
+        if (
+            record.get("schema") == 1
+            and record.get("status") == "success"
+            and record.get("engine") == host.expected_engine
+            and record.get("route_kind") == host.expected_route_kind
+            and output is not None
+            and output.parent == expected_parent
+            and output.name.startswith(prefix)
+            and output.name.endswith(host.executable_suffix)
+        ):
+            candidates.append(output)
+    if len(candidates) != 1:
+        raise AcceptanceError(
+            f"cargo install {RUST_CRATE} logged {len(candidates)} matching final links; expected 1"
+        )
+    if not candidates[0].is_file():
+        raise AcceptanceError(f"logged Rust output is missing: {candidates[0]}")
+    return candidates[0]
+
+
+def exercise_rust(host: Host, linker: Path, work_dir: Path) -> None:
+    print(f"== Rust consumer: {RUST_CRATE} {RUST_CRATE_VERSION} ==", flush=True)
+    install_root = work_dir / "rust-install"
+    target_dir = work_dir / "rust-target"
+    invocation_log = work_dir / "rust-invocations.jsonl"
+    env = rust_environment(host, linker, target_dir, invocation_log)
+    run_checked(
+        [
+            require_tool("cargo"),
+            "install",
+            RUST_CRATE,
+            "--version",
+            RUST_CRATE_VERSION,
+            "--locked",
+            "--root",
+            install_root,
+            "--target",
+            host.target,
+            "--target-dir",
+            target_dir,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+    require_logged_rust_binary(invocation_log, host, target_dir)
+
+    sample = work_dir / "sample.csv"
+    sample.write_text("name,value\nalpha,1\nbeta,2\n", encoding="utf-8")
+    executable = install_root / "bin" / f"{RUST_CRATE}{host.executable_suffix}"
+    if not executable.is_file():
+        raise AcceptanceError(f"installed Rust executable is missing: {executable}")
+    executed = run_checked([executable, "count", sample], cwd=work_dir, env=env)
+    require_exact_output(executed, stdout="2\n", description="xsv count")
+
+
+def exercise_logging_equivalence(
+    host: Host,
+    linker: Path,
+    work_dir: Path,
+    *,
+    cc: str,
+) -> None:
+    print("== Logging equivalence: identical artifact with audit off/on ==", flush=True)
+    fixture = work_dir / "logging-equivalence"
+    fixture.mkdir()
+    source = fixture / "main.c"
+    object_file = fixture / ("main.obj" if host.name == "windows" else "main.o")
+    executable = fixture / f"logging-equivalence{host.executable_suffix}"
+    invocation_log = fixture / "invocations.jsonl"
+    source.write_text("int main(void) { return 0; }\n", encoding="utf-8")
+
+    env_without_log = cmake_environment(linker, host=host)
+    selector = cmake_linker_selector(host, linker, env_without_log)
+    compiler = require_tool(cc)
+    run_checked([compiler, "-c", source, "-o", object_file], cwd=fixture, env=env_without_log)
+    link_command = [compiler, object_file, "-o", executable, f"-fuse-ld={selector}"]
+    if host.name == "windows":
+        link_command.extend(["-Xlinker", "/Brepro"])
+    elif host.name == "macos":
+        link_command.append("-Wl,-no_uuid")
+    else:
+        link_command.append("-Wl,--build-id=sha1")
+
+    first_link = run_checked(link_command, cwd=fixture, env=env_without_log)
+    require_route(first_link.stdout + first_link.stderr, host, "logging-disabled link")
+    baseline = executable.read_bytes()
+    second_off_link = run_checked(link_command, cwd=fixture, env=env_without_log)
+    require_route(second_off_link.stdout + second_off_link.stderr, host, "logging-disabled replay")
+    if executable.read_bytes() != baseline:
+        raise AcceptanceError("logging-disabled linker output is not self-deterministic")
+
+    env_with_log = cmake_environment(linker, invocation_log, host=host)
+    first_on_link = run_checked(link_command, cwd=fixture, env=env_with_log)
+    require_route(first_on_link.stdout + first_on_link.stderr, host, "logging-enabled link")
+    logged_baseline = executable.read_bytes()
+    second_on_link = run_checked(link_command, cwd=fixture, env=env_with_log)
+    require_route(second_on_link.stdout + second_on_link.stderr, host, "logging-enabled replay")
+    require_logged_outputs(invocation_log, host, [executable], "logging-enabled link")
+    if executable.read_bytes() != logged_baseline:
+        raise AcceptanceError("logging-enabled linker output is not self-deterministic")
+    if logged_baseline != baseline:
+        raise AcceptanceError("RELD_INVOCATION_LOG changed the linked artifact bytes")
+
+    executed = run_checked([executable], cwd=fixture, env=env_with_log)
+    require_exact_output(executed, stdout="", description="logging-equivalence executable")
+
+
+def checkout_pinned(repository: str, commit: str, destination: Path, env: Mapping[str, str]) -> None:
+    destination.mkdir(parents=True)
+    git = require_tool("git")
+    run_checked([git, "init"], cwd=destination, env=env)
+    run_checked([git, "remote", "add", "origin", repository], cwd=destination, env=env)
+    run_checked([git, "fetch", "--depth", "1", "origin", commit], cwd=destination, env=env)
+    run_checked([git, "checkout", "--detach", "FETCH_HEAD"], cwd=destination, env=env)
+    actual = run_checked([git, "rev-parse", "HEAD"], cwd=destination, env=env).stdout.strip()
+    if actual != commit:
+        raise AcceptanceError(f"pinned checkout drifted: expected {commit}, got {actual}")
+
+
+def prepare_pcre2_tests(host: Host, source: Path) -> None:
+    if host.name != "windows":
+        return
+    script = source / "RunGrepTest.bat"
+    contents = script.read_text(encoding="utf-8")
+    helper = str(PCRE2_TEST_TOOLS)
+    replacements = {
+        "set printf=cscript //nologo printf.js": (
+            f'set printf=powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass '
+            f'-File "{helper}" printf'
+        ),
+        "set trnull=cscript //nologo trnull.js": (
+            f'set trnull=powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass '
+            f'-File "{helper}" trnull'
+        ),
+    }
+    for original, replacement in replacements.items():
+        if contents.count(original) != 1:
+            raise AcceptanceError(f"pinned PCRE2 helper marker changed: {original}")
+        contents = contents.replace(original, replacement)
+    script.write_text(contents, encoding="utf-8", newline="\n")
+
+
+def cmake_environment(
+    linker: Path,
+    invocation_log: Path | None = None,
+    *,
+    host: Host | None = None,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    if host is not None and host.name == "windows":
+        # Git Bash exports a Unix locale name that the Windows CRT rejects.
+        for variable in ("LANG", "LC_ALL", "LC_CTYPE"):
+            env.pop(variable, None)
+    env["RELD_LOG_ENGINE"] = "1"
+    env["PATH"] = os.pathsep.join([str(linker.parent), env.get("PATH", "")])
+    if invocation_log is not None:
+        env["RELD_INVOCATION_LOG"] = str(invocation_log)
+    else:
+        env.pop("RELD_INVOCATION_LOG", None)
+    return env
+
+
+def cmake_linker_selector(host: Host, linker: Path, env: Mapping[str, str]) -> str:
+    if host.name != "windows":
+        return str(linker)
+    resolved = shutil.which("reld-link", path=env.get("PATH"))
+    if resolved is None or Path(resolved).resolve() != linker:
+        raise AcceptanceError(
+            f"{host.name} compiler cannot resolve the exact reld-link under test: {linker}"
+        )
+    return "reld-link"
+
+
+def configure_and_build(
+    *,
+    host: Host,
+    linker: Path,
+    source_dir: Path,
+    build_dir: Path,
+    cc: str,
+    cxx: str | None,
+    definitions: Sequence[str],
+    invocation_log: Path,
+) -> str:
+    env = cmake_environment(linker, invocation_log, host=host)
+    selector = cmake_linker_selector(host, linker, env)
+    env["RELD_LINKER_SELECTOR"] = selector
+    command = [
+        require_tool("cmake"),
+        "-S",
+        source_dir,
+        "-B",
+        build_dir,
+        "-G",
+        "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        f"-DCMAKE_C_COMPILER={require_tool(cc)}",
+        f"-DCMAKE_USER_MAKE_RULES_OVERRIDE={CMAKE_LINK_RULES}",
+        *definitions,
+    ]
+    if cxx is not None:
+        command.append(f"-DCMAKE_CXX_COMPILER={require_tool(cxx)}")
+    run_checked(command, cwd=REPO_ROOT, env=env)
+    built = run_checked(
+        [require_tool("cmake"), "--build", build_dir, "--parallel", "4", "--verbose"],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    output = built.stdout + built.stderr
+    require_route(output, host, f"CMake build of {source_dir.name}")
+    return output
+
+
+def ctest_count(build_dir: Path, env: Mapping[str, str]) -> int:
+    listed = run_checked(
+        [require_tool("ctest"), "--test-dir", build_dir, "--show-only=json-v1"],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    try:
+        payload = json.loads(listed.stdout)
+        return len(payload["tests"])
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        raise AcceptanceError(f"could not parse CTest inventory for {build_dir}") from error
+
+
+def run_ctest(build_dir: Path, linker: Path, host: Host, *, minimum_tests: int) -> None:
+    env = cmake_environment(linker, host=host)
+    count = ctest_count(build_dir, env)
+    if count < minimum_tests:
+        raise AcceptanceError(
+            f"{build_dir.name} registered {count} CTest tests; expected at least {minimum_tests}"
+        )
+    run_checked(
+        [require_tool("ctest"), "--test-dir", build_dir, "--output-on-failure"],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
+def exercise_c(host: Host, linker: Path, work_dir: Path, *, cc: str) -> None:
+    print(f"== C consumer: PCRE2 {PCRE2_COMMIT} ==", flush=True)
+    source = work_dir / "pcre2"
+    build = work_dir / "pcre2-build"
+    invocation_log = work_dir / "pcre2-invocations.jsonl"
+    env = cmake_environment(linker, host=host)
+    checkout_pinned(PCRE2_REPOSITORY, PCRE2_COMMIT, source, env)
+    prepare_pcre2_tests(host, source)
+    definitions = [
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DPCRE2_BUILD_TESTS=ON",
+        "-DPCRE2_SUPPORT_LIBBZ2=OFF",
+        "-DPCRE2_SUPPORT_LIBZ=OFF",
+        "-DPCRE2_SUPPORT_LIBREADLINE=OFF",
+        "-DPCRE2_SUPPORT_LIBEDIT=OFF",
+    ]
+    if host.name == "windows":
+        # External script callouts depend on optional Windows script engines.
+        # PCRE2's complete non-fork callout suite still runs.
+        definitions.append("-DPCRE2GREP_SUPPORT_CALLOUT_FORK=OFF")
+    configure_and_build(
+        host=host,
+        linker=linker,
+        source_dir=source,
+        build_dir=build,
+        cc=cc,
+        cxx=None,
+        definitions=definitions,
+        invocation_log=invocation_log,
+    )
+    require_logged_outputs(
+        invocation_log,
+        host,
+        [
+            build / f"pcre2test{host.executable_suffix}",
+            build / f"pcre2grep{host.executable_suffix}",
+            build / f"pcre2posix_test{host.executable_suffix}",
+        ],
+        "PCRE2 build",
+    )
+    run_ctest(build, linker, host, minimum_tests=3)
+
+
+def exercise_cpp(host: Host, linker: Path, work_dir: Path, *, cc: str, cxx: str) -> None:
+    print("== C++ consumer: name-mangling fixture ==", flush=True)
+    build = work_dir / "cpp-name-mangling-build"
+    invocation_log = work_dir / "cpp-name-mangling-invocations.jsonl"
+    configure_and_build(
+        host=host,
+        linker=linker,
+        source_dir=CPP_FIXTURE,
+        build_dir=build,
+        cc=cc,
+        cxx=cxx,
+        definitions=("-DBUILD_SHARED_LIBS=OFF",),
+        invocation_log=invocation_log,
+    )
+    require_logged_outputs(
+        invocation_log,
+        host,
+        [build / f"reld_cpp_name_mangling{host.executable_suffix}"],
+        "C++ name-mangling build",
+    )
+    executable = build / f"reld_cpp_name_mangling{host.executable_suffix}"
+    executed = run_checked(
+        [executable],
+        cwd=build,
+        env=cmake_environment(linker, host=host),
+    )
+    require_exact_output(
+        executed,
+        stdout="reld-cxx-name-mangling-ok\n",
+        description="C++ name-mangling executable",
+    )
+    run_ctest(build, linker, host, minimum_tests=1)
+
+
+def run_acceptance(
+    *,
+    host: Host,
+    linker: Path,
+    work_dir: Path,
+    cc: str,
+    cxx: str,
+) -> None:
+    linker = linker.resolve()
+    if not linker.is_file():
+        raise AcceptanceError(f"reld linker is missing: {linker}")
+    if work_dir.exists() and any(work_dir.iterdir()):
+        raise AcceptanceError(f"work directory must be empty: {work_dir}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    exercise_logging_equivalence(host, linker, work_dir, cc=cc)
+    exercise_rust(host, linker, work_dir)
+    exercise_c(host, linker, work_dir, cc=cc)
+    exercise_cpp(host, linker, work_dir, cc=cc, cxx=cxx)
+    print(f"PASS: reld linked working Rust, C, and C++ consumers on {host.name}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ci.consumer_acceptance")
+    parser.add_argument("--platform", choices=("auto", *HOSTS), default="auto")
+    parser.add_argument("--linker", type=Path, required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument("--cc", default="clang")
+    parser.add_argument("--cxx", default="clang++")
+    args = parser.parse_args(argv)
+    try:
+        run_acceptance(
+            host=detect_host(args.platform),
+            linker=args.linker,
+            work_dir=args.work_dir.resolve(),
+            cc=args.cc,
+            cxx=args.cxx,
+        )
+    except AcceptanceError as error:
+        print(f"consumer acceptance failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/e2e/cpp-name-mangling/CMakeLists.txt
+++ b/ci/e2e/cpp-name-mangling/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+project(reld_cpp_name_mangling LANGUAGES CXX)
+
+enable_testing()
+
+add_library(reld_mangled_symbols STATIC src/mangled.cpp)
+target_compile_features(reld_mangled_symbols PUBLIC cxx_std_17)
+target_include_directories(reld_mangled_symbols PUBLIC include)
+
+add_executable(reld_cpp_name_mangling src/main.cpp)
+target_link_libraries(reld_cpp_name_mangling PRIVATE reld_mangled_symbols)
+
+add_test(NAME reld_cpp_name_mangling COMMAND reld_cpp_name_mangling)

--- a/ci/e2e/cpp-name-mangling/include/reld_mangled.hpp
+++ b/ci/e2e/cpp-name-mangling/include/reld_mangled.hpp
@@ -1,16 +1,11 @@
 #pragma once
 
-#include <memory>
-#include <string>
-#include <string_view>
-#include <vector>
-
 namespace reld::consumer::abi {
 
 class Accumulator {
 public:
-    int fold(const std::vector<int>& values) const;
-    std::string fold(std::string_view left, std::string_view right) const;
+    int fold(int first, int second, int third, int fourth) const;
+    long fold(long left, long right) const;
 };
 
 template <typename T>
@@ -21,9 +16,10 @@ extern template int weighted_sum<int>(int left, int right);
 class Formatter {
 public:
     virtual ~Formatter();
-    virtual std::string render(int value) const = 0;
+    virtual int render(int value) const = 0;
 };
 
-std::unique_ptr<Formatter> make_formatter(std::string prefix);
+Formatter* make_formatter(int prefix);
+void destroy_formatter(Formatter* formatter);
 
 } // namespace reld::consumer::abi

--- a/ci/e2e/cpp-name-mangling/include/reld_mangled.hpp
+++ b/ci/e2e/cpp-name-mangling/include/reld_mangled.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace reld::consumer::abi {
+
+class Accumulator {
+public:
+    int fold(const std::vector<int>& values) const;
+    std::string fold(std::string_view left, std::string_view right) const;
+};
+
+template <typename T>
+T weighted_sum(T left, T right);
+
+extern template int weighted_sum<int>(int left, int right);
+
+class Formatter {
+public:
+    virtual ~Formatter();
+    virtual std::string render(int value) const = 0;
+};
+
+std::unique_ptr<Formatter> make_formatter(std::string prefix);
+
+} // namespace reld::consumer::abi

--- a/ci/e2e/cpp-name-mangling/src/main.cpp
+++ b/ci/e2e/cpp-name-mangling/src/main.cpp
@@ -1,0 +1,25 @@
+#include "reld_mangled.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    using reld::consumer::abi::Accumulator;
+    using reld::consumer::abi::make_formatter;
+    using reld::consumer::abi::weighted_sum;
+
+    const Accumulator accumulator;
+    const int folded = accumulator.fold(std::vector<int>{2, 3, 5, 7});
+    const std::string joined = accumulator.fold("mangled", "symbols");
+    const int weighted = weighted_sum(4, 6);
+    const auto formatter = make_formatter("reld-cxx-");
+
+    if (folded != 17 || joined != "mangled::symbols" || weighted != 42 ||
+        formatter->render(weighted) != "reld-cxx-42") {
+        return 1;
+    }
+
+    std::cout << "reld-cxx-name-mangling-ok\n";
+    return 0;
+}

--- a/ci/e2e/cpp-name-mangling/src/main.cpp
+++ b/ci/e2e/cpp-name-mangling/src/main.cpp
@@ -1,25 +1,25 @@
 #include "reld_mangled.hpp"
 
-#include <iostream>
-#include <string>
-#include <vector>
+extern "C" int puts(const char* text);
 
 int main() {
     using reld::consumer::abi::Accumulator;
+    using reld::consumer::abi::destroy_formatter;
     using reld::consumer::abi::make_formatter;
     using reld::consumer::abi::weighted_sum;
 
     const Accumulator accumulator;
-    const int folded = accumulator.fold(std::vector<int>{2, 3, 5, 7});
-    const std::string joined = accumulator.fold("mangled", "symbols");
+    const int folded = accumulator.fold(2, 3, 5, 7);
+    const long combined = accumulator.fold(3L, 5L);
     const int weighted = weighted_sum(4, 6);
-    const auto formatter = make_formatter("reld-cxx-");
+    auto* formatter = make_formatter(100);
 
-    if (folded != 17 || joined != "mangled::symbols" || weighted != 42 ||
-        formatter->render(weighted) != "reld-cxx-42") {
+    const bool valid = folded == 17 && combined == 98 && weighted == 42 && formatter->render(weighted) == 142;
+    destroy_formatter(formatter);
+    if (!valid) {
         return 1;
     }
 
-    std::cout << "reld-cxx-name-mangling-ok\n";
+    puts("reld-cxx-name-mangling-ok");
     return 0;
 }

--- a/ci/e2e/cpp-name-mangling/src/mangled.cpp
+++ b/ci/e2e/cpp-name-mangling/src/mangled.cpp
@@ -1,0 +1,45 @@
+#include "reld_mangled.hpp"
+
+#include <numeric>
+#include <utility>
+
+namespace reld::consumer::abi {
+
+int Accumulator::fold(const std::vector<int>& values) const {
+    return std::accumulate(values.begin(), values.end(), 0);
+}
+
+std::string Accumulator::fold(std::string_view left, std::string_view right) const {
+    return std::string(left) + "::" + std::string(right);
+}
+
+template <typename T>
+T weighted_sum(T left, T right) {
+    return left * 3 + right * 5;
+}
+
+template int weighted_sum<int>(int left, int right);
+
+Formatter::~Formatter() = default;
+
+namespace {
+
+class PrefixFormatter final : public Formatter {
+public:
+    explicit PrefixFormatter(std::string prefix) : prefix_(std::move(prefix)) {}
+
+    std::string render(int value) const override {
+        return prefix_ + std::to_string(value);
+    }
+
+private:
+    std::string prefix_;
+};
+
+} // namespace
+
+std::unique_ptr<Formatter> make_formatter(std::string prefix) {
+    return std::make_unique<PrefixFormatter>(std::move(prefix));
+}
+
+} // namespace reld::consumer::abi

--- a/ci/e2e/cpp-name-mangling/src/mangled.cpp
+++ b/ci/e2e/cpp-name-mangling/src/mangled.cpp
@@ -1,16 +1,13 @@
 #include "reld_mangled.hpp"
 
-#include <numeric>
-#include <utility>
-
 namespace reld::consumer::abi {
 
-int Accumulator::fold(const std::vector<int>& values) const {
-    return std::accumulate(values.begin(), values.end(), 0);
+int Accumulator::fold(int first, int second, int third, int fourth) const {
+    return first + second + third + fourth;
 }
 
-std::string Accumulator::fold(std::string_view left, std::string_view right) const {
-    return std::string(left) + "::" + std::string(right);
+long Accumulator::fold(long left, long right) const {
+    return left * 11 + right * 13;
 }
 
 template <typename T>
@@ -26,20 +23,24 @@ namespace {
 
 class PrefixFormatter final : public Formatter {
 public:
-    explicit PrefixFormatter(std::string prefix) : prefix_(std::move(prefix)) {}
+    explicit PrefixFormatter(int prefix) : prefix_(prefix) {}
 
-    std::string render(int value) const override {
-        return prefix_ + std::to_string(value);
+    int render(int value) const override {
+        return prefix_ + value;
     }
 
 private:
-    std::string prefix_;
+    int prefix_;
 };
 
 } // namespace
 
-std::unique_ptr<Formatter> make_formatter(std::string prefix) {
-    return std::make_unique<PrefixFormatter>(std::move(prefix));
+Formatter* make_formatter(int prefix) {
+    return new PrefixFormatter(prefix);
+}
+
+void destroy_formatter(Formatter* formatter) {
+    delete formatter;
 }
 
 } // namespace reld::consumer::abi

--- a/ci/pcre2-test-tools.ps1
+++ b/ci/pcre2-test-tools.ps1
@@ -1,0 +1,33 @@
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet("printf", "trnull")]
+    [string]$Mode,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Values
+)
+
+$output = [Console]::OpenStandardOutput()
+if ($Mode -eq "printf") {
+    if ($Values.Count -lt 1) {
+        throw "printf requires a format string"
+    }
+    $text = $Values[0].Replace("\r", "`r").Replace("\n", "`n").Replace("\0", "`0")
+    if ($Values.Count -ge 2) {
+        $text = $text.Replace("%s", $Values[1])
+    }
+    $bytes = [Text.Encoding]::UTF8.GetBytes($text)
+    $output.Write($bytes, 0, $bytes.Length)
+    exit 0
+}
+
+$inputStream = [Console]::OpenStandardInput()
+$buffer = [byte[]]::new(8192)
+while (($count = $inputStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+    for ($index = 0; $index -lt $count; $index++) {
+        if ($buffer[$index] -eq 0) {
+            $buffer[$index] = [byte][char]'@'
+        }
+    }
+    $output.Write($buffer, 0, $count)
+}

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -393,6 +393,20 @@ def test_compiled_policy_is_target_calibrated_for_significant_final_links():
     assert "256 * 1024 * 1024" in source
 
 
+def test_benchmark_platform_routes_are_exhaustive():
+    source = (Path(__file__).parents[2] / "crates" / "reld-testkit" / "src" / "bin" / "reld-bench.rs").read_text(
+        encoding="utf-8"
+    )
+
+    # Rust 1.95's cfg_select! emits a compile error when no arm matches. Keep the
+    # three supported host routes explicit rather than treating every other target as Linux.
+    assert source.count("cfg_select! {") >= 2
+    assert source.count('target_os = "windows"') >= 2
+    assert source.count('target_os = "macos"') >= 2
+    assert source.count('target_os = "linux"') >= 2
+    assert "_ =>" not in source
+
+
 def test_startup_probe_is_target_correct(tmp_path: Path):
     linker = Linker("reference", tmp_path / "linker")
 

--- a/ci/tests/test_ci_workflow.py
+++ b/ci/tests/test_ci_workflow.py
@@ -2,6 +2,21 @@ from pathlib import Path
 
 
 WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "ci.yml"
+REPO_ROOT = WORKFLOW.parents[2]
+
+
+def test_normal_toolchains_pin_the_rust_195_msrv():
+    rust_toolchain = (REPO_ROOT / "rust-toolchain.toml").read_text(encoding="utf-8")
+    manifest = (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    workflow_texts = [
+        (REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+        for name in ("ci.yml", "linker-modes.yml", "stress.yml", "benchmark-stats.yml")
+    ]
+
+    assert 'rust-version = "1.95"' in manifest
+    assert 'channel = "1.95.0"' in rust_toolchain
+    assert "RUST_VERSION: 1.95.0" in workflow_texts[0]
+    assert all("e081816240890017053eacbb1bdf337761dc5582 # 1.95.0" in text for text in workflow_texts)
 
 
 def test_ci_caches_linux_reference_linkers():

--- a/ci/tests/test_consumer_acceptance.py
+++ b/ci/tests/test_consumer_acceptance.py
@@ -46,22 +46,26 @@ def test_rust_environment_selects_exact_linker_and_audit_log(tmp_path: Path) -> 
     assert "CARGO_ENCODED_RUSTFLAGS" not in env
 
 
-def test_linux_rust_environment_uses_the_stable_direct_lld_linker_flavor(tmp_path: Path) -> None:
+def test_linux_rust_environment_uses_clang_to_select_the_exact_linker(tmp_path: Path) -> None:
     target_dir = tmp_path / "target"
-    env = rust_environment(HOSTS["linux"], tmp_path / "reld", target_dir, tmp_path / "log.jsonl")
+    linker = tmp_path / "reld"
+    env = rust_environment(HOSTS["linux"], linker, target_dir, tmp_path / "log.jsonl")
 
-    assert env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS"] == "-Clinker-flavor=ld.lld"
-    assert env["CARGO_ENCODED_RUSTFLAGS"] == "-Clinker-flavor=ld.lld"
+    assert env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"] == "clang"
+    assert env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS"] == f"-Clink-arg=-fuse-ld={linker}"
+    assert env["CARGO_ENCODED_RUSTFLAGS"] == f"-Clink-arg=-fuse-ld={linker}"
 
 
 def test_macos_rust_environment_applies_direct_flavor_to_host_build_scripts(tmp_path: Path) -> None:
+    linker = tmp_path / "reld"
     env = rust_environment(
-        HOSTS["macos"], tmp_path / "reld", tmp_path / "target", tmp_path / "log.jsonl"
+        HOSTS["macos"], linker, tmp_path / "target", tmp_path / "log.jsonl"
     )
 
-    assert env["CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
-    assert env["CARGO_ENCODED_RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
-    assert env["RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
+    assert env["CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER"] == "clang"
+    assert env["CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS"] == f"-Clink-arg=-fuse-ld={linker}"
+    assert env["CARGO_ENCODED_RUSTFLAGS"] == f"-Clink-arg=-fuse-ld={linker}"
+    assert env["RUSTFLAGS"] == f"-Clink-arg=-fuse-ld={linker}"
 
 
 def test_tool_lookup_preserves_proxy_executable_name() -> None:

--- a/ci/tests/test_consumer_acceptance.py
+++ b/ci/tests/test_consumer_acceptance.py
@@ -43,6 +43,7 @@ def test_rust_environment_selects_exact_linker_and_audit_log(tmp_path: Path) -> 
     assert env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] == str(linker)
     assert env["CARGO_TARGET_DIR"] == str(target_dir)
     assert env["RELD_INVOCATION_LOG"] == str(invocation_log)
+    assert "CARGO_ENCODED_RUSTFLAGS" not in env
 
 
 def test_linux_rust_environment_uses_the_stable_direct_lld_linker_flavor(tmp_path: Path) -> None:
@@ -50,6 +51,7 @@ def test_linux_rust_environment_uses_the_stable_direct_lld_linker_flavor(tmp_pat
     env = rust_environment(HOSTS["linux"], tmp_path / "reld", target_dir, tmp_path / "log.jsonl")
 
     assert env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS"] == "-Clinker-flavor=ld.lld"
+    assert env["CARGO_ENCODED_RUSTFLAGS"] == "-Clinker-flavor=ld.lld"
 
 
 def test_macos_rust_environment_applies_direct_flavor_to_host_build_scripts(tmp_path: Path) -> None:
@@ -58,6 +60,7 @@ def test_macos_rust_environment_applies_direct_flavor_to_host_build_scripts(tmp_
     )
 
     assert env["CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
+    assert env["CARGO_ENCODED_RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
     assert env["RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
 
 

--- a/ci/tests/test_consumer_acceptance.py
+++ b/ci/tests/test_consumer_acceptance.py
@@ -1,0 +1,214 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ci.consumer_acceptance import (
+    CMAKE_LINK_RULES,
+    CPP_FIXTURE,
+    HOSTS,
+    PCRE2_COMMIT,
+    PCRE2_TEST_TOOLS,
+    RUST_CRATE_VERSION,
+    AcceptanceError,
+    cmake_environment,
+    require_logged_outputs,
+    require_logged_rust_binary,
+    require_exact_output,
+    require_tool,
+    rust_environment,
+    prepare_pcre2_tests,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "linker-artifacts.yml"
+
+
+def test_external_consumers_are_immutably_pinned() -> None:
+    assert RUST_CRATE_VERSION == "0.13.0"
+    assert len(PCRE2_COMMIT) == 40
+    assert all(character in "0123456789abcdef" for character in PCRE2_COMMIT)
+    assert PCRE2_TEST_TOOLS.is_file()
+
+
+def test_rust_environment_selects_exact_linker_and_audit_log(tmp_path: Path) -> None:
+    linker = tmp_path / "reld-link.exe"
+    invocation_log = tmp_path / "rust-invocations.jsonl"
+    target_dir = tmp_path / "target"
+
+    env = rust_environment(HOSTS["windows"], linker, target_dir, invocation_log)
+
+    assert env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] == str(linker)
+    assert env["CARGO_TARGET_DIR"] == str(target_dir)
+    assert env["RELD_INVOCATION_LOG"] == str(invocation_log)
+
+
+def test_linux_rust_environment_uses_the_stable_direct_lld_linker_flavor(tmp_path: Path) -> None:
+    target_dir = tmp_path / "target"
+    env = rust_environment(HOSTS["linux"], tmp_path / "reld", target_dir, tmp_path / "log.jsonl")
+
+    assert env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS"] == "-Clinker-flavor=ld.lld"
+
+
+def test_macos_rust_environment_applies_direct_flavor_to_host_build_scripts(tmp_path: Path) -> None:
+    env = rust_environment(
+        HOSTS["macos"], tmp_path / "reld", tmp_path / "target", tmp_path / "log.jsonl"
+    )
+
+    assert env["CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
+    assert env["RUSTFLAGS"] == "-Clinker-flavor=ld64.lld"
+
+
+def test_tool_lookup_preserves_proxy_executable_name() -> None:
+    assert Path(require_tool("python")).name.casefold().startswith("python")
+
+
+def test_windows_consumer_environment_drops_unix_locale(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LC_ALL", "C.UTF-8")
+
+    env = cmake_environment(Path("reld-link.exe"), host=HOSTS["windows"])
+
+    assert "LC_ALL" not in env
+
+
+def test_windows_pcre2_suite_uses_committed_binary_safe_helpers(tmp_path: Path) -> None:
+    script = tmp_path / "RunGrepTest.bat"
+    script.write_text(
+        "set printf=cscript //nologo printf.js\n"
+        "set trnull=cscript //nologo trnull.js\n",
+        encoding="utf-8",
+    )
+
+    prepare_pcre2_tests(HOSTS["windows"], tmp_path)
+
+    updated = script.read_text(encoding="utf-8")
+    assert "powershell.exe" in updated
+    assert str(PCRE2_TEST_TOOLS) in updated
+
+
+def test_invocation_log_must_match_expected_output_and_route(tmp_path: Path) -> None:
+    output = tmp_path / "build" / "consumer.exe"
+    log = tmp_path / "invocations.jsonl"
+    record = {
+        "schema": 1,
+        "status": "success",
+        "engine": "lld-link",
+        "route_kind": "bridge",
+        "working_directory": str(output.parent),
+        "output": output.name,
+    }
+    log.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    require_logged_outputs(log, HOSTS["windows"], [output], "consumer")
+
+    with pytest.raises(AcceptanceError, match="no successful reld invocation"):
+        require_logged_outputs(log, HOSTS["linux"], [output], "consumer")
+
+
+def test_exact_execution_output_rejects_stderr() -> None:
+    passing = subprocess.CompletedProcess([], 0, stdout="ok\n", stderr="")
+    require_exact_output(passing, stdout="ok\n", description="fixture")
+
+    noisy = subprocess.CompletedProcess([], 0, stdout="ok\n", stderr="warning\n")
+    with pytest.raises(AcceptanceError, match="output mismatch"):
+        require_exact_output(noisy, stdout="ok\n", description="fixture")
+
+
+def test_missing_invocation_log_is_a_hard_failure(tmp_path: Path) -> None:
+    with pytest.raises(AcceptanceError, match="did not create"):
+        require_logged_outputs(
+            tmp_path / "missing.jsonl",
+            HOSTS["linux"],
+            [tmp_path / "consumer"],
+            "consumer",
+        )
+
+
+def test_rust_link_proof_matches_the_hashed_output_cargo_requested(tmp_path: Path) -> None:
+    host = HOSTS["windows"]
+    target_dir = tmp_path / "target"
+    output = target_dir / host.target / "release" / "deps" / "xsv-deadbeef.exe"
+    output.parent.mkdir(parents=True)
+    output.write_bytes(b"linked")
+    log = tmp_path / "rust-invocations.jsonl"
+    log.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "status": "success",
+                "engine": "lld-link",
+                "route_kind": "bridge",
+                "working_directory": str(tmp_path),
+                "output": str(output),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert require_logged_rust_binary(log, host, target_dir) == output.resolve()
+
+
+def test_cmake_override_puts_reld_selection_last() -> None:
+    rules = CMAKE_LINK_RULES.read_text(encoding="utf-8")
+
+    assert "CMAKE_C_LINK_EXECUTABLE" in rules
+    assert "CMAKE_CXX_LINK_EXECUTABLE" in rules
+    for line in rules.splitlines():
+        if "<CMAKE_" in line and "LINK_LIBRARIES" in line:
+            assert line.index("<LINK_LIBRARIES>") < line.index("-fuse-ld=${RELD_LINKER_SELECTOR}")
+
+
+def test_cpp_fixture_exercises_cross_translation_unit_mangling() -> None:
+    header = (CPP_FIXTURE / "include" / "reld_mangled.hpp").read_text(encoding="utf-8")
+    implementation = (CPP_FIXTURE / "src" / "mangled.cpp").read_text(encoding="utf-8")
+    consumer = (CPP_FIXTURE / "src" / "main.cpp").read_text(encoding="utf-8")
+
+    assert "namespace reld::consumer::abi" in header
+    assert "extern template int weighted_sum<int>" in header
+    assert "virtual std::string render" in header
+    assert "template int weighted_sum<int>" in implementation
+    assert 'formatter->render(weighted) != "reld-cxx-42"' in consumer
+
+
+def test_three_platform_artifact_workflow_runs_consumer_acceptance() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "runner: ubuntu-24.04" in workflow
+    assert "runner: macos-14" in workflow
+    assert "runner: windows-2022" in workflow
+    assert "cache: false" in workflow
+    assert "prebuild-deps: none" in workflow
+    assert (
+        'soldr cargo build --locked --release --target "${{ matrix.target }}" '
+        '--package reld --bin "${{ matrix.binary }}"'
+    ) in workflow
+    assert workflow.count("binary: reld\n") == 2
+    assert "binary: reld-link" in workflow
+    assert 'msvc_link="${VCToolsInstallDir}bin/Hostx64/x64/link.exe"' in workflow
+    assert "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$msvc_link" in workflow
+    assert "uv run --no-project python -m ci.consumer_acceptance" in workflow
+    assert workflow.index("name: Build linker") < workflow.index(
+        "name: Link and run pinned Rust, C, and C++ consumers"
+    )
+    assert "consumer-invocations-${{ matrix.name }}" in workflow
+
+
+def test_acceptance_compares_logging_off_and_on_artifact_bytes() -> None:
+    source = (REPO_ROOT / "ci" / "consumer_acceptance.py").read_text(encoding="utf-8")
+
+    assert "baseline = executable.read_bytes()" in source
+    assert "logging-disabled linker output is not self-deterministic" in source
+    assert "logging-enabled linker output is not self-deterministic" in source
+    assert "RELD_INVOCATION_LOG changed the linked artifact bytes" in source
+
+
+def test_dependency_policy_requires_explicit_developer_approval() -> None:
+    design = (REPO_ROOT / "DESIGN.md").read_text(encoding="utf-8")
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert "requires explicit developer approval" in " ".join(design.split())
+    assert "requires explicit developer approval" in " ".join(agents.split())
+    assert "Agents must not update" in agents

--- a/ci/tests/test_consumer_acceptance.py
+++ b/ci/tests/test_consumer_acceptance.py
@@ -175,9 +175,10 @@ def test_cpp_fixture_exercises_cross_translation_unit_mangling() -> None:
 
     assert "namespace reld::consumer::abi" in header
     assert "extern template int weighted_sum<int>" in header
-    assert "virtual std::string render" in header
+    assert "virtual int render" in header
+    assert "long fold(long left, long right)" in header
     assert "template int weighted_sum<int>" in implementation
-    assert 'formatter->render(weighted) != "reld-cxx-42"' in consumer
+    assert "formatter->render(weighted) == 142" in consumer
 
 
 def test_three_platform_artifact_workflow_runs_consumer_acceptance() -> None:

--- a/ci/tests/test_windows_ci.py
+++ b/ci/tests/test_windows_ci.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from ci import windows_ci
 from ci.windows_ci import (
     _msvc_linker,
     _msvc_path_env,
@@ -25,3 +26,26 @@ def test_msvc_linker_uses_visual_studio_tools_instead_of_path(tmp_path: Path, mo
     env = _msvc_path_env()
     assert env["PATH"].split(os.pathsep)[0] == str(expected.parent)
     assert env["CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"] == str(expected)
+
+
+def test_self_host_accepts_the_coff_bridge_version_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(windows_ci, "_workspace", lambda: tmp_path)
+    monkeypatch.setattr(windows_ci, "_require_file", lambda path, _label: path)
+    monkeypatch.setattr(windows_ci, "_cargo", lambda *args: list(args))
+
+    def run(args, **_kwargs):
+        commands.append(list(args))
+        return "LLD 22.1.2\n" if args[-1] == "--version" else ""
+
+    monkeypatch.setattr(windows_ci, "_run", run)
+
+    windows_ci.self_host()
+
+    assert commands == [
+        ["build", "-p", "reld", "--bin", "reld"],
+        [str(tmp_path / "target" / "debug" / "reld.exe"), "--version"],
+    ]

--- a/ci/windows_ci.py
+++ b/ci/windows_ci.py
@@ -233,8 +233,11 @@ def self_host() -> None:
     _run(_cargo("build", "-p", "reld", "--bin", "reld"), env=env)
     reld = _require_file(workspace / "target" / "debug" / "reld.exe", "reld.exe")
     output = _run([str(reld), "--version"])
-    if "Reld" not in output:
-        raise WindowsCiError("self-linked reld --version output missing 'Reld' marker")
+    # On COFF, the generic executable is a linker-driver front door: --version
+    # deliberately reaches the pinned lld-link bridge. Executing it successfully
+    # and observing that backend marker proves the self-linked PE executable works.
+    if "LLD" not in output:
+        raise WindowsCiError("self-linked reld --version output missing LLD bridge marker")
 
 
 COMMANDS = {

--- a/crates/reld-core/src/args.rs
+++ b/crates/reld-core/src/args.rs
@@ -262,10 +262,10 @@ enum PlatformKind {
 
 impl PlatformKind {
     fn host() -> Self {
-        if cfg!(target_os = "macos") {
-            PlatformKind::MachO
-        } else {
-            PlatformKind::Elf
+        cfg_select! {
+            target_os = "windows" => PlatformKind::Coff,
+            target_os = "macos" => PlatformKind::MachO,
+            target_os = "linux" => PlatformKind::Elf,
         }
     }
 

--- a/crates/reld-core/src/bridge.rs
+++ b/crates/reld-core/src/bridge.rs
@@ -23,6 +23,8 @@ use crate::error::Context;
 use crate::error::Result;
 use std::ffi::OsStr;
 use std::ffi::OsString;
+use std::fs::OpenOptions;
+use std::io::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -210,6 +212,12 @@ pub const RELD_ENGINE_ENV: &str = "RELD_ENGINE";
 /// Enables one routing-decision line on stderr when present in the environment.
 pub const RELD_LOG_ENGINE_ENV: &str = "RELD_LOG_ENGINE";
 
+/// Appends one JSON object after every successful link when set to a file path.
+///
+/// This is an acceptance-test audit channel, deliberately separate from human-readable stderr
+/// logging. A record is written only after the selected native or bridge engine returns success.
+pub const RELD_INVOCATION_LOG_ENV: &str = "RELD_INVOCATION_LOG";
+
 fn route_logging_enabled() -> bool {
     std::env::var_os(RELD_LOG_ENGINE_ENV).is_some()
 }
@@ -219,6 +227,172 @@ fn route_logging_enabled() -> bool {
 pub struct Route {
     engine: &'static Engine,
     reason: SelectionReason,
+}
+
+fn decode_response_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("Failed to read linker response file `{}`", path.display()))?;
+    if bytes.starts_with(&[0xff, 0xfe])
+        || (bytes.len() >= 2 && bytes.len().is_multiple_of(2) && bytes[1] == 0)
+    {
+        let words: Vec<u16> = bytes
+            .chunks_exact(2)
+            .skip(usize::from(bytes.starts_with(&[0xff, 0xfe])))
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        return String::from_utf16(&words)
+            .with_context(|| format!("Invalid UTF-16 linker response file `{}`", path.display()));
+    }
+    String::from_utf8(bytes)
+        .with_context(|| format!("Invalid UTF-8 linker response file `{}`", path.display()))
+}
+
+fn response_arguments(contents: &str) -> Result<Vec<OsString>> {
+    let mut arguments = Vec::new();
+    let mut argument = String::new();
+    let mut quote = None;
+    for character in contents.chars() {
+        match (quote, character) {
+            (None, '\'' | '"') => quote = Some(character),
+            (Some(open), close) if open == close => quote = None,
+            (None, character) if character.is_whitespace() => {
+                if !argument.is_empty() {
+                    arguments.push(OsString::from(std::mem::take(&mut argument)));
+                }
+            }
+            (_, character) => argument.push(character),
+        }
+    }
+    if let Some(quote) = quote {
+        bail!("Unclosed `{quote}` in linker response file");
+    }
+    if !argument.is_empty() {
+        arguments.push(OsString::from(argument));
+    }
+    Ok(arguments)
+}
+
+fn requested_output_in(argv: &[OsString], response_depth: usize) -> Result<Option<String>> {
+    let mut arguments = argv.iter();
+    while let Some(argument) = arguments.next() {
+        let value = argument.to_string_lossy();
+        if let Some(path) = value.strip_prefix('@') {
+            if response_depth >= 16 {
+                bail!("Linker response-file nesting exceeds 16 levels at `{path}`");
+            }
+            let nested = response_arguments(&decode_response_file(Path::new(path))?)?;
+            if let Some(output) = requested_output_in(&nested, response_depth + 1)? {
+                return Ok(Some(output));
+            }
+            continue;
+        }
+        if value == "-o" {
+            return Ok(arguments
+                .next()
+                .map(|output| output.to_string_lossy().into_owned()));
+        }
+        let lowercase = value.to_ascii_lowercase();
+        if let Some(output) = lowercase
+            .strip_prefix("/out:")
+            .or_else(|| lowercase.strip_prefix("-out:"))
+        {
+            let prefix_length = value.len() - output.len();
+            return Ok(Some(value[prefix_length..].to_owned()));
+        }
+    }
+    Ok(None)
+}
+
+fn requested_output(argv: &[OsString]) -> Result<Option<String>> {
+    requested_output_in(&argv[1..], 0)
+}
+
+fn append_json_string(encoded: &mut String, value: &str) {
+    encoded.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => encoded.push_str("\\\""),
+            '\\' => encoded.push_str("\\\\"),
+            '\u{08}' => encoded.push_str("\\b"),
+            '\u{0c}' => encoded.push_str("\\f"),
+            '\n' => encoded.push_str("\\n"),
+            '\r' => encoded.push_str("\\r"),
+            '\t' => encoded.push_str("\\t"),
+            character if character <= '\u{1f}' => {
+                const HEX: &[u8; 16] = b"0123456789abcdef";
+                let value = character as usize;
+                encoded.push_str("\\u00");
+                encoded.push(HEX[value >> 4] as char);
+                encoded.push(HEX[value & 0x0f] as char);
+            }
+            character => encoded.push(character),
+        }
+    }
+    encoded.push('"');
+}
+
+fn encode_invocation_record(
+    argv: &[OsString],
+    route: Route,
+    working_directory: &Path,
+    output: Option<&str>,
+) -> String {
+    let mut encoded = String::from("{\"schema\":1,\"status\":\"success\",\"process_id\":");
+    encoded.push_str(&std::process::id().to_string());
+    encoded.push_str(",\"working_directory\":");
+    append_json_string(&mut encoded, &working_directory.to_string_lossy());
+    encoded.push_str(",\"engine\":");
+    append_json_string(&mut encoded, route.engine.name);
+    encoded.push_str(",\"route_kind\":");
+    append_json_string(
+        &mut encoded,
+        if route.engine.native {
+            "native"
+        } else {
+            "bridge"
+        },
+    );
+    encoded.push_str(",\"reason\":");
+    append_json_string(&mut encoded, route.reason.label());
+    encoded.push_str(",\"output\":");
+    if let Some(output) = output {
+        append_json_string(&mut encoded, output);
+    } else {
+        encoded.push_str("null");
+    }
+    encoded.push_str(",\"arguments\":[");
+    for (index, argument) in argv.iter().skip(1).enumerate() {
+        if index != 0 {
+            encoded.push(',');
+        }
+        append_json_string(&mut encoded, &argument.to_string_lossy());
+    }
+    encoded.push_str("]}\n");
+    encoded
+}
+
+/// Records one successfully completed linker invocation when [`RELD_INVOCATION_LOG_ENV`] is set.
+///
+/// The JSONL record includes enough information for an external test to match the exact output
+/// artifact and selected engine. Failure to append is an error: silently losing the audit record
+/// would let an acceptance test pass without proving that reld handled the link.
+pub fn log_successful_invocation(argv: &[OsString], route: Route) -> Result<()> {
+    let Some(path) = std::env::var_os(RELD_INVOCATION_LOG_ENV) else {
+        return Ok(());
+    };
+    let path = PathBuf::from(path);
+    let working_directory = std::env::current_dir()
+        .with_context(|| "Failed to determine the linker working directory".to_owned())?;
+    let output = requested_output(argv)?;
+    let encoded = encode_invocation_record(argv, route, &working_directory, output.as_deref());
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("Failed to open invocation log `{}`", path.display()))?;
+    log.write_all(encoded.as_bytes())
+        .with_context(|| format!("Failed to append invocation log `{}`", path.display()))?;
+    Ok(())
 }
 
 impl Route {
@@ -812,7 +986,7 @@ mod tests {
     use std::sync::Mutex;
 
     // Environment variable mutation isn't thread-safe, so serialize the tests that touch
-    // `RELD_BRIDGE_LINKER`.
+    // linker-control environment variables.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvVarGuard {
@@ -905,6 +1079,74 @@ mod tests {
         assert!(
             message.contains("does not exist"),
             "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn successful_invocation_log_records_exact_output_and_route() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let log = TempFile::create("successful-invocation.jsonl");
+        let _guard = EnvVarGuard::set(RELD_INVOCATION_LOG_ENV, log.path().to_str().unwrap());
+        let argv = vec![
+            OsString::from("reld-link"),
+            OsString::from("input.obj"),
+            OsString::from("/OUT:C:/build/consumer.exe"),
+        ];
+        let route = Route {
+            engine: &COFF_LLD_ENGINE,
+            reason: SelectionReason::Default,
+        };
+
+        log_successful_invocation(&argv, route).unwrap();
+
+        let contents = std::fs::read_to_string(log.path()).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let record: serde_yaml::Value = serde_yaml::from_str(lines[0]).unwrap();
+        assert_eq!(record["schema"], 1);
+        assert_eq!(record["status"], "success");
+        assert_eq!(record["engine"], "lld-link");
+        assert_eq!(record["route_kind"], "bridge");
+        assert_eq!(record["reason"], "default");
+        assert_eq!(record["output"], "C:/build/consumer.exe");
+        assert_eq!(record["arguments"][0], "input.obj");
+        assert_eq!(record["arguments"][1], "/OUT:C:/build/consumer.exe");
+        assert!(record["process_id"].as_u64().unwrap() > 0);
+        assert!(!record["working_directory"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn requested_output_preserves_gnu_and_coff_path_spelling() {
+        let gnu = vec![
+            OsString::from("reld"),
+            OsString::from("-o"),
+            OsString::from("Build/Mixed Case/app"),
+        ];
+        assert_eq!(
+            requested_output(&gnu).unwrap().as_deref(),
+            Some("Build/Mixed Case/app")
+        );
+
+        let coff = vec![
+            OsString::from("reld-link"),
+            OsString::from("-OUT:C:/Build/Mixed Case/app.exe"),
+        ];
+        assert_eq!(
+            requested_output(&coff).unwrap().as_deref(),
+            Some("C:/Build/Mixed Case/app.exe")
+        );
+
+        let response = TempFile::create_with_contents(
+            "coff-output-response",
+            br#"input.obj "/OUT:C:\Build\Mixed Case\response.exe" /DEBUG"#,
+        );
+        let response_argv = vec![
+            OsString::from("reld-link"),
+            OsString::from(format!("@{}", response.path().display())),
+        ];
+        assert_eq!(
+            requested_output(&response_argv).unwrap().as_deref(),
+            Some(r"C:\Build\Mixed Case\response.exe")
         );
     }
 

--- a/crates/reld-core/src/gc_stats.rs
+++ b/crates/reld-core/src/gc_stats.rs
@@ -141,7 +141,11 @@ fn write_gc_stats<'data, P: Platform>(
         if total == 0 {
             continue;
         }
-        let percent = f.discarded * 100 / total;
+        let percent = f
+            .discarded
+            .checked_mul(100)
+            .and_then(|scaled| scaled.checked_div(total))
+            .unwrap_or(0);
         writeln!(
             &mut out,
             "Discarded {}. {percent}% of {} from {}",

--- a/crates/reld-core/src/lib.rs
+++ b/crates/reld-core/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod archive;
 pub mod args;
 pub mod bridge;
 pub use bridge::BridgeTarget;
+pub use bridge::log_successful_invocation;
 pub use bridge::run_bridge;
 pub use bridge::select_route;
 pub(crate) mod compression;

--- a/crates/reld-core/src/subprocess.rs
+++ b/crates/reld-core/src/subprocess.rs
@@ -8,7 +8,7 @@ use libc::pid_t;
 use std::ffi::c_int;
 use std::ffi::c_void;
 
-/// Runs the linker, in a subprocess if possible, prints any errors, then exits.
+/// Runs the linker in a subprocess if possible.
 ///
 /// This is done by forking a sub-process which runs the linker and waits for communication back
 /// from the sub-process (via a pipe) when the main link task is done (the output file has been
@@ -20,15 +20,21 @@ use std::ffi::c_void;
 /// # Safety
 /// Must not be called once threads have been spawned. Calling this function from main is generally
 /// the best way to ensure this.
-pub unsafe fn run_in_subprocess(args: Args) -> ! {
-    let exit_code = match subprocess_result(args) {
-        Ok(code) => code,
-        Err(error) => crate::error::report_error_and_exit(&error),
-    };
-    std::process::exit(exit_code);
+pub unsafe fn run_in_subprocess(args: Args) -> Result {
+    match subprocess_result(args)? {
+        SubprocessResult::Parent(0) => Ok(()),
+        SubprocessResult::Parent(exit_code) | SubprocessResult::Child(exit_code) => {
+            std::process::exit(exit_code);
+        }
+    }
 }
 
-fn subprocess_result(mut args: Args) -> Result<i32> {
+enum SubprocessResult {
+    Parent(i32),
+    Child(i32),
+}
+
+fn subprocess_result(mut args: Args) -> Result<SubprocessResult> {
     let mut fds: [c_int; 2] = [0; 2];
     // create the pipe used to communicate between the parent and child processes - exit on failure
     make_pipe(&mut fds).context("make_pipe")?;
@@ -49,18 +55,18 @@ fn subprocess_result(mut args: Args) -> Result<i32> {
                 inform_parent_done(&fds);
                 Ok(())
             })?;
-            Ok(0)
+            Ok(SubprocessResult::Child(0))
         }
         -1 => {
             // Fork failure in the parent - Fallback to running linker in this process
 
             crate::run(args)?;
-            Ok(0)
+            Ok(SubprocessResult::Parent(0))
         }
         pid => {
             // Fork success in the parent - wait for the child to "signal" us it's done
             let exit_status = wait_for_child_done(&fds, pid);
-            Ok(exit_status)
+            Ok(SubprocessResult::Parent(exit_status))
         }
     }
 }

--- a/crates/reld-core/src/subprocess_unsupported.rs
+++ b/crates/reld-core/src/subprocess_unsupported.rs
@@ -1,12 +1,5 @@
 /// # Safety
 /// See function of the same name in `subprocess.rs`
-pub unsafe fn run_in_subprocess(args: crate::args::Args) -> ! {
-    let exit_code = match crate::run(args) {
-        Ok(()) => 0,
-        Err(error) => {
-            eprintln!("{}", error.to_string());
-            -1
-        }
-    };
-    std::process::exit(exit_code);
+pub unsafe fn run_in_subprocess(args: crate::args::Args) -> crate::error::Result {
+    crate::run(args)
 }

--- a/crates/reld-diff/src/lib.rs
+++ b/crates/reld-diff/src/lib.rs
@@ -929,11 +929,10 @@ impl Display for Coverage {
         writeln!(
             f,
             "Diffed {total_diffed} of {total_bytes} section bytes ({}%)",
-            if total_bytes == 0 {
-                0
-            } else {
-                total_diffed * 100 / total_bytes
-            }
+            total_diffed
+                .checked_mul(100)
+                .and_then(|scaled| scaled.checked_div(total_bytes))
+                .unwrap_or(0)
         )?;
         writeln!(
             f,
@@ -956,7 +955,10 @@ impl Coverage {
 
     fn relocation_percentage(&self) -> u64 {
         let (diffed, total) = self.relocation_counts();
-        if total == 0 { 0 } else { diffed * 100 / total }
+        diffed
+            .checked_mul(100)
+            .and_then(|scaled| scaled.checked_div(total))
+            .unwrap_or(0)
     }
 }
 

--- a/crates/reld-testkit/src/bin/reld-bench.rs
+++ b/crates/reld-testkit/src/bin/reld-bench.rs
@@ -117,12 +117,10 @@ fn scenarios() -> Vec<(String, WorkloadSpec)> {
 
 /// `-fuse-ld=` values. `""` means the compiler default.
 fn default_linkers() -> Vec<&'static str> {
-    if cfg!(target_os = "windows") {
-        vec!["", "lld"]
-    } else if cfg!(target_os = "macos") {
-        vec!["", "ld64.lld"]
-    } else {
-        vec!["bfd", "lld", "mold", "wild"]
+    cfg_select! {
+        target_os = "windows" => vec!["", "lld"],
+        target_os = "macos" => vec!["", "ld64.lld"],
+        target_os = "linux" => vec!["bfd", "lld", "mold", "wild"],
     }
 }
 
@@ -130,12 +128,10 @@ fn display_linker(linker: &str) -> &str {
     if !linker.is_empty() {
         return linker;
     }
-    if cfg!(target_os = "windows") {
-        "link.exe"
-    } else if cfg!(target_os = "macos") {
-        "ld"
-    } else {
-        "default"
+    cfg_select! {
+        target_os = "windows" => "link.exe",
+        target_os = "macos" => "ld",
+        target_os = "linux" => "default",
     }
 }
 

--- a/crates/reld/src/main.rs
+++ b/crates/reld/src/main.rs
@@ -26,23 +26,26 @@ fn run() -> reld_core::error::Result {
     let route = reld_core::select_route(&raw_args, args.link_target())?;
 
     if route.is_bridge() {
-        return reld_core::run_bridge(raw_args, route);
-    }
-    route.log_native();
-
-    args.set_version(VERSION);
-    args.parse(std::env::args)?;
-
-    if reld_core::should_fork(&args) {
-        // Safety: We haven't spawned any threads yet.
-        unsafe { reld_core::run_in_subprocess(args) };
+        reld_core::run_bridge(raw_args.clone(), route)?;
     } else {
-        // Run the linker in this process without forking.
+        route.log_native();
 
-        // Note, we need to setup tracing before worker, otherwise the threads won't contribute to
-        // counters such as --time=cycles,instructions etc.
-        reld_core::setup_tracing(&args)?;
+        args.set_version(VERSION);
+        args.parse(std::env::args)?;
 
-        reld_core::run(args)
+        if reld_core::should_fork(&args) {
+            // Safety: We haven't spawned any threads yet.
+            unsafe { reld_core::run_in_subprocess(args)? };
+        } else {
+            // Run the linker in this process without forking.
+
+            // Note, we need to setup tracing before worker, otherwise the threads won't contribute to
+            // counters such as --time=cycles,instructions etc.
+            reld_core::setup_tracing(&args)?;
+
+            reld_core::run(args)?;
+        }
     }
+
+    reld_core::log_successful_invocation(&raw_args, route)
 }

--- a/crates/reld/tests/acceptance_policy.rs
+++ b/crates/reld/tests/acceptance_policy.rs
@@ -175,11 +175,10 @@ struct FormatCoverage {
 
 impl FormatCoverage {
     fn percentage(&self) -> u64 {
-        if self.total_relocations == 0 {
-            0
-        } else {
-            self.diffed_relocations.saturating_mul(100) / self.total_relocations
-        }
+        self.diffed_relocations
+            .saturating_mul(100)
+            .checked_div(self.total_relocations)
+            .unwrap_or(0)
     }
 }
 

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,7 +3,7 @@
 # docker build --progress=plain -t reld-dev-alpine . -f docker/alpine.Dockerfile
 # docker run -it reld-dev-alpine
 
-FROM rust:1.94-alpine AS chef
+FROM rust:1.95.0-alpine AS chef
 RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.70/cargo-chef-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
     mv cargo-chef /usr/local/bin
 RUN rustup toolchain install nightly && \

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -46,7 +46,7 @@ RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.
 
 RUN wget https://sh.rustup.rs -O rustup-installer && \
     chmod +x rustup-installer && \
-    ./rustup-installer -y --default-toolchain 1.94.0
+    ./rustup-installer -y --default-toolchain 1.95.0
 
 ENV PATH="/root/.cargo/bin:$PATH"
 

--- a/docker/bosn.Dockerfile
+++ b/docker/bosn.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94.1-bookworm
+FROM rust:1.95.0-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HOME=/bosn/cargo-home \

--- a/docker/ci/alpine.Dockerfile
+++ b/docker/ci/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94-alpine
+FROM rust:1.95.0-alpine
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/docker/ci/arch.Dockerfile
+++ b/docker/ci/arch.Dockerfile
@@ -18,7 +18,7 @@ RUN pacman --noconfirm -Syu \
 RUN pacman --noconfirm -Scc
 RUN wget https://sh.rustup.rs -O rustup-installer && \
     chmod +x rustup-installer && \
-    ./rustup-installer -y --default-toolchain 1.94.0
+    ./rustup-installer -y --default-toolchain 1.95.0
 RUN rustup toolchain install nightly \
         --allow-downgrade \
         --target x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,riscv64gc-unknown-linux-gnu,riscv64gc-unknown-linux-musl \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -3,7 +3,7 @@
 # docker build --progress=plain -t reld-dev-debian . -f docker/debian.Dockerfile
 # docker run -it reld-dev-debian
 
-FROM rust:1.94 AS chef
+FROM rust:1.95.0 AS chef
 RUN apt-get update && \
     apt-get install -y \
         clang \

--- a/docker/ubuntu-24.04.Dockerfile
+++ b/docker/ubuntu-24.04.Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 
 RUN wget https://sh.rustup.rs -O rustup-installer && \
     chmod +x rustup-installer && \
-    ./rustup-installer -y --default-toolchain 1.94.0
+    ./rustup-installer -y --default-toolchain 1.95.0
 
 ENV PATH="/root/.cargo/bin:$PATH"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,5 +6,5 @@
 # `-Zsanitizer=address` and `-Zbuild-std` are nightly-only. Pinning the repo
 # to nightly to serve those two jobs would make every other contributor
 # build on nightly for no reason.
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- add three-platform, pinned Rust/C/C++ consumer acceptance through the release reld executable
- record successful reld invocations in optional JSONL audit logs and prove audit-on/off byte equivalence
- raise the normal MSRV/toolchain pin to Rust 1.95.0 and use its exhaustive `cfg_select!` platform routing
- document per-platform acceptance evidence and the no-new-crates approval policy

## Windows GNU scope

Related to #90. `x86_64-pc-windows-gnu` remains compile-checked from Linux but is not yet a native consumer-acceptance or advertised runtime route; #90 stays open for its GNU-dialect/MSYS2 acceptance work.

## Validation
- Windows logging-equivalence link/run under MSVC + LLVM clang
- `uv run --no-project pytest ci/tests/test_benchmark_runner.py ci/tests/test_ci_workflow.py ci/tests/test_consumer_acceptance.py`
- `soldr rustc --version` (1.95.0)
- focused Rust 1.95 builds/tests (in progress)