### PR TITLE
perf: add correctness-gated allocator benchmark

### DIFF
--- a/.github/workflows/allocator-benchmark.yml
+++ b/.github/workflows/allocator-benchmark.yml
@@ -2,6 +2,19 @@ name: Allocator benchmark evidence
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/allocator-benchmark.yml"
+      - "ci/allocator_benchmark.py"
+      - "ci/allocator_benchmark.sh"
+      - "ci/allocator_profile_runner.py"
+      - "ci/allocator_profiles.sh"
+      - "ci/allocator_source_cleanup.py"
+      - "ci/benchmark_runner.py"
+      - "ci/tests/test_allocator_benchmark.py"
+      - "ci/tests/test_benchmark_runner.py"
+      - "docker/bosn.Dockerfile"
 
 permissions:
   contents: read

--- a/.github/workflows/allocator-benchmark.yml
+++ b/.github/workflows/allocator-benchmark.yml
@@ -1,0 +1,67 @@
+name: Allocator benchmark evidence
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  allocator-linux:
+    runs-on: ubuntu-24.04
+    container:
+      image: rust:1.95.0-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install native benchmark tools
+        run: |
+          apt-get update
+          apt-get install --yes clang=1:14.0-55.7~deb12u1 time=1.9-0.2
+          test "$(clang --version | head -1)" = "Debian clang version 14.0.6"
+
+      - name: Generate and verify exact candidate archive
+        run: |
+          mkdir -p allocator-evidence
+          git archive --format=tar --output=/tmp/reld-e0868677.tar e08686773514edf0b30a88e5950a6071d3caf373
+          git archive --format=tar --output=/tmp/reld-e2d6be5a.tar e2d6be5ae31350862c562d24da01e2147cd5c125
+          test "$(git rev-parse 'e08686773514edf0b30a88e5950a6071d3caf373^{tree}')" = 7162acc8005911d79aa85397a20a6744d27a09b8
+          test "$(git rev-parse 'e2d6be5ae31350862c562d24da01e2147cd5c125^{tree}')" = 24bb072b12b3e2e49dfe8e729195f51bc5f8e93d
+          sha256sum /tmp/reld-e0868677.tar /tmp/reld-e2d6be5a.tar | tee allocator-evidence/source-archives.sha256
+        env:
+          RUSTUP_TOOLCHAIN: 1.95.0
+
+      - name: Run correctness-gated allocator benchmark
+        run: bash ci/allocator_benchmark.sh
+        env:
+          RUSTUP_TOOLCHAIN: 1.95.0
+          RELD_ALLOCATOR_BENCHMARK_OUTPUT: allocator-evidence/timing.json
+          RELD_ALLOCATOR_SOURCE_ARCHIVE: /tmp/reld-e0868677.tar
+          RELD_ALLOCATOR_BASELINE_ARCHIVE: /tmp/reld-e2d6be5a.tar
+          RELD_PINNED_CARGO_BIN: /usr/local/cargo/bin
+          RELD_PINNED_RUSTUP_HOME: /usr/local/rustup
+
+      - name: Collect diagnostic allocator profiles
+        run: bash ci/allocator_profiles.sh
+        env:
+          RUSTUP_TOOLCHAIN: 1.95.0
+          RELD_ALLOCATOR_PROFILE_OUTPUT: allocator-evidence/profiles.json
+          RELD_ALLOCATOR_SOURCE_ARCHIVE: /tmp/reld-e0868677.tar
+          RELD_PINNED_CARGO_BIN: /usr/local/cargo/bin
+          RELD_PINNED_RUSTUP_HOME: /usr/local/rustup
+
+      - name: Upload raw evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: allocator-evidence-${{ github.sha }}
+          path: |
+            allocator-evidence/
+            target/allocator-benchmark/replay/capture.log
+            target/allocator-benchmark/candidate-feature-tree.txt
+            target/allocator-profiles/evidence/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/allocator-benchmark.yml
+++ b/.github/workflows/allocator-benchmark.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Generate and verify exact candidate archive
         run: |
           mkdir -p allocator-evidence
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git archive --format=tar --output=/tmp/reld-e0868677.tar e08686773514edf0b30a88e5950a6071d3caf373
           git archive --format=tar --output=/tmp/reld-e2d6be5a.tar e2d6be5ae31350862c562d24da01e2147cd5c125
           test "$(git rev-parse 'e08686773514edf0b30a88e5950a6071d3caf373^{tree}')" = 7162acc8005911d79aa85397a20a6744d27a09b8

--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -62,6 +62,18 @@ identity and native-execution proof across the pinned system baseline, default, 
 exact-DHAT builds. The script clears all supported profiler activation/dump environment controls
 before invoking every linker.
 
+The authoritative allocator decision uses `bash ci/allocator_benchmark.sh` at revision `e0868677`.
+It verifies and archives the exact allocator-change Git tree at `e0868677` and the exact pinned
+pre-change system-allocator tree at `e2d6be5a` (no worktree). The intervening linker-relevant diff
+is allocator selection in the manifests and `main`; linker implementation source is unchanged.
+It builds both release binaries with the pinned lockfiles/toolchain, rejects profiler
+environment contamination and sampled-pprof symbols, and then benchmarks the three frozen replay
+profiles. Each mode first links twice for raw identity and exact native-output validation. Timing
+uses two excluded warmups and at least ten rotating/interleaved samples per cell, recording wall
+and CPU time, peak RSS, dispersion, bootstrap confidence intervals, raw samples, order, binary and
+artifact hashes, plus machine/toolchain provenance. The resulting JSON is evidence for #93; pprof
+and DHAT collection must be performed separately and must never be added to its timing cells.
+
 ## Consumer acceptance
 
 The three-platform consumer job builds the host-named `reld` ELF driver through `setup-soldr`, then

--- a/ci/allocator_benchmark.py
+++ b/ci/allocator_benchmark.py
@@ -1,0 +1,544 @@
+"""Correctness-gated Linux allocator A/B benchmark for issue #93.
+
+This runner consumes two already-built ``reld`` executables.  Build provenance is supplied by
+``ci/allocator_benchmark.sh``; keeping build and replay separate makes the timed environment small
+and auditable.  Diagnostic profiler builds are intentionally outside this timing program.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import math
+import os
+import platform
+import random
+import shutil
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+from ci.benchmark_runner import (
+    CONFIGURATIONS,
+    DEFAULT_MANIFEST,
+    BenchmarkError,
+    LinkCommand,
+    capture_executable_oracle,
+    capture_final_link,
+    prune_capture_artifacts,
+    release_capture_artifacts,
+    replay_command,
+)
+
+
+BASELINE_REVISION = "e2d6be5ae31350862c562d24da01e2147cd5c125"
+MIN_SAMPLES = 10
+NON_REGRESSION_MARGIN = 0.03
+MEASURED_FIELDS = ("wall_seconds", "cpu_seconds", "peak_rss_kib")
+PROFILER_ENV_VARS = frozenset(
+    {
+        "MIMALLOC_PROF",
+        "MIMALLOC_PROF_ACTIVE",
+        "MIMALLOC_PROF_DUMP_AT_EXIT",
+        "MIMALLOC_PROF_PREFIX",
+        "MIMALLOC_PROF_SAMPLE_INTERVAL",
+        "MIMALLOC_PROF_SAMPLE_RATE",
+        "MIMALLOC_PROF_ACCUM",
+        "MIMALLOC_PROF_BT_MAX",
+        "MIMALLOC_PROF_MAX_BYTES",
+        "MIMALLOC_PROF_SEED",
+        "MIMALLOC_PROF_DUMP_FORMAT",
+        "MIMALLOC_DHAT",
+        "MIMALLOC_DHAT_DUMP_AT_EXIT",
+        "MIMALLOC_DHAT_MAX_BYTES",
+        "RELD_DHAT_OUTPUT",
+    }
+)
+
+
+class BenchmarkFailure(RuntimeError):
+    pass
+
+
+def clean_benchmark_environment(environment: dict[str, str]) -> tuple[dict[str, str], list[str]]:
+    contaminated = sorted(name for name in PROFILER_ENV_VARS if name in environment)
+    return {name: value for name, value in environment.items() if name not in PROFILER_ENV_VARS}, contaminated
+
+
+def require_clean_parent_environment(environment: dict[str, str]) -> dict[str, str]:
+    cleaned, contaminated = clean_benchmark_environment(environment)
+    if contaminated:
+        raise BenchmarkFailure("profiler environment contamination: " + ", ".join(contaminated))
+    # The child receives explicit off values as a second line of defence and as reportable proof.
+    cleaned.update({"MIMALLOC_PROF": "0", "MIMALLOC_PROF_ACTIVE": "0", "MIMALLOC_DHAT": "0"})
+    return cleaned
+
+
+def rotated_order(labels: tuple[str, ...], round_index: int, *, seed: int) -> tuple[str, ...]:
+    if not labels:
+        return ()
+    shuffled = list(labels)
+    random.Random(seed).shuffle(shuffled)
+    offset = round_index % len(shuffled)
+    return tuple(shuffled[offset:] + shuffled[:offset])
+
+
+def bootstrap_improvement_ci(baseline: list[float], candidate: list[float], *, iterations: int = 20_000, seed: int = 93) -> tuple[float, float]:
+    if not baseline or len(baseline) != len(candidate):
+        raise BenchmarkFailure("paired bootstrap requires equal non-empty samples")
+    if any(value <= 0 for value in baseline + candidate):
+        raise BenchmarkFailure("paired bootstrap requires strictly positive measurements")
+    rng = random.Random(seed)
+    improvements: list[float] = []
+    for _ in range(iterations):
+        indices = rng.choices(range(len(baseline)), k=len(baseline))
+        base = statistics.median(baseline[index] for index in indices)
+        cand = statistics.median(candidate[index] for index in indices)
+        improvements.append(1.0 - cand / base)
+    improvements.sort()
+    return improvements[int(iterations * 0.025)], improvements[min(iterations - 1, int(iterations * 0.975))]
+
+
+def bootstrap_geometric_improvement_ci(cells: list[tuple[list[float], list[float]]], *, iterations: int = 20_000, seed: int = 93) -> tuple[float, float]:
+    rng = random.Random(seed)
+    improvements: list[float] = []
+    for _ in range(iterations):
+        ratios: list[float] = []
+        for baseline, candidate in cells:
+            if not baseline or len(baseline) != len(candidate):
+                raise BenchmarkFailure("aggregate paired bootstrap requires equal non-empty cells")
+            if any(value <= 0 for value in baseline + candidate):
+                raise BenchmarkFailure("aggregate paired bootstrap requires strictly positive measurements")
+            indices = rng.choices(range(len(baseline)), k=len(baseline))
+            base = statistics.median(baseline[index] for index in indices)
+            cand = statistics.median(candidate[index] for index in indices)
+            ratios.append(cand / base)
+        improvements.append(1.0 - math.prod(ratios) ** (1.0 / len(ratios)))
+    improvements.sort()
+    return improvements[int(iterations * 0.025)], improvements[min(iterations - 1, int(iterations * 0.975))]
+
+
+def should_keep_allocator(
+    configuration_metrics: list[dict[str, dict[str, object]]],
+    aggregate_metrics: dict[str, dict[str, object]],
+) -> bool:
+    every_cell_non_regressing = all(metric["non_regressing"] for configuration in configuration_metrics for metric in configuration.values())
+    every_aggregate_non_regressing = all(metric["non_regressing"] for metric in aggregate_metrics.values())
+    wall_better = aggregate_metrics["wall_seconds"]["bootstrap_95_ci"][0] > 0
+    return wall_better and every_cell_non_regressing and every_aggregate_non_regressing
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _assert_hook_free(candidate: Path, feature_proof: Path) -> dict[str, object]:
+    feature_text = feature_proof.read_text(encoding="utf-8")
+    forbidden_features = ('mimalloc-pprof feature "pprof"', "mimalloc-pprof/pprof", "mimalloc-pprof-dhat")
+    if any(feature in feature_text for feature in forbidden_features):
+        raise BenchmarkFailure("candidate Cargo feature proof contains a profiling feature")
+    completed = subprocess.run(["nm", "-a", str(candidate)], capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
+    if completed.returncode:
+        raise BenchmarkFailure(f"nm could not inspect candidate: {completed.stderr}")
+    symbols = [line for line in completed.stdout.splitlines() if "mi_pprof" in line.lower()]
+    if symbols:
+        raise BenchmarkFailure("candidate contains sampled-pprof symbols; authoritative timing refused")
+    return {
+        "cargo_feature_tree_sha256": _sha256(feature_proof),
+        "cargo_feature_tree": str(feature_proof.resolve()),
+        "binary_tool": "nm -a",
+        "sampled_pprof_symbols": [],
+        "compiled_off": True,
+    }
+
+
+def _assert_no_profile_output(profile_dir: Path) -> None:
+    outputs = [path for path in profile_dir.rglob("*") if path.is_file()]
+    if outputs:
+        raise BenchmarkFailure(f"profiler output contaminated authoritative timing: {outputs}")
+
+
+def _prepare_command(captured: LinkCommand, binary: Path, output: Path, driver_dir: Path) -> list[str]:
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    shim = driver_dir / "ld"
+    shim.unlink(missing_ok=True)
+    shim.symlink_to(binary.resolve())
+    command, response = replay_command(
+        captured,
+        linker=binary.name,
+        linker_path=binary,
+        output=output,
+        response_file=output.with_suffix(".rsp"),
+        driver_linker_dir=driver_dir,
+    )
+    if response is not None:
+        raise BenchmarkFailure("Linux replay unexpectedly required a response file")
+    command.append("-Wl,--engine=reld")
+    return command
+
+
+def _run_native(
+    output: Path,
+    oracle_stdout: str,
+    oracle_stderr: str,
+    environment: dict[str, str],
+    cwd: Path,
+    *,
+    timeout_seconds: float,
+) -> None:
+    try:
+        completed = subprocess.run(
+            [output],
+            cwd=cwd,
+            env=environment,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise BenchmarkFailure(f"native oracle exceeded {timeout_seconds:.0f}s for {output}") from error
+    if completed.returncode != 0 or completed.stdout != oracle_stdout or completed.stderr != oracle_stderr:
+        raise BenchmarkFailure(f"native oracle mismatch for {output}: rc={completed.returncode}")
+
+
+def _timed_link(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    timing_file: Path,
+    timeout_seconds: float,
+) -> dict[str, float]:
+    timing_file.unlink(missing_ok=True)
+    wrapped = ["/usr/bin/time", "-f", "%e %U %S %M", "-o", str(timing_file), "--", *command]
+    try:
+        completed = subprocess.run(
+            wrapped,
+            cwd=cwd,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise BenchmarkFailure(f"link exceeded {timeout_seconds:.0f}s: {command[0]}") from error
+    if completed.returncode:
+        raise BenchmarkFailure(f"timed link failed:\n{completed.stdout}{completed.stderr}")
+    fields = timing_file.read_text(encoding="utf-8").strip().split()
+    if len(fields) != 4:
+        raise BenchmarkFailure(f"invalid /usr/bin/time record: {fields!r}")
+    wall, user, system, rss_kib = map(float, fields)
+    return {"wall_seconds": wall, "user_seconds": user, "system_seconds": system, "cpu_seconds": user + system, "peak_rss_kib": rss_kib}
+
+
+def _summary(samples: list[dict[str, float]]) -> dict[str, object]:
+    result: dict[str, object] = {"samples": samples}
+    for field in ("wall_seconds", "cpu_seconds", "peak_rss_kib"):
+        values = [sample[field] for sample in samples]
+        median = statistics.median(values)
+        result[f"median_{field}"] = median
+        result[f"mad_{field}"] = statistics.median(abs(value - median) for value in values)
+    return result
+
+
+def cleanup_ephemeral_outputs(target_dir: Path, workdir: Path) -> None:
+    target_dir = target_dir.resolve()
+    for configuration in CONFIGURATIONS:
+        release_capture_artifacts(
+            profile_dir=target_dir / configuration.profile,
+            target_dir=target_dir,
+            log=io.StringIO(),
+        )
+    resolved_workdir = workdir.resolve()
+    for pattern in ("identity-*", "timed-*", "time-*.txt", "*.rsp", "app"):
+        for path in resolved_workdir.glob(f"**/{pattern}"):
+            if path.is_file() and path.resolve().is_relative_to(resolved_workdir):
+                path.unlink()
+    driver_links = [*resolved_workdir.glob("**/driver/ld"), *resolved_workdir.glob("**/driver-*/ld")]
+    for path in driver_links:
+        if path.is_symlink() and path.parent.resolve().is_relative_to(resolved_workdir):
+            path.unlink()
+    for path in sorted(resolved_workdir.glob("**/*"), key=lambda item: len(item.parts), reverse=True):
+        if path.is_dir() and (path.name == "driver" or path.name.startswith("driver-")):
+            path.rmdir()
+
+
+def run(args: argparse.Namespace) -> dict[str, object]:
+    if sys.platform != "linux":
+        raise BenchmarkFailure("allocator timing is authoritative only on Linux")
+    if args.trials < MIN_SAMPLES or args.warmup < 0:
+        raise BenchmarkFailure(f"at least {MIN_SAMPLES} trials and non-negative warmups are required")
+    environment = require_clean_parent_environment(dict(os.environ))
+    proof = _assert_hook_free(args.candidate, args.feature_proof)
+    workdir = args.workdir.resolve()
+    target_dir = args.target_dir.resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+    profile_dir = workdir / "profiler-output-must-stay-empty"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    _assert_no_profile_output(profile_dir)
+    environment["RELD_DHAT_OUTPUT"] = str(profile_dir / "dhat-heap.json")
+    report: dict[str, object] = {
+        "schema": 1,
+        "authoritative": True,
+        "baseline_revision": BASELINE_REVISION,
+        "candidate_revision": args.source_revision,
+        "candidate_tree": args.source_tree,
+        "source_archive": {"path": str(args.source_archive.resolve()), "sha256": _sha256(args.source_archive)},
+        "baseline_construction": "exact pinned pre-allocator Git archive e2d6be5a; linker implementation matches candidate and allocator-facing manifest/main changes select the system allocator",
+        "baseline_archive": {"path": str(args.baseline_archive.resolve()), "sha256": _sha256(args.baseline_archive)},
+        "build_environment": {
+            "inherited_environment": False,
+            "toolchain": "1.95.0",
+            "cc": "/usr/bin/clang",
+            "cxx": "/usr/bin/clang++",
+            "features": ["fork", "plugins", "zstd"],
+            "profile": "release",
+            "source_date_epoch": "0",
+        },
+        "profilers": {
+            "sampled_pprof": proof,
+            "runtime_environment": {name: environment[name] for name in ("MIMALLOC_PROF", "MIMALLOC_PROF_ACTIVE", "MIMALLOC_DHAT")},
+            "profile_output_directory": str(profile_dir),
+            "profile_output_checked_empty": True,
+        },
+        "machine": {"platform": platform.platform(), "processor": platform.processor(), "cpu_count": os.cpu_count()},
+        "toolchain": {},
+        "binaries": {"system": {"path": str(args.baseline.resolve()), "sha256": _sha256(args.baseline)}, "mimalloc": {"path": str(args.candidate.resolve()), "sha256": _sha256(args.candidate)}},
+        "warmups": args.warmup,
+        "trials": args.trials,
+        "seed": args.seed,
+        "workload": {
+            "manifest": str(args.manifest.resolve()),
+            "manifest_sha256": _sha256(args.manifest.resolve()),
+            "lockfile": str((args.manifest.resolve().parent / "Cargo.lock")),
+            "lockfile_sha256": _sha256(args.manifest.resolve().parent / "Cargo.lock"),
+        },
+        "configurations": {},
+    }
+    for tool in ("rustc", "cargo", "clang"):
+        completed = subprocess.run([tool, "--version"], env=environment, capture_output=True, text=True, check=True)
+        report["toolchain"][tool] = {"path": shutil.which(tool), "version": completed.stdout.strip()}
+
+    labels = ("system", "mimalloc")
+    binaries = {"system": args.baseline, "mimalloc": args.candidate}
+    log_path = workdir / "capture.log"
+    with log_path.open("w", encoding="utf-8") as log:
+        for config_index, configuration in enumerate(CONFIGURATIONS):
+            print(
+                f"allocator benchmark: capturing {configuration.label} (timeout {args.capture_timeout:.0f}s)",
+                flush=True,
+            )
+            captured = capture_final_link(
+                configuration,
+                cargo="cargo",
+                manifest=args.manifest.resolve(),
+                target_dir=target_dir,
+                environment=environment,
+                log=log,
+                linker="clang",
+                timeout_seconds=args.capture_timeout,
+            )
+            oracle = capture_executable_oracle(
+                captured.output,
+                cwd=args.manifest.resolve().parent,
+                environment=environment,
+                timeout_seconds=args.native_timeout,
+            )
+            prune_capture_artifacts(captured, profile_dir=target_dir / configuration.profile, log=log)
+            config_dir = workdir / configuration.profile
+            config_dir.mkdir(parents=True, exist_ok=True)
+            hashes: dict[str, list[str]] = {label: [] for label in labels}
+            for label in labels:
+                for repetition in range(2):
+                    output = config_dir / f"identity-{label}-{repetition}"
+                    command = _prepare_command(captured, binaries[label], output, config_dir / f"driver-{label}")
+                    try:
+                        completed = subprocess.run(
+                            command,
+                            cwd=args.manifest.parent,
+                            env=environment,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                            timeout=args.link_timeout,
+                        )
+                    except subprocess.TimeoutExpired as error:
+                        raise BenchmarkFailure(f"identity link exceeded {args.link_timeout:.0f}s for {configuration.label}/{label}") from error
+                    if completed.returncode:
+                        raise BenchmarkFailure(f"identity link failed for {configuration.label}/{label}: {completed.stderr}")
+                    _run_native(
+                        output,
+                        oracle.stdout,
+                        oracle.stderr,
+                        environment,
+                        args.manifest.parent,
+                        timeout_seconds=args.native_timeout,
+                    )
+                    hashes[label].append(_sha256(output))
+            if len(set(hashes["system"] + hashes["mimalloc"])) != 1:
+                raise BenchmarkFailure(f"raw artifact identity failed for {configuration.label}: {hashes}")
+            expected_hash = hashes["system"][0]
+            for label in labels:
+                for repetition in range(2):
+                    (config_dir / f"identity-{label}-{repetition}").unlink()
+
+            samples: dict[str, list[dict[str, float]]] = {label: [] for label in labels}
+            orders: list[list[str]] = []
+            for round_index in range(args.warmup + args.trials):
+                order = rotated_order(labels, round_index, seed=args.seed + config_index)
+                if round_index >= args.warmup:
+                    orders.append(list(order))
+                for label in order:
+                    output = config_dir / f"timed-{round_index}-{label}"
+                    command = _prepare_command(captured, binaries[label], output, config_dir / f"driver-{label}")
+                    timing = _timed_link(
+                        command,
+                        cwd=args.manifest.parent,
+                        environment=environment,
+                        timing_file=config_dir / f"time-{round_index}-{label}.txt",
+                        timeout_seconds=args.link_timeout,
+                    )
+                    _run_native(
+                        output,
+                        oracle.stdout,
+                        oracle.stderr,
+                        environment,
+                        args.manifest.parent,
+                        timeout_seconds=args.native_timeout,
+                    )
+                    actual_hash = _sha256(output)
+                    if actual_hash != expected_hash:
+                        raise BenchmarkFailure(f"timed artifact identity failed for {configuration.label}/{label}/round-{round_index}: {actual_hash} != {expected_hash}")
+                    output.unlink()
+                    (config_dir / f"time-{round_index}-{label}.txt").unlink()
+                    _assert_no_profile_output(profile_dir)
+                    if round_index >= args.warmup:
+                        samples[label].append(timing)
+            metric_improvements: dict[str, dict[str, object]] = {}
+            for field in MEASURED_FIELDS:
+                baseline_values = [sample[field] for sample in samples["system"]]
+                candidate_values = [sample[field] for sample in samples["mimalloc"]]
+                ci_low, ci_high = bootstrap_improvement_ci(
+                    baseline_values,
+                    candidate_values,
+                    seed=args.seed + config_index,
+                )
+                metric_improvements[field] = {
+                    "improvement_fraction": 1.0 - statistics.median(candidate_values) / statistics.median(baseline_values),
+                    "bootstrap_95_ci": [ci_low, ci_high],
+                    "non_regressing": ci_low >= -NON_REGRESSION_MARGIN,
+                }
+            report["configurations"][configuration.label] = {
+                "captured_command": {
+                    "executable": captured.executable,
+                    "arguments": list(captured.arguments),
+                    "cwd": str(args.manifest.resolve().parent),
+                },
+                "artifact_sha256": hashes["system"][0],
+                "identity_runs": hashes,
+                "native_oracle": {"stdout": oracle.stdout, "stderr": oracle.stderr, "exit_code": 0},
+                "orders": orders,
+                "modes": {label: _summary(samples[label]) for label in labels},
+                "improvement_fraction": metric_improvements["wall_seconds"]["improvement_fraction"],
+                "bootstrap_95_ci": metric_improvements["wall_seconds"]["bootstrap_95_ci"],
+                "metric_improvements": metric_improvements,
+                "bootstrap": {
+                    "method": "paired round bootstrap of median ratio",
+                    "iterations": 20_000,
+                    "confidence": 0.95,
+                },
+            }
+            result = report["configurations"][configuration.label]
+            print(
+                f"allocator benchmark: {configuration.label} complete; "
+                f"system={result['modes']['system']['median_wall_seconds']:.4f}s "
+                f"mimalloc={result['modes']['mimalloc']['median_wall_seconds']:.4f}s "
+                f"improvement={result['improvement_fraction']:.2%}",
+                flush=True,
+            )
+            release_capture_artifacts(profile_dir=target_dir / configuration.profile, target_dir=target_dir, log=log)
+
+    aggregate_metrics: dict[str, dict[str, object]] = {}
+    for field in MEASURED_FIELDS:
+        ratios = []
+        aggregate_cells: list[tuple[list[float], list[float]]] = []
+        for config in report["configurations"].values():
+            baseline = [sample[field] for sample in config["modes"]["system"]["samples"]]
+            candidate = [sample[field] for sample in config["modes"]["mimalloc"]["samples"]]
+            aggregate_cells.append((baseline, candidate))
+            ratios.append(statistics.median(candidate) / statistics.median(baseline))
+        aggregate_ci = bootstrap_geometric_improvement_ci(aggregate_cells, seed=args.seed)
+        aggregate_metrics[field] = {
+            "geometric_improvement_fraction": 1.0 - math.prod(ratios) ** (1.0 / len(ratios)),
+            "bootstrap_95_ci": list(aggregate_ci),
+            "non_regressing": aggregate_ci[0] >= -NON_REGRESSION_MARGIN,
+        }
+    keep_allocator = should_keep_allocator(
+        [config["metric_improvements"] for config in report["configurations"].values()],
+        aggregate_metrics,
+    )
+    report["aggregate"] = {
+        "geometric_improvement_fraction": aggregate_metrics["wall_seconds"]["geometric_improvement_fraction"],
+        "bootstrap_95_ci": aggregate_metrics["wall_seconds"]["bootstrap_95_ci"],
+        "metrics": aggregate_metrics,
+        "bootstrap_method": "paired-within-workload bootstrap of geometric median ratio",
+        "bootstrap_iterations": 20_000,
+        "non_regression_margin_fraction": NON_REGRESSION_MARGIN,
+        "decision": "better" if keep_allocator else "inconclusive_or_worse",
+        "keep_allocator": keep_allocator,
+    }
+    _assert_no_profile_output(profile_dir)
+    report["profilers"]["profile_output_verified_empty_after_timing"] = True
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--feature-proof", required=True, type=Path)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--source-tree", required=True)
+    parser.add_argument("--source-archive", required=True, type=Path)
+    parser.add_argument("--baseline-archive", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--workdir", type=Path, default=Path("target/allocator-benchmark/replay"))
+    parser.add_argument("--target-dir", type=Path, default=Path("target/allocator-benchmark/workload"))
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--trials", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=93)
+    parser.add_argument("--capture-timeout", type=float, default=1_800.0)
+    parser.add_argument("--link-timeout", type=float, default=300.0)
+    parser.add_argument("--native-timeout", type=float, default=30.0)
+    args = parser.parse_args(argv)
+    result: dict[str, object] | None = None
+    failure: Exception | None = None
+    try:
+        result = run(args)
+    except (BenchmarkFailure, BenchmarkError, OSError, subprocess.SubprocessError) as error:
+        failure = error
+    finally:
+        cleanup_ephemeral_outputs(args.target_dir, args.workdir)
+    if failure is not None:
+        sys.stderr.write(f"allocator benchmark failed: {failure}\n")
+        return 1
+    assert result is not None
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/allocator_benchmark.sh
+++ b/ci/allocator_benchmark.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Build the exact pre-allocator baseline and current candidate, then run the correctness-gated A/B.
+set -euo pipefail
+
+candidate_revision=e08686773514edf0b30a88e5950a6071d3caf373
+candidate_tree=7162acc8005911d79aa85397a20a6744d27a09b8
+candidate_archive_sha256=53ba911ffc1ffe65e806c47b066064cae76ab461d97a156b4a4e86fa37f3211f
+baseline_revision=e2d6be5ae31350862c562d24da01e2147cd5c125
+baseline_tree=24bb072b12b3e2e49dfe8e729195f51bc5f8e93d
+baseline_archive_sha256=e05a472ad5c2dcc4b3e3e2293c1332f255efd491bc256557c454b3c856fda640
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+state="${root}/target/allocator-benchmark"
+output="${RELD_ALLOCATOR_BENCHMARK_OUTPUT:-${state}/results.json}"
+source_archive="${RELD_ALLOCATOR_SOURCE_ARCHIVE:-${state}/candidate-e0868677.tar}"
+baseline_archive="${RELD_ALLOCATOR_BASELINE_ARCHIVE:-${state}/baseline-e2d6be5a.tar}"
+
+test "$(git -C "${root}" rev-parse "${candidate_revision}^{tree}")" = "${candidate_tree}"
+if [[ ! -f "${source_archive}" ]]; then
+  mkdir -p "$(dirname "${source_archive}")"
+  git -C "${root}" archive --format=tar --output="${source_archive}" "${candidate_revision}"
+fi
+echo "${candidate_archive_sha256}  ${source_archive}" | sha256sum --check --status
+test "$(git -C "${root}" rev-parse "${baseline_revision}^{tree}")" = "${baseline_tree}"
+if [[ ! -f "${baseline_archive}" ]]; then
+  mkdir -p "$(dirname "${baseline_archive}")"
+  git -C "${root}" archive --format=tar --output="${baseline_archive}" "${baseline_revision}"
+fi
+echo "${baseline_archive_sha256}  ${baseline_archive}" | sha256sum --check --status
+
+for variable in MIMALLOC_PROF MIMALLOC_PROF_ACTIVE MIMALLOC_PROF_DUMP_AT_EXIT MIMALLOC_PROF_PREFIX MIMALLOC_PROF_SAMPLE_INTERVAL MIMALLOC_PROF_SAMPLE_RATE MIMALLOC_PROF_ACCUM MIMALLOC_PROF_BT_MAX MIMALLOC_PROF_MAX_BYTES MIMALLOC_PROF_SEED MIMALLOC_PROF_DUMP_FORMAT MIMALLOC_DHAT MIMALLOC_DHAT_DUMP_AT_EXIT MIMALLOC_DHAT_MAX_BYTES RELD_DHAT_OUTPUT; do
+  if [[ -v "${variable}" ]]; then
+    echo "profiler environment contamination: ${variable}" >&2
+    exit 2
+  fi
+done
+
+mkdir -p "${state}"
+baseline_source=
+candidate_source=
+trap 'python3 "${root}/ci/allocator_source_cleanup.py" "${baseline_source}" "${candidate_source}"' EXIT
+baseline_source="$(mktemp -d "${state}/baseline-source-e2d6be5a.XXXXXXXX")"
+candidate_source="$(mktemp -d "${state}/candidate-source-e0868677.XXXXXXXX")"
+tar -xf "${baseline_archive}" -C "${baseline_source}"
+tar -xf "${source_archive}" -C "${candidate_source}"
+printf '%s\n' "${baseline_tree}" >"${baseline_source}/.reld-source-tree"
+printf '%s\n' "${candidate_tree}" >"${candidate_source}/.reld-source-tree"
+
+for variable in RUSTFLAGS CARGO_ENCODED_RUSTFLAGS RUSTC RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER CC CFLAGS CXX CXXFLAGS CARGO_BUILD_RUSTFLAGS CARGO_TARGET_DIR; do
+  if [[ -v "${variable}" ]]; then
+    echo "build environment contamination: ${variable}" >&2
+    exit 2
+  fi
+done
+
+common_env=(
+  env -i
+  "PATH=${RELD_PINNED_CARGO_BIN:-/usr/local/cargo/bin}:/usr/bin:/bin"
+  "HOME=/tmp/reld-allocator-home"
+  "CARGO_HOME=${state}/cargo-home"
+  "RUSTUP_HOME=${RELD_PINNED_RUSTUP_HOME:-/usr/local/rustup}"
+  "RUSTUP_TOOLCHAIN=1.95.0"
+  "CC=/usr/bin/clang"
+  "CXX=/usr/bin/clang++"
+  "SOURCE_DATE_EPOCH=0"
+)
+mkdir -p /tmp/reld-allocator-home
+mkdir -p "${state}/cargo-home"
+test "$(command -v cargo)" = "${RELD_PINNED_CARGO_BIN:-/usr/local/cargo/bin}/cargo"
+test -x "${RELD_PINNED_RUSTUP_HOME:-/usr/local/rustup}/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin/rustc"
+
+"${common_env[@]}" CARGO_TARGET_DIR="${state}/baseline-target" cargo build --locked --release --no-default-features --features fork,plugins,zstd --manifest-path "${baseline_source}/Cargo.toml" -p reld --bin reld
+"${common_env[@]}" CARGO_TARGET_DIR="${state}/candidate-target" cargo build --locked --release --no-default-features --features fork,plugins,zstd --manifest-path "${candidate_source}/Cargo.toml" -p reld --bin reld
+"${common_env[@]}" cargo tree --locked --manifest-path "${candidate_source}/Cargo.toml" -p reld -e features >"${state}/candidate-feature-tree.txt"
+if grep -Eq 'mimalloc-pprof feature "pprof"|mimalloc-pprof/(pprof|dhat)' "${state}/candidate-feature-tree.txt"; then
+  echo "profiling feature present in authoritative candidate" >&2
+  exit 2
+fi
+
+"${common_env[@]}" python3 -m ci.allocator_benchmark \
+  --baseline "${state}/baseline-target/release/reld" \
+  --candidate "${state}/candidate-target/release/reld" \
+  --feature-proof "${state}/candidate-feature-tree.txt" \
+  --source-revision "${candidate_revision}" \
+  --source-tree "${candidate_tree}" \
+  --source-archive "${source_archive}" \
+  --baseline-archive "${baseline_archive}" \
+  --manifest "${candidate_source}/ci/e2e/link-workload/Cargo.toml" \
+  --output "${output}" \
+  "$@"
+
+echo "allocator benchmark evidence: ${output}"

--- a/ci/allocator_profile_runner.py
+++ b/ci/allocator_profile_runner.py
@@ -1,0 +1,203 @@
+"""Collect non-timing sampled-pprof and exact-DHAT evidence for issue #93."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from ci.allocator_benchmark import (
+    BenchmarkFailure,
+    _prepare_command,
+    _run_native,
+    clean_benchmark_environment,
+    cleanup_ephemeral_outputs,
+)
+from ci.benchmark_runner import (
+    CONFIGURATIONS,
+    DEFAULT_MANIFEST,
+    BenchmarkError,
+    capture_executable_oracle,
+    capture_final_link,
+    prune_capture_artifacts,
+    release_capture_artifacts,
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def profile_mode_environment(base: dict[str, str], mode: str, output: Path) -> dict[str, str]:
+    environment, contaminated = clean_benchmark_environment(base)
+    if contaminated:
+        raise BenchmarkFailure("profiler environment contamination: " + ", ".join(contaminated))
+    environment.update({"MIMALLOC_PROF": "0", "MIMALLOC_PROF_ACTIVE": "0", "MIMALLOC_DHAT": "0"})
+    if mode == "pprof":
+        environment.update({"MIMALLOC_PROF": "1", "MIMALLOC_PROF_DUMP_AT_EXIT": str(output)})
+    elif mode == "dhat":
+        environment["RELD_DHAT_OUTPUT"] = str(output)
+    elif mode != "default":
+        raise BenchmarkFailure(f"unknown diagnostic allocator mode: {mode}")
+    return environment
+
+
+def profile_evidence(path: Path, *, label: str) -> dict[str, object]:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise BenchmarkFailure(f"{label} emitted no profile")
+    return {"path": str(path), "size_bytes": path.stat().st_size, "sha256": _sha256(path)}
+
+
+def require_identical_artifacts(hashes: dict[str, str], *, configuration: str) -> None:
+    if len(set(hashes.values())) != 1:
+        raise BenchmarkFailure(f"diagnostic artifact identity failed for {configuration}: {hashes}")
+
+
+def run(args: argparse.Namespace) -> dict[str, object]:
+    if sys.platform != "linux":
+        raise BenchmarkFailure("allocator profiles are supported only on Linux")
+    environment, contaminated = clean_benchmark_environment(dict(os.environ))
+    if contaminated:
+        raise BenchmarkFailure("profiler environment contamination: " + ", ".join(contaminated))
+    output_dir = args.output_dir.resolve()
+    target_dir = args.target_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    modes = {"default": args.default, "pprof": args.pprof, "dhat": args.dhat}
+    report: dict[str, object] = {
+        "schema": 1,
+        "diagnostic_only": True,
+        "timing_evidence": False,
+        "configurations": {},
+    }
+    log_path = output_dir / "capture.log"
+    with log_path.open("w", encoding="utf-8") as log:
+        for configuration in CONFIGURATIONS:
+            print(f"allocator profiles: capturing {configuration.label}", flush=True)
+            captured = capture_final_link(
+                configuration,
+                cargo="cargo",
+                manifest=args.manifest.resolve(),
+                target_dir=target_dir,
+                environment=environment,
+                log=log,
+                linker="clang",
+                timeout_seconds=args.capture_timeout,
+            )
+            oracle = capture_executable_oracle(
+                captured.output,
+                cwd=args.manifest.parent,
+                environment=environment,
+                timeout_seconds=args.native_timeout,
+            )
+            prune_capture_artifacts(captured, profile_dir=target_dir / configuration.profile, log=log)
+            hashes: dict[str, str] = {}
+            profiles: dict[str, dict[str, object]] = {}
+            mode_environments: dict[str, dict[str, str]] = {}
+            try:
+                for mode, binary in modes.items():
+                    mode_dir = output_dir / configuration.profile / mode
+                    mode_dir.mkdir(parents=True, exist_ok=True)
+                    output = mode_dir / "app"
+                    command = _prepare_command(captured, binary, output, mode_dir / "driver")
+                    expected_profile: Path | None = None
+                    if mode == "pprof":
+                        expected_profile = mode_dir / "heap.prof"
+                    elif mode == "dhat":
+                        expected_profile = mode_dir / "dhat-heap.json"
+                    mode_environment = profile_mode_environment(
+                        environment,
+                        mode,
+                        expected_profile or mode_dir / "unused-profile-output",
+                    )
+                    mode_environments[mode] = {name: mode_environment[name] for name in ("MIMALLOC_PROF", "MIMALLOC_PROF_ACTIVE", "MIMALLOC_DHAT")}
+                    try:
+                        completed = subprocess.run(
+                            command,
+                            cwd=args.manifest.parent,
+                            env=mode_environment,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                            timeout=args.link_timeout,
+                        )
+                    except subprocess.TimeoutExpired as error:
+                        raise BenchmarkFailure(f"{configuration.label}/{mode} profile link exceeded {args.link_timeout:.0f}s") from error
+                    if completed.returncode:
+                        raise BenchmarkFailure(f"{configuration.label}/{mode} profile link failed: {completed.stderr}")
+                    _run_native(
+                        output,
+                        oracle.stdout,
+                        oracle.stderr,
+                        mode_environment,
+                        args.manifest.parent,
+                        timeout_seconds=args.native_timeout,
+                    )
+                    hashes[mode] = _sha256(output)
+                    if expected_profile is not None:
+                        profiles[mode] = {
+                            **profile_evidence(expected_profile, label=f"{configuration.label}/{mode}"),
+                            "environment": {name: mode_environment[name] for name in ("MIMALLOC_PROF", "MIMALLOC_PROF_ACTIVE", "MIMALLOC_DHAT")},
+                        }
+                    output.unlink()
+                    (mode_dir / "driver" / "ld").unlink(missing_ok=True)
+                    (mode_dir / "driver").rmdir()
+                require_identical_artifacts(hashes, configuration=configuration.label)
+                report["configurations"][configuration.label] = {
+                    "artifact_sha256": hashes["default"],
+                    "mode_artifact_sha256": hashes,
+                    "native_oracle": {"exit_code": 0, "stdout": oracle.stdout, "stderr": oracle.stderr},
+                    "profiles": profiles,
+                    "mode_environments": mode_environments,
+                }
+            finally:
+                release_capture_artifacts(
+                    profile_dir=target_dir / configuration.profile,
+                    target_dir=target_dir,
+                    log=log,
+                )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--default", required=True, type=Path)
+    parser.add_argument("--pprof", required=True, type=Path)
+    parser.add_argument("--dhat", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--target-dir", type=Path, default=Path("target/allocator-profiles/workload"))
+    parser.add_argument("--capture-timeout", type=float, default=1_800.0)
+    parser.add_argument("--native-timeout", type=float, default=30.0)
+    parser.add_argument("--link-timeout", type=float, default=300.0)
+    args = parser.parse_args(argv)
+    report: dict[str, object] | None = None
+    failure: Exception | None = None
+    try:
+        report = run(args)
+    except (BenchmarkFailure, BenchmarkError, OSError, subprocess.SubprocessError) as error:
+        failure = error
+    finally:
+        cleanup_ephemeral_outputs(args.target_dir, args.output_dir)
+    if failure is not None:
+        resolved_output = args.output_dir.resolve()
+        for pattern in ("heap.prof", "dhat-heap.json"):
+            for path in resolved_output.glob(f"**/{pattern}"):
+                if path.is_file() and path.resolve().is_relative_to(resolved_output):
+                    path.unlink()
+        sys.stderr.write(f"allocator profiling failed: {failure}\n")
+        return 1
+    assert report is not None
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/allocator_profiles.sh
+++ b/ci/allocator_profiles.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Diagnostic-only pprof and exact-DHAT collection; never use these runs as timing evidence.
+set -euo pipefail
+
+candidate_revision=e08686773514edf0b30a88e5950a6071d3caf373
+candidate_tree=7162acc8005911d79aa85397a20a6744d27a09b8
+candidate_archive_sha256=53ba911ffc1ffe65e806c47b066064cae76ab461d97a156b4a4e86fa37f3211f
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+state="${root}/target/allocator-profiles"
+build_dir="${state}/build"
+binary_dir="${state}/bin"
+output="${RELD_ALLOCATOR_PROFILE_OUTPUT:-${state}/results.json}"
+source_archive="${RELD_ALLOCATOR_SOURCE_ARCHIVE:-${state}/candidate-e0868677.tar}"
+
+test "$(git -C "${root}" rev-parse "${candidate_revision}^{tree}")" = "${candidate_tree}"
+if [[ ! -f "${source_archive}" ]]; then
+  mkdir -p "$(dirname "${source_archive}")"
+  git -C "${root}" archive --format=tar --output="${source_archive}" "${candidate_revision}"
+fi
+echo "${candidate_archive_sha256}  ${source_archive}" | sha256sum --check --status
+mkdir -p "${state}" "${binary_dir}"
+source_dir=
+trap 'python3 "${root}/ci/allocator_source_cleanup.py" "${source_dir}"' EXIT
+source_dir="$(mktemp -d "${state}/source-e0868677.XXXXXXXX")"
+tar -xf "${source_archive}" -C "${source_dir}"
+
+common_env=(
+  env -i
+  "PATH=${RELD_PINNED_CARGO_BIN:-/usr/local/cargo/bin}:/usr/bin:/bin"
+  "HOME=/tmp/reld-allocator-profile-home"
+  "CARGO_HOME=${state}/cargo-home"
+  "RUSTUP_HOME=${RELD_PINNED_RUSTUP_HOME:-/usr/local/rustup}"
+  "RUSTUP_TOOLCHAIN=1.95.0"
+  "CC=/usr/bin/clang"
+  "CXX=/usr/bin/clang++"
+  "SOURCE_DATE_EPOCH=0"
+)
+mkdir -p /tmp/reld-allocator-profile-home
+mkdir -p "${state}/cargo-home"
+test "$(command -v cargo)" = "${RELD_PINNED_CARGO_BIN:-/usr/local/cargo/bin}/cargo"
+test -x "${RELD_PINNED_RUSTUP_HOME:-/usr/local/rustup}/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin/rustc"
+
+for mode in default pprof dhat; do
+  features=fork,plugins,zstd
+  if [[ "${mode}" == pprof ]]; then
+    features="${features},mimalloc-pprof-profile"
+  elif [[ "${mode}" == dhat ]]; then
+    features="${features},mimalloc-pprof-dhat"
+  fi
+  "${common_env[@]}" CARGO_TARGET_DIR="${build_dir}" cargo build --locked --release --no-default-features --features "${features}" --manifest-path "${source_dir}/Cargo.toml" -p reld --bin reld
+  install -m 755 "${build_dir}/release/reld" "${binary_dir}/reld-${mode}"
+done
+
+"${common_env[@]}" python3 -m ci.allocator_profile_runner \
+  --default "${binary_dir}/reld-default" \
+  --pprof "${binary_dir}/reld-pprof" \
+  --dhat "${binary_dir}/reld-dhat" \
+  --output "${output}" \
+  --output-dir "${state}/evidence" \
+  --manifest "${source_dir}/ci/e2e/link-workload/Cargo.toml"
+
+echo "diagnostic allocator profiles: ${output}"

--- a/ci/allocator_source_cleanup.py
+++ b/ci/allocator_source_cleanup.py
@@ -1,0 +1,53 @@
+"""Remove only validated temporary allocator benchmark source trees."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATTERNS = {
+    Path("target/allocator-benchmark"): re.compile(r"(?:baseline-source-e2d6be5a|candidate-source-e0868677)\.[A-Za-z0-9]{8}"),
+    Path("target/allocator-profiles"): re.compile(r"source-e0868677\.[A-Za-z0-9]{8}"),
+}
+
+
+def cleanup(requested: list[Path], root: Path = REPO_ROOT) -> list[Path]:
+    removed: list[Path] = []
+    resolved_root = root.resolve()
+    allowed: dict[Path, re.Pattern[str]] = {}
+    for relative_parent, pattern in SOURCE_PATTERNS.items():
+        lexical_parent = resolved_root / relative_parent
+        is_junction = getattr(lexical_parent, "is_junction", lambda: False)
+        if lexical_parent.is_symlink() or is_junction():
+            raise ValueError(f"refusing linked allocator cleanup parent: {lexical_parent}")
+        resolved_parent = lexical_parent.resolve()
+        if not resolved_parent.is_relative_to(resolved_root):
+            raise ValueError(f"refusing allocator cleanup parent outside repository: {resolved_parent}")
+        allowed[resolved_parent] = pattern
+    for source in requested:
+        if not str(source):
+            continue
+        absolute_source = source if source.is_absolute() else resolved_root / source
+        if not absolute_source.exists():
+            continue
+        if not absolute_source.is_dir() or absolute_source.is_symlink():
+            raise ValueError(f"refusing non-directory allocator source cleanup: {absolute_source}")
+        resolved_source = absolute_source.resolve()
+        name_pattern = allowed.get(resolved_source.parent)
+        if name_pattern is None or name_pattern.fullmatch(resolved_source.name) is None:
+            raise ValueError(f"refusing unsafe allocator source cleanup: {resolved_source}")
+        for path in sorted(resolved_source.rglob("*"), key=lambda item: len(item.parts), reverse=True):
+            if path.is_symlink() or path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()
+        resolved_source.rmdir()
+        removed.append(resolved_source)
+    return removed
+
+
+if __name__ == "__main__":
+    cleanup([Path(argument) for argument in sys.argv[1:] if argument])

--- a/ci/benchmark_runner.py
+++ b/ci/benchmark_runner.py
@@ -385,6 +385,7 @@ def capture_final_link(
     environment: dict[str, str],
     log: TextIO,
     linker: str | None = None,
+    timeout_seconds: float | None = None,
 ) -> LinkCommand:
     command = cargo_capture_command(
         cargo=cargo,
@@ -394,16 +395,20 @@ def capture_final_link(
         linker=linker,
     )
     print(f"capturing {configuration.label}: {' '.join(command)}", file=log, flush=True)
-    completed = subprocess.run(
-        command,
-        cwd=manifest.parent,
-        env=environment,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=manifest.parent,
+            env=environment,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise BenchmarkError(f"{configuration.label} compilation/capture exceeded {timeout_seconds:.0f}s") from error
     if completed.returncode:
         raise BenchmarkError(f"{configuration.label} compilation/capture failed:\n{completed.stderr}")
     try:
@@ -462,7 +467,7 @@ def _run_link(command: list[str], *, cwd: Path, environment: dict[str, str]) -> 
     )
 
 
-def _run_executable(output: Path, *, cwd: Path, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_executable(output: Path, *, cwd: Path, environment: dict[str, str], timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     if not output.is_file() or output.stat().st_size == 0:
         raise BenchmarkError(f"linked output is missing or empty: {output}")
     return subprocess.run(
@@ -474,12 +479,22 @@ def _run_executable(output: Path, *, cwd: Path, environment: dict[str, str]) -> 
         encoding="utf-8",
         errors="replace",
         check=False,
+        timeout=timeout_seconds,
     )
 
 
-def capture_executable_oracle(output: Path, *, cwd: Path, environment: dict[str, str]) -> ExecutableOracle:
+def capture_executable_oracle(
+    output: Path,
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    timeout_seconds: float | None = None,
+) -> ExecutableOracle:
     """Capture exact behavior from Cargo's target-native reference executable."""
-    completed = _run_executable(output, cwd=cwd, environment=environment)
+    try:
+        completed = _run_executable(output, cwd=cwd, environment=environment, timeout_seconds=timeout_seconds)
+    except subprocess.TimeoutExpired as error:
+        raise BenchmarkError(f"captured reference exceeded {timeout_seconds:.0f}s: {output}") from error
     if completed.returncode or not completed.stdout.startswith("OK "):
         raise BenchmarkError(f"captured reference failed its OK oracle ({completed.returncode}):\n{completed.stdout}{completed.stderr}")
     return ExecutableOracle(stdout=completed.stdout, stderr=completed.stderr)
@@ -843,8 +858,7 @@ def run_benchmark(
             environment=environment,
         )
         print(
-            f"captured executable oracle for {configuration.label}: "
-            f"stdout={oracle.stdout.strip()!r}, stderr_bytes={len(oracle.stderr.encode('utf-8'))}",
+            f"captured executable oracle for {configuration.label}: stdout={oracle.stdout.strip()!r}, stderr_bytes={len(oracle.stderr.encode('utf-8'))}",
             file=log,
             flush=True,
         )

--- a/ci/tests/test_allocator_benchmark.py
+++ b/ci/tests/test_allocator_benchmark.py
@@ -1,0 +1,211 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from ci.allocator_benchmark import (
+    PROFILER_ENV_VARS,
+    BenchmarkFailure,
+    _assert_hook_free,
+    _assert_no_profile_output,
+    _run_native,
+    _timed_link,
+    bootstrap_geometric_improvement_ci,
+    bootstrap_improvement_ci,
+    clean_benchmark_environment,
+    rotated_order,
+    should_keep_allocator,
+)
+from ci.allocator_profile_runner import profile_evidence, profile_mode_environment, require_identical_artifacts
+from ci.allocator_source_cleanup import cleanup
+
+
+def test_profiler_environment_is_removed_and_contamination_is_reported() -> None:
+    environment = {"PATH": "/bin", **{name: "1" for name in PROFILER_ENV_VARS}}
+
+    cleaned, contaminated = clean_benchmark_environment(environment)
+
+    assert cleaned == {"PATH": "/bin"}
+    assert contaminated == sorted(PROFILER_ENV_VARS)
+
+
+def test_round_order_is_seeded_randomized_and_balanced() -> None:
+    orders = [rotated_order(("system", "mimalloc"), round_index, seed=93) for round_index in range(10)]
+
+    assert orders == [rotated_order(("system", "mimalloc"), index, seed=93) for index in range(10)]
+    assert sum(order[0] == "system" for order in orders) == 5
+    assert sum(order[0] == "mimalloc" for order in orders) == 5
+
+
+def test_bootstrap_ci_is_reproducible_and_reports_candidate_improvement() -> None:
+    baseline = [10.0, 10.1, 9.9, 10.0, 10.2, 9.8, 10.0, 10.1, 9.9, 10.0]
+    candidate = [8.0, 8.1, 7.9, 8.0, 8.2, 7.8, 8.0, 8.1, 7.9, 8.0]
+
+    first = bootstrap_improvement_ci(baseline, candidate, iterations=2_000, seed=93)
+    second = bootstrap_improvement_ci(baseline, candidate, iterations=2_000, seed=93)
+
+    assert first == second
+    assert first[0] > 0.15
+    assert first[1] > first[0]
+
+    with pytest.raises(BenchmarkFailure, match="strictly positive"):
+        bootstrap_improvement_ci([0.0] * 10, [1.0] * 10)
+
+
+def test_benchmark_module_rejects_profiler_contaminated_parent_environment(tmp_path: Path) -> None:
+    from ci import allocator_benchmark
+
+    with pytest.raises(BenchmarkFailure, match="profiler environment contamination"):
+        allocator_benchmark.require_clean_parent_environment({"MIMALLOC_DHAT": "1", "PATH": os.defpath})
+
+
+def test_feature_proof_rejects_compiled_pprof(tmp_path: Path) -> None:
+    proof = tmp_path / "features.txt"
+    proof.write_text('mimalloc-pprof feature "pprof"\n', encoding="utf-8")
+
+    with pytest.raises(BenchmarkFailure, match="profiling feature"):
+        _assert_hook_free(tmp_path / "reld", proof)
+
+
+def test_profile_output_guard_checks_the_filesystem(tmp_path: Path) -> None:
+    _assert_no_profile_output(tmp_path)
+    (tmp_path / "dhat-heap.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(BenchmarkFailure, match="profiler output contaminated"):
+        _assert_no_profile_output(tmp_path)
+
+
+def test_aggregate_bootstrap_preserves_workload_pairing() -> None:
+    cells = [
+        ([10.0] * 10, [9.0] * 10),
+        ([20.0] * 10, [18.0] * 10),
+        ([30.0] * 10, [27.0] * 10),
+    ]
+
+    low, high = bootstrap_geometric_improvement_ci(cells, iterations=500, seed=93)
+
+    assert low == pytest.approx(0.1)
+    assert high == pytest.approx(0.1)
+
+
+def test_shell_builds_both_modes_from_exact_git_archive_and_scrubbed_env() -> None:
+    script = (Path(__file__).parents[1] / "allocator_benchmark.sh").read_text(encoding="utf-8")
+
+    assert 'git -C "${root}" archive --format=tar --output="${source_archive}" "${candidate_revision}"' in script
+    assert 'baseline_source="$(mktemp -d "${state}/baseline-source-e2d6be5a.XXXXXXXX")"' in script
+    assert 'candidate_source="$(mktemp -d "${state}/candidate-source-e0868677.XXXXXXXX")"' in script
+    assert 'trap \'python3 "${root}/ci/allocator_source_cleanup.py" "${baseline_source}" "${candidate_source}"\' EXIT' in script
+    assert 'test "$(git -C "${root}" rev-parse "${candidate_revision}^{tree}")" = "${candidate_tree}"' in script
+    assert script.count('"${common_env[@]}" CARGO_TARGET_DIR=') == 2
+    assert "env -i" in script
+    assert "--no-default-features --features fork,plugins,zstd" in script
+
+
+def test_diagnostic_mode_environments_are_isolated(tmp_path: Path) -> None:
+    output = tmp_path / "profile"
+
+    default = profile_mode_environment({"PATH": "/bin"}, "default", output)
+    pprof = profile_mode_environment({"PATH": "/bin"}, "pprof", output)
+    dhat = profile_mode_environment({"PATH": "/bin"}, "dhat", output)
+
+    assert default == {"PATH": "/bin", "MIMALLOC_PROF": "0", "MIMALLOC_PROF_ACTIVE": "0", "MIMALLOC_DHAT": "0"}
+    assert pprof["MIMALLOC_PROF"] == "1"
+    assert pprof["MIMALLOC_PROF_DUMP_AT_EXIT"] == str(output)
+    assert pprof["MIMALLOC_DHAT"] == "0"
+    assert dhat["MIMALLOC_PROF"] == "0"
+    assert dhat["RELD_DHAT_OUTPUT"] == str(output)
+
+    with pytest.raises(BenchmarkFailure, match="contamination"):
+        profile_mode_environment({"MIMALLOC_PROF": "1"}, "default", output)
+
+
+def test_allocator_workflow_uses_and_uploads_exact_archives() -> None:
+    workflow = (Path(__file__).parents[2] / ".github" / "workflows" / "allocator-benchmark.yml").read_text(encoding="utf-8")
+
+    assert "fetch-depth: 0" in workflow
+    assert "RELD_ALLOCATOR_SOURCE_ARCHIVE: /tmp/reld-e0868677.tar" in workflow
+    assert "RELD_ALLOCATOR_BASELINE_ARCHIVE: /tmp/reld-e2d6be5a.tar" in workflow
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow
+
+
+def test_link_and_native_timeouts_are_actionable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from ci import allocator_benchmark
+
+    def time_out(command, **kwargs):
+        raise allocator_benchmark.subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(allocator_benchmark.subprocess, "run", time_out)
+    with pytest.raises(BenchmarkFailure, match="link exceeded 12s"):
+        _timed_link(
+            ["clang", "input.o"],
+            cwd=tmp_path,
+            environment={},
+            timing_file=tmp_path / "time.txt",
+            timeout_seconds=12,
+        )
+    with pytest.raises(BenchmarkFailure, match="native oracle exceeded 7s"):
+        _run_native(tmp_path / "app", "", "", {}, tmp_path, timeout_seconds=7)
+
+
+def test_diagnostic_profiles_must_be_nonempty_and_artifacts_identical(tmp_path: Path) -> None:
+    profile = tmp_path / "heap.prof"
+    with pytest.raises(BenchmarkFailure, match="emitted no profile"):
+        profile_evidence(profile, label="no-LTO/pprof")
+    profile.write_bytes(b"profile")
+    assert profile_evidence(profile, label="no-LTO/pprof")["size_bytes"] == 7
+
+    require_identical_artifacts({"default": "abc", "pprof": "abc", "dhat": "abc"}, configuration="no-LTO")
+    with pytest.raises(BenchmarkFailure, match="artifact identity failed"):
+        require_identical_artifacts({"default": "abc", "pprof": "def"}, configuration="no-LTO")
+
+
+def test_allocator_decision_requires_wall_confidence_and_cpu_rss_non_regression() -> None:
+    good = {
+        "wall_seconds": {"bootstrap_95_ci": [0.01, 0.10], "non_regressing": True},
+        "cpu_seconds": {"bootstrap_95_ci": [-0.01, 0.05], "non_regressing": True},
+        "peak_rss_kib": {"bootstrap_95_ci": [-0.02, 0.04], "non_regressing": True},
+    }
+    assert should_keep_allocator([good, good, good], good)
+
+    cpu_regression = {name: dict(value) for name, value in good.items()}
+    cpu_regression["cpu_seconds"]["non_regressing"] = False
+    assert not should_keep_allocator([good, cpu_regression, good], good)
+
+    inconclusive_wall = {name: dict(value) for name, value in good.items()}
+    inconclusive_wall["wall_seconds"]["bootstrap_95_ci"] = [-0.01, 0.10]
+    assert not should_keep_allocator([good, good, good], inconclusive_wall)
+
+
+def test_source_cleanup_removes_only_validated_temporary_trees(tmp_path: Path) -> None:
+    parent = tmp_path / "target" / "allocator-benchmark"
+    removable = parent / "candidate-source-e0868677.Ab12Cd34"
+    removable.mkdir(parents=True)
+    (removable / "nested").mkdir()
+    (removable / "nested" / "source.rs").write_text("fn main() {}", encoding="utf-8")
+    preserved = parent / "candidate-source-e0868677.Zy98Xw76"
+    preserved.mkdir()
+
+    assert cleanup([removable], tmp_path) == [removable.resolve()]
+    assert not removable.exists()
+    assert preserved.is_dir()
+
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    with pytest.raises(ValueError, match="unsafe allocator source cleanup"):
+        cleanup([unrelated], tmp_path)
+
+
+def test_source_cleanup_rejects_symlinked_parent(tmp_path: Path) -> None:
+    external = tmp_path / "external"
+    external.mkdir()
+    linked_parent = tmp_path / "target" / "allocator-benchmark"
+    linked_parent.parent.mkdir()
+    try:
+        linked_parent.symlink_to(external, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
+    requested = linked_parent / "candidate-source-e0868677.Ab12Cd34"
+    requested.mkdir()
+
+    with pytest.raises(ValueError, match="linked allocator cleanup parent"):
+        cleanup([requested], tmp_path)

--- a/ci/tests/test_benchmark_runner.py
+++ b/ci/tests/test_benchmark_runner.py
@@ -90,6 +90,24 @@ def test_linux_capture_uses_clang_without_gccs_synthetic_lto_plugin():
     assert "plugin" not in " ".join(command)
 
 
+def test_capture_timeout_is_reported_as_benchmark_failure(tmp_path: Path, monkeypatch):
+    def time_out(*args, **kwargs):
+        del args, kwargs
+        raise runner_module.subprocess.TimeoutExpired(["cargo"], timeout=12)
+
+    monkeypatch.setattr(runner_module.subprocess, "run", time_out)
+    with pytest.raises(BenchmarkError, match="no-LTO compilation/capture exceeded 12s"):
+        runner_module.capture_final_link(
+            CONFIGURATIONS[0],
+            cargo="cargo",
+            manifest=tmp_path / "Cargo.toml",
+            target_dir=tmp_path / "target",
+            environment={},
+            log=StringIO(),
+            timeout_seconds=12,
+        )
+
+
 def test_each_configuration_is_replayed_then_released_before_the_next_capture(tmp_path: Path, monkeypatch):
     events: list[str] = []
     linker = Linker("wild", tmp_path / "wild")
@@ -394,9 +412,7 @@ def test_compiled_policy_is_target_calibrated_for_significant_final_links():
 
 
 def test_benchmark_platform_routes_are_exhaustive():
-    source = (Path(__file__).parents[2] / "crates" / "reld-testkit" / "src" / "bin" / "reld-bench.rs").read_text(
-        encoding="utf-8"
-    )
+    source = (Path(__file__).parents[2] / "crates" / "reld-testkit" / "src" / "bin" / "reld-bench.rs").read_text(encoding="utf-8")
 
     # Rust 1.95's cfg_select! emits a compile error when no arm matches. Keep the
     # three supported host routes explicit rather than treating every other target as Linux.
@@ -600,11 +616,7 @@ def test_windows_round_robin_does_not_reuse_locked_trial_output(tmp_path: Path, 
     def fake_run(command, *, cwd, environment):
         del cwd, environment
         response_file = Path(command[1][1:])
-        output_line = next(
-            line.strip('"')
-            for line in response_file.read_text(encoding="utf-8").splitlines()
-            if line.strip('"').upper().startswith("/OUT:")
-        )
+        output_line = next(line.strip('"') for line in response_file.read_text(encoding="utf-8").splitlines() if line.strip('"').upper().startswith("/OUT:"))
         output = Path(output_line[5:])
         if output.exists():
             return runner_module.subprocess.CompletedProcess(

--- a/docker/bosn.Dockerfile
+++ b/docker/bosn.Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
         lld \
         mold \
         python3 \
+        time \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /reld


### PR DESCRIPTION
Closes #93
Part of #97

## Outcome

Adds the reproducible correctness-first allocator decision harness. This PR does not claim that mimalloc is faster and does not change linker behavior. It creates the evidence gate that will decide whether the already-landed allocator remains or is reverted.

## Controlled comparison

- system baseline is the exact archived `e2d6be5a` Git tree
- mimalloc candidate is the exact archived `e0868677` Git tree
- archives, Git tree IDs, lockfiles, binary hashes, workload manifest/lock, effective captured linker command/arguments/cwd, tool paths, and machine provenance are recorded
- both release builds use Rust 1.95.0, isolated Cargo state, fixed Clang, identical explicit features and an empty inherited build environment
- candidate feature-tree plus `nm` proof rejects sampled pprof hooks; all documented pprof/DHAT controls are scrubbed and a dedicated output directory must remain empty before, during, and after timing

## Correctness before timing

Every no-LTO, ThinLTO, and full-LTO cell links twice with each allocator, requires one raw SHA-256 artifact identity across all four outputs, and checks exact native exit/stdout/stderr. Every timed artifact is hash-checked against that oracle and natively executed outside timing.

## Statistics and decision

- two excluded warmups and ten balanced interleaved samples per allocator/workload
- GNU time wall/user/system/peak-RSS raw samples and MAD
- paired round bootstrap 95% CIs per workload
- paired-within-workload geometric aggregate CIs
- keep only when aggregate wall lower CI is above zero and every workload plus aggregate wall/CPU/RSS lower CI stays within the declared 3% non-regression margin
- otherwise report `inconclusive_or_worse`; #97 then requires reverting the allocator default

## Diagnostic evidence

A separate non-timing runner builds default, sampled-pprof, and exact-DHAT modes, requires artifact identity and exact native behavior, and uploads nonempty profile evidence. Diagnostic runs never enter timing cells.

## Safety and observability

All capture/link/native phases are bounded. Exact temporary archive trees are created with `mktemp`; EXIT cleanup accepts only the exact passed directories after fixed-parent, basename, symlink/junction, and containment validation. The GitHub job runs in a pinned Rust container digest, pins native package versions and action SHAs, and uploads raw evidence even on failure.

## Host validation

- `ruff check`: pass
- allocator/benchmark focused pytest: 59 passed
- `bash -n ci/allocator_benchmark.sh ci/allocator_profiles.sh`: pass
- `git diff --check`: pass
- clud-review: clean

The PR must not merge until the manual allocator workflow completes and its authoritative JSON decision has been applied.