### PR TITLE
perf: restore system allocator by default

### DIFF
--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -15,13 +15,13 @@ and the root [`AGENTS.md`](../../AGENTS.md) first.
   `DESIGN.md`, or a pinned pre-change `reld` revision when validating a later optimization.
 - `bfd`, `lld`, and `mold` are useful compatibility or performance comparators, but they are not
   byte-identity references because each linker has its own ELF layout policy.
-- The Linux `reld` executable always uses the exact crates.io `mimalloc-pprof`
-  allocator pinned in the workspace manifest and lockfile. Its default configuration
-  compiles sampled-profiler hooks out (`MI_PPROF=0`) and leaves internal exact DHAT
-  inactive. Use `--features mimalloc-pprof-profile` only for sampled profiling and
-  `--features mimalloc-pprof-dhat` only for an exact diagnostic run. Neither profile
-  mode replaces the process allocator. The system allocator reference is the pinned
-  pre-change baseline, not a supported reld feature.
+- The default Linux `reld` executable uses Rust's system allocator. The exact crates.io
+  `mimalloc-pprof` release pinned in the workspace manifest and lockfile is optional and
+  compiled only by explicit diagnostic features. Use `--features mimalloc-pprof-profile`
+  for sampled profiling or `--features mimalloc-pprof-dhat` for an exact diagnostic run.
+  Both modes select the same mimalloc global allocator; internal DHAT never installs a
+  second allocator. The default was restored after the #93 evidence found no demonstrated
+  wall-time improvement and an inconclusive CPU non-regression interval.
   See [`../../docs/MIMALLOC-PPROF.md`](../../docs/MIMALLOC-PPROF.md) for
   provenance and updates.
 

--- a/ci/tests/test_allocator_config.py
+++ b/ci/tests/test_allocator_config.py
@@ -13,14 +13,23 @@ def test_allocator_uses_exact_registry_release_without_vendor_state() -> None:
     assert "mimalloc-pprof" not in (REPO_ROOT / ".gitmodules").read_text(encoding="utf-8")
 
 
-def test_reld_has_one_allocator_and_internal_dhat_modes() -> None:
+def test_reld_defaults_to_system_allocator_and_keeps_one_diagnostic_allocator() -> None:
     manifest = tomllib.loads((REPO_ROOT / "crates" / "reld" / "Cargo.toml").read_text(encoding="utf-8"))
     assert "dhat" not in manifest["dependencies"]
-    assert manifest["features"]["mimalloc-pprof-profile"] == ["mimalloc-pprof/pprof"]
-    assert manifest["features"]["mimalloc-pprof-dhat"] == []
+    assert manifest["dependencies"]["mimalloc-pprof"] == {"workspace": True, "optional": True}
+    assert manifest["features"]["mimalloc-pprof-profile"] == [
+        "dep:mimalloc-pprof",
+        "mimalloc-pprof/pprof",
+    ]
+    assert manifest["features"]["mimalloc-pprof-dhat"] == ["dep:mimalloc-pprof"]
+    assert not set(manifest["features"]["default"]) & {
+        "mimalloc-pprof-profile",
+        "mimalloc-pprof-dhat",
+    }
 
     source = (REPO_ROOT / "crates" / "reld" / "src" / "main.rs").read_text(encoding="utf-8")
     assert source.count("#[global_allocator]") == 1
+    assert '#[cfg(any(feature = "mimalloc-pprof-profile", feature = "mimalloc-pprof-dhat"))]' in source
     assert "mimalloc_pprof::MiMalloc" in source
     assert "dhat::Alloc" not in source
     assert "mimalloc_pprof::dhat::start()" in source

--- a/crates/reld/Cargo.toml
+++ b/crates/reld/Cargo.toml
@@ -40,9 +40,9 @@ path = "tests/acceptance_policy_tests.rs"
 [dependencies]
 reld-core = { path = "../reld-core", version = "0.0.0", default-features = false }
 
-# Exact crates.io dependency approved in #97. Default features are disabled so
-# authoritative timing builds compile sampled pprof hooks out.
-mimalloc-pprof.workspace = true
+# Exact crates.io dependency approved in #97. Production builds use the system
+# allocator; this dependency is compiled only for explicit diagnostic modes.
+mimalloc-pprof = { workspace = true, optional = true }
 
 [dev-dependencies]
 ar.workspace = true
@@ -79,11 +79,11 @@ default = ["fork", "plugins", "zstd"]
 
 # Compile pprof hooks in; collection remains opt-in through mimalloc's API or
 # documented environment controls.
-mimalloc-pprof-profile = ["mimalloc-pprof/pprof"]
+mimalloc-pprof-profile = ["dep:mimalloc-pprof", "mimalloc-pprof/pprof"]
 
-# Exact DHAT profiling is provided internally by mimalloc-pprof, so enabling it
-# never replaces the process global allocator.
-mimalloc-pprof-dhat = []
+# Exact DHAT profiling is provided internally by the same mimalloc-pprof
+# allocator, avoiding a second global allocator.
+mimalloc-pprof-dhat = ["dep:mimalloc-pprof"]
 
 fork = ["reld-core/fork"]
 

--- a/crates/reld/src/main.rs
+++ b/crates/reld/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "mimalloc-pprof-profile", feature = "mimalloc-pprof-dhat"))]
 #[global_allocator]
 static MIMALLOC: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
 

--- a/docs/MIMALLOC-PPROF.md
+++ b/docs/MIMALLOC-PPROF.md
@@ -7,19 +7,21 @@ in #97 under the dependency policy tracked by #88.
 
 ## Configurations
 
-- Default Linux build: `mimalloc-pprof` is the sole global allocator and sampled
-  profiler hooks are compiled out (`MI_PPROF=0`). Internal exact DHAT is inactive.
+- Default Linux build: Rust's system allocator. The optional `mimalloc-pprof`
+  dependency and its profiling hooks are not compiled into this configuration.
 - Sampled diagnostic build: `--features mimalloc-pprof-profile` compiles pprof hooks
-  in; collection remains explicitly runtime-controlled.
+  in and selects mimalloc as the sole global allocator; collection remains explicitly
+  runtime-controlled.
 - Exact diagnostic build: `--features mimalloc-pprof-dhat` uses mimalloc-pprof's
   internal DHAT collector and writes `dhat-heap.json` (override with
-  `RELD_DHAT_OUTPUT`). It does not replace the global allocator.
-- There is no supported system-allocator configuration. The system allocator is
-  retained only as the pinned pre-change baseline for artifact comparison.
+  `RELD_DHAT_OUTPUT`). It uses that same mimalloc global allocator and never installs
+  a second allocator.
 
-Authoritative timing uses only the default hook-free build and must prove sampled
-pprof and exact DHAT are runtime-off. Sampled and exact profile-collection runs are
-diagnostic evidence, never timing evidence.
+The #93 allocator benchmark measured 0.000% aggregate wall improvement with a paired
+bootstrap 95% confidence interval of -1.610% to +0.385%. Its CPU interval was also
+inconclusive, so the #97 decision gate returned `keep_allocator=false` and restored
+the system allocator as the production default. Sampled and exact profile-collection
+runs remain diagnostic evidence, never production timing evidence.
 
 ## Updating
 


### PR DESCRIPTION
Closes #93
Part of #97

## Outcome

Restore Rust system allocation as the production/default `reld` configuration. Retain exact crates.io `mimalloc-pprof = 0.9.5` only as an optional dependency selected by the explicit `mimalloc-pprof-profile` and `mimalloc-pprof-dhat` diagnostic features.

Both diagnostics continue to use the same `mimalloc_pprof::MiMalloc` global allocator. Internal DHAT does not install a second allocator, so there is no duplicate-global-allocator or DHAT/mimalloc conflict.

## Why this reverts the default

The correctness-gated allocator benchmark in PR #99 and run https://github.com/zackees/reld/actions/runs/33068576290 compared the pinned pre-change system allocator at `e2d6be5a` with the exact mimalloc candidate at `e0868677`.

All artifact and execution gates passed, but performance did not:
- aggregate wall improvement: 0.000%, paired bootstrap 95% CI [-1.610%, +0.385%]
- aggregate CPU improvement: 0.000%, 95% CI [-14.471%, +12.642%]
- aggregate peak RSS improvement: -0.098%, 95% CI [-0.384%, +0.361%]
- wall medians were identical for no-LTO (0.38s), ThinLTO (0.43s), and full-LTO (0.28s)

The declared decision was `inconclusive_or_worse` with `keep_allocator=false`. CPU also failed the uncertainty-aware non-regression gate. This PR applies that predeclared #97 policy as one causal allocator-selection change.

Raw evidence artifact: `allocator-evidence-bacc628ae2f14f15db198b1587ce6e524edb3435`, artifact ID 9645699405.

## Validation

RED:
- updated allocator config test failed because mimalloc remained unconditional.

GREEN:
- allocator/benchmark suite: 59 passed
- dependency contract check
- Ruff
- Cargo formatting
- all-features Clippy with warnings denied
- default, sampled-pprof, and internal-DHAT `reld` builds
- independent clud-review: clean

Remote GitHub Actions must pass before merge. No local Docker was used.