### PR TITLE
perf(elf): make output-section part maps sparse

### DIFF
--- a/.github/workflows/clang-link-replay.yml
+++ b/.github/workflows/clang-link-replay.yml
@@ -25,6 +25,7 @@ jobs:
       REPLAY_WORKDIR: target/clang-link-replay
       RUSTUP_TOOLCHAIN: 1.95.0
       CARGO_INCREMENTAL: "0"
+      SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -34,6 +35,16 @@ jobs:
         with:
           version: "0.12.3"
           python-version: "3.12.11"
+
+      - name: Install pinned archive decoder
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            zstd=1.5.4+dfsg2-5
+          rm -rf /var/lib/apt/lists/*
+          zstd --version
 
       - name: Validate immutable corpus lock
         run: >-

--- a/.github/workflows/clang-link-replay.yml
+++ b/.github/workflows/clang-link-replay.yml
@@ -1,0 +1,103 @@
+name: Immutable Clang link replay
+
+# This is deliberately separate from benchmark-stats.yml. It replays one precompiled Linux ELF
+# link for profiling/regression evidence and must never add LLVM compilation to the timed interval.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: clang-link-replay-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  replay-linux:
+    runs-on: ubuntu-24.04
+    container:
+      image: rust:1.95.0-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1
+    timeout-minutes: 120
+    env:
+      BASELINE_SHA: 6ec92be6674d026e74f7524271fbcbce68b50a39
+      CORPUS_LOCK: ci/clang-link-corpus.lock.json
+      EVIDENCE_DIR: clang-replay-evidence
+      REPLAY_WORKDIR: target/clang-link-replay
+      RUSTUP_TOOLCHAIN: 1.95.0
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.3"
+          python-version: "3.12.11"
+
+      - name: Validate immutable corpus lock
+        run: >-
+          uv run --no-project --python 3.12.11
+          python -m ci.clang_link_replay validate-lock --lock "$CORPUS_LOCK"
+
+      - name: Export controlled non-git source trees
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          test "$(git rev-parse "$BASELINE_SHA")" = "$BASELINE_SHA"
+          mkdir -p "$RUNNER_TEMP/reld-baseline" "$RUNNER_TEMP/reld-candidate" "$EVIDENCE_DIR"
+          git archive "$BASELINE_SHA" | tar -xf - -C "$RUNNER_TEMP/reld-baseline"
+          git archive HEAD | tar -xf - -C "$RUNNER_TEMP/reld-candidate"
+          test ! -e "$RUNNER_TEMP/reld-baseline/.git"
+          test ! -e "$RUNNER_TEMP/reld-candidate/.git"
+          git archive --format=tar --output="$EVIDENCE_DIR/baseline-source.tar" "$BASELINE_SHA"
+          git archive --format=tar --output="$EVIDENCE_DIR/candidate-source.tar" HEAD
+          sha256sum "$EVIDENCE_DIR/baseline-source.tar" \
+            "$EVIDENCE_DIR/candidate-source.tar" | tee "$EVIDENCE_DIR/source-archives.sha256"
+
+      - name: Build baseline and candidate with identical provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --release --package reld --bin reld \
+            --manifest-path "$RUNNER_TEMP/reld-baseline/Cargo.toml" \
+            --target-dir "$RUNNER_TEMP/reld-baseline-target"
+          cargo build --locked --release --package reld --bin reld \
+            --manifest-path "$RUNNER_TEMP/reld-candidate/Cargo.toml" \
+            --target-dir "$RUNNER_TEMP/reld-candidate-target"
+          install -D "$RUNNER_TEMP/reld-baseline-target/release/reld" \
+            "$EVIDENCE_DIR/baseline-reld"
+          install -D "$RUNNER_TEMP/reld-candidate-target/release/reld" \
+            "$EVIDENCE_DIR/candidate-reld"
+          "$EVIDENCE_DIR/baseline-reld" --version > "$EVIDENCE_DIR/baseline-version.txt"
+          "$EVIDENCE_DIR/candidate-reld" --version > "$EVIDENCE_DIR/candidate-version.txt"
+          cmp "$EVIDENCE_DIR/baseline-version.txt" "$EVIDENCE_DIR/candidate-version.txt"
+          grep -F "non-git-build" "$EVIDENCE_DIR/baseline-version.txt"
+          sha256sum "$EVIDENCE_DIR/baseline-reld" "$EVIDENCE_DIR/candidate-reld" \
+            | tee "$EVIDENCE_DIR/linkers.sha256"
+
+      - name: Acquire, verify, and replay immutable final link
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-project --python 3.12.11 \
+            python -m ci.clang_link_replay replay \
+            --lock "$CORPUS_LOCK" \
+            --baseline "$EVIDENCE_DIR/baseline-reld" \
+            --candidate "$EVIDENCE_DIR/candidate-reld" \
+            --workdir "$REPLAY_WORKDIR" \
+            --report "$EVIDENCE_DIR/replay-report.json" \
+            2>&1 | tee "$EVIDENCE_DIR/replay.log"
+
+      - name: Upload replay and artifact-identity evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: clang-link-replay-${{ github.sha }}
+          path: |
+            ci/clang-link-corpus.lock.json
+            clang-replay-evidence/
+            target/clang-link-replay/identity-artifacts/
+          if-no-files-found: warn
+          retention-days: 30

--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -48,6 +48,68 @@ Every produced executable must also run natively with exact exit status, stdout,
 the randomized `reld-difftest` execution comparison as a supplemental oracle; it does not replace
 artifact comparison.
 
+### Immutable Clang final-link corpus
+
+The long-form Linux workload is a captured LLVM/Clang final link, separate from the published
+five-linker × three-LTO matrix. The checked `ci/clang-link-corpus.lock.json` is the contract for a
+GitHub Release `.tar.gz` or `.tar.zst` asset. It records the LLVM source tag, annotated tag object,
+and peeled commit; digest-pinned builder image; exact package and toolchain versions; configure and
+build argv; archive URL, byte size, and SHA-256; captured linker argv, working directory,
+environment, response files, and expected linker output; exact native oracle; and every regular
+file in the input closure with its relative path, byte size, and SHA-256. The archive must contain
+no symlinks or unrecorded files. Arguments use `{CORPUS}` for the verified extraction root and one
+`{OUTPUT}` token for the fixed output path.
+
+Validate a checked lock without downloading the asset:
+
+```sh
+uv run --no-project --python 3.12.11 \
+  python -m ci.clang_link_replay validate-lock \
+  --lock ci/clang-link-corpus.lock.json
+```
+
+For pre-publication validation, replay the locally packed archive explicitly; never substitute an
+unverified or floating URL, digest, toolchain, cache, or branch:
+
+```sh
+uv run --no-project --python 3.12.11 \
+  python -m ci.clang_link_replay replay \
+  --lock ci/clang-link-corpus.lock.json \
+  --archive /absolute/path/to/clang-link-corpus.tar.zst \
+  --baseline /absolute/path/to/baseline-reld \
+  --candidate /absolute/path/to/candidate-reld \
+  --workdir target/clang-link-replay \
+  --report clang-replay-evidence/replay-report.json
+```
+
+Omit `--archive` only after the lock names the immutable GitHub Release asset. The replay verifies
+the archive and complete extracted closure before any link. Its locked direct-link arguments must
+include `--no-fork`; compilation, download, extraction, output removal, native execution, and
+evidence writing are outside timing. It first links twice with the pinned baseline and twice with
+the candidate, runs the exact native oracle after every output, and requires raw identity within
+and between both sides. A mismatch retains all four files, both hashes, and the first differing
+offset. One excluded candidate warmup supplies the calibration duration; the resulting fixed count
+of identical candidate links targets 30 seconds total. The native oracle still runs after every
+timed link, after its timer stops.
+
+The manual-only `.github/workflows/clang-link-replay.yml` owns hosted replay. It builds baseline
+`6ec92be6674d026e74f7524271fbcbce68b50a39` and the candidate from separate non-git source archives
+with Rust 1.95.0, requires identical `non-git-build` linker-version output so `.comment` provenance
+cannot create a false artifact delta, validates the checked lock, downloads its asset, runs the
+gate, and uploads the report plus retained identity-failure evidence. Do not add this workload to
+the public benchmark matrix.
+
+Prefer the complete `RelWithDebInfo` closure. The standard public `ubuntu-24.04` runner has a
+measured 16 GB RAM and 14 GB SSD, and each GitHub Release asset must remain below 2 GiB; the checked
+corpus must fit all three constraints with operational headroom. These ceilings are not permission
+for an undocumented transform, and this guide does not invent a smaller fixed gate that the harness
+does not enforce. If the complete closure cannot fit, the only accepted reduced variant is produced
+by deterministic GNU binutils 2.40 `strip --strip-debug` applied to copied ELF `.o` and `.a` inputs
+only. Retain complete pre-strip and post-strip SHA-256 manifests, and record the exact strip
+package, version, and argv in the lock. Keep every other link argument fixed and apply the same
+raw-artifact and native gates after the transform. Such a corpus represents a non-debug Clang final
+link and must not support claims about debug-heavy link performance.
+
 For allocator changes, build and replay the same captured ELF link in the default,
 sampled-profiling, and exact-DHAT configurations. First establish two-run self-determinism for each
 configuration, then compare the default artifact with the pinned pre-change system-allocator
@@ -88,6 +150,8 @@ run `xsv count`, the full pinned PCRE2 CTest suite, and the C++ name-mangling CT
 - Native implementation: `crates/reld-core/src/`
 - Differential runner: `crates/reld-testkit/src/bin/reld-difftest.rs`
 - Benchmark replay and execution oracle: `ci/benchmark_runner.py`
+- Immutable Clang corpus lock/replay: `ci/clang_link_replay.py` and
+  `.github/workflows/clang-link-replay.yml`
 - Consumer acceptance driver: `ci/consumer_acceptance.py`
 - Linux acceptance and differential CI: `.github/workflows/ci.yml`
 - Three-platform consumer acceptance: `.github/workflows/linker-artifacts.yml`

--- a/ci/clang-link-corpus.lock.json
+++ b/ci/clang-link-corpus.lock.json
@@ -1,0 +1,732 @@
+{
+  "archive": {
+    "bytes": 73413916,
+    "sha256": "beb1f73eaab4257572ff60d04f08391b605990e4377c5d137fbf254db8ad5440",
+    "url": null
+  },
+  "builder": {
+    "build_argv": [
+      "ninja",
+      "-C",
+      "llvm-build",
+      "-j16",
+      "-v",
+      "clang"
+    ],
+    "configure_argv": [
+      "cmake",
+      "-S",
+      "llvm-project/llvm",
+      "-B",
+      "llvm-build",
+      "-G",
+      "Ninja",
+      "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+      "-DLLVM_ENABLE_PROJECTS=clang",
+      "-DLLVM_TARGETS_TO_BUILD=X86",
+      "-DLLVM_ENABLE_LTO=OFF",
+      "-DLLVM_ENABLE_ASSERTIONS=OFF",
+      "-DLLVM_INCLUDE_TESTS=OFF",
+      "-DLLVM_INCLUDE_EXAMPLES=OFF",
+      "-DCLANG_INCLUDE_TESTS=OFF",
+      "-DCLANG_INCLUDE_EXAMPLES=OFF"
+    ],
+    "image": "reld-clang22-toolchain@sha256:06f93cb4978039b012d1f3643a4cb4f89c1391eb33fed8a97fd5c4f7b4771bb5",
+    "packages": [
+      "binutils=2.40-2",
+      "ca-certificates=20250419~deb12u1",
+      "clang=1:14.0-55.7~deb12u1",
+      "cmake=3.25.1-1",
+      "file=1:5.44-3",
+      "git=1:2.39.5-0+deb12u3",
+      "jq=1.6-2.1+deb12u2",
+      "lld=1:14.0-55.7~deb12u1",
+      "ninja-build=1.11.1-2~deb12u1",
+      "python3=3.11.2-1+b1",
+      "zstd=1.5.4+dfsg2-5"
+    ],
+    "toolchain": {
+      "ar": "GNU ar (GNU Binutils for Debian) 2.40",
+      "captured_ld_argv_sha256": "c1e737eca3a1c0ee9af88e70968b558cc2643c46db0f474dce74883f7b7f7e13",
+      "cc": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+      "cmake": "cmake version 3.25.1",
+      "cxx": "c++ (Debian 12.2.0-14+deb12u1) 12.2.0",
+      "ld": "GNU ld (GNU Binutils for Debian) 2.40",
+      "ninja": "1.11.1",
+      "packages_full_sha256": "92cd621156f4cdaabe2cb93746efabb3919b1b6d6d4d82f3c770ef14954d773e",
+      "post_strip_manifest_asset": "reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.post-strip-manifest.json",
+      "post_strip_manifest_sha256": "b9d3c2ccaad7fce5e3bfb87b0b03bfd5ee9cc13ddadb881391de06f9fbd04386",
+      "post_strip_manifest_url": "pending",
+      "pre_strip_manifest_asset": "reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.pre-strip-manifest.json",
+      "pre_strip_manifest_sha256": "d3e152030d709c41d313b00c463e46218c246f7a60a8e9587e6694e20e9039ae",
+      "pre_strip_manifest_url": "pending",
+      "python": "Python 3.11.2",
+      "source_tree": "1e4fdb95266974a0cbca9ec4c6f740488322f238",
+      "strip": "GNU strip (GNU Binutils for Debian) 2.40",
+      "strip_argv": "/usr/bin/strip --strip-debug <each .o/.a in LC_ALL=C path order; xargs -n1 -P4>",
+      "tar": "GNU tar 1.34; --sort=name --format=gnu --mtime=@0 --owner=0 --group=0 --numeric-owner --mode=u+rwX,go+rX,go-w",
+      "zstd": "Zstandard CLI v1.5.4; -3 -T1"
+    }
+  },
+  "files": [
+    {
+      "bytes": 219194,
+      "path": "lib/libLLVMAggressiveInstCombine.a",
+      "sha256": "e167884a4727b0c88df75055e5252f498a37c03e90e35882bb3a939cc06ff416"
+    },
+    {
+      "bytes": 11645328,
+      "path": "lib/libLLVMAnalysis.a",
+      "sha256": "734949adfdd2dd3009dd5b152937b62a82104e35e7a63e07625be9bbc6db832b"
+    },
+    {
+      "bytes": 1219074,
+      "path": "lib/libLLVMAsmParser.a",
+      "sha256": "23377cdfd2ebde6fefe9b817d8ab8d0f71c7c130230657d5b07c7b8f28132798"
+    },
+    {
+      "bytes": 2279454,
+      "path": "lib/libLLVMAsmPrinter.a",
+      "sha256": "530c99124e10620acfeddd79fc06286cb82022c40d0bd14734299f2973a21ba1"
+    },
+    {
+      "bytes": 567662,
+      "path": "lib/libLLVMBinaryFormat.a",
+      "sha256": "93c02efb25558e113dfc62255387d0996907779a54a5c9b30090d8f5bfdbe477"
+    },
+    {
+      "bytes": 991330,
+      "path": "lib/libLLVMBitReader.a",
+      "sha256": "41d810745c68d53b55993452c5646a16e34656cb06497a2ff85b4d35c52d3465"
+    },
+    {
+      "bytes": 553434,
+      "path": "lib/libLLVMBitWriter.a",
+      "sha256": "3ed17eae4f985a0cc17497ddd5a39e518d411c0faed7092e672002e6625b8136"
+    },
+    {
+      "bytes": 51046,
+      "path": "lib/libLLVMBitstreamReader.a",
+      "sha256": "d4da2a0a130c21813436644ee4546cf51cf6d6386ddc6da0f8a099842b2b66fa"
+    },
+    {
+      "bytes": 30950,
+      "path": "lib/libLLVMCFGuard.a",
+      "sha256": "644f9d7f0a29fa786f38d1cb0322e1327a6de876b0a28c440e6bbe5c87b3e53e"
+    },
+    {
+      "bytes": 326346,
+      "path": "lib/libLLVMCGData.a",
+      "sha256": "f4486ca547b37c30f6a5592271774a6819baf45bb9c4eda1cc9ed7764dc39c24"
+    },
+    {
+      "bytes": 18855372,
+      "path": "lib/libLLVMCodeGen.a",
+      "sha256": "a07640e8c9418b203f296609e0f96b2040f1a23e52fe27ef4fb537ab66350a23"
+    },
+    {
+      "bytes": 10882,
+      "path": "lib/libLLVMCodeGenTypes.a",
+      "sha256": "e1b43b6a30148922d6e5b4aad26e4f698f9aa5dd172a9d35d57fcb47092fba3f"
+    },
+    {
+      "bytes": 8868130,
+      "path": "lib/libLLVMCore.a",
+      "sha256": "00abd61c1a893cfd41db3f0501bf0ee0503b5c6e1854d63421ac3beb2dce2b19"
+    },
+    {
+      "bytes": 687878,
+      "path": "lib/libLLVMCoroutines.a",
+      "sha256": "cb8ba904dc7d138c5a60742f94bb4c377cc33af2fbe89f3abbd8403add34bdee"
+    },
+    {
+      "bytes": 551086,
+      "path": "lib/libLLVMCoverage.a",
+      "sha256": "833084dba8515e9e7d7b9d77a03d32c8c7ca176b574b70ad0f076ccbfc29056d"
+    },
+    {
+      "bytes": 108250,
+      "path": "lib/libLLVMDebugInfoBTF.a",
+      "sha256": "676ffd60e2ebcd940216841cfc5c73328391b5a04690ab9e94dc28111b883c85"
+    },
+    {
+      "bytes": 2193118,
+      "path": "lib/libLLVMDebugInfoCodeView.a",
+      "sha256": "fa305bf99b0faadcdd6838e581b5a240e764dbe91385df8edc6f2b44eeb1bb2a"
+    },
+    {
+      "bytes": 2130948,
+      "path": "lib/libLLVMDebugInfoDWARF.a",
+      "sha256": "e97ee8b3b987aa19ff9a5cd2edb004b60f329362ec0adcf8bbb63ca95c41bfbe"
+    },
+    {
+      "bytes": 91596,
+      "path": "lib/libLLVMDebugInfoDWARFLowLevel.a",
+      "sha256": "5a85cd606e83c017f58ff9ed89297d9ca0b5314abd3a82c7c9295fb500b3f3d0"
+    },
+    {
+      "bytes": 607250,
+      "path": "lib/libLLVMDebugInfoGSYM.a",
+      "sha256": "df34c74169f556043e0801714cd2ca1169fd48f53beeb0ae0e1308170d5bcfa1"
+    },
+    {
+      "bytes": 151902,
+      "path": "lib/libLLVMDebugInfoMSF.a",
+      "sha256": "d6ea67f4020f87b6d713bbf8bb36b28a948235d4ae21e99abaa4d59a3455333c"
+    },
+    {
+      "bytes": 2976614,
+      "path": "lib/libLLVMDebugInfoPDB.a",
+      "sha256": "3f11607ee08ad7f680697dd66c09f1611fc08546b1d8d2b935fe73736da37ef5"
+    },
+    {
+      "bytes": 748752,
+      "path": "lib/libLLVMDemangle.a",
+      "sha256": "3330ea02dba577096e0a9eba4ba7d869b708842f2c7f14fecbbccc3922e91b15"
+    },
+    {
+      "bytes": 1842,
+      "path": "lib/libLLVMExtensions.a",
+      "sha256": "c2440af0462538d76cecdb564142614577671b72736f58ae100b69c38c6007f1"
+    },
+    {
+      "bytes": 30974,
+      "path": "lib/libLLVMFrontendAtomic.a",
+      "sha256": "c97cc3df52bdd9a8914b3d14ec0d7ddfe062760bf28a90c04cbddefce0af9a40"
+    },
+    {
+      "bytes": 1492,
+      "path": "lib/libLLVMFrontendDirective.a",
+      "sha256": "0bac0d887e04f173c9ca33f8b9a7e32893d879088088af196a1d7006919fb3be"
+    },
+    {
+      "bytes": 4050,
+      "path": "lib/libLLVMFrontendDriver.a",
+      "sha256": "a58b7fcd0551216d95eecd47bdabf2e114ff414293752165dabab658cd1ca9e4"
+    },
+    {
+      "bytes": 164364,
+      "path": "lib/libLLVMFrontendHLSL.a",
+      "sha256": "90c95e036dbaddd7e95ac2db66fd1136d8cfe5a9e2a6d6881d9e8464a007c80f"
+    },
+    {
+      "bytes": 196166,
+      "path": "lib/libLLVMFrontendOffloading.a",
+      "sha256": "9dc3664e8dfcd211ec71905992c7b036154940c7e9a3a13ea6092fd826065448"
+    },
+    {
+      "bytes": 1449300,
+      "path": "lib/libLLVMFrontendOpenMP.a",
+      "sha256": "c617d199c9470de60a0b5081fac5b242eb1aa5945535b7f66e93843df7886924"
+    },
+    {
+      "bytes": 3182944,
+      "path": "lib/libLLVMGlobalISel.a",
+      "sha256": "4cc8da096ae829f4ee693a7d2d5030997105f926314907e735b6b70acb7da396"
+    },
+    {
+      "bytes": 54676,
+      "path": "lib/libLLVMHipStdPar.a",
+      "sha256": "018a4098dae4cf30e7258f8a2cdb1e23f38c3b637491f6619d626413a7ccb3ac"
+    },
+    {
+      "bytes": 9890,
+      "path": "lib/libLLVMIRPrinter.a",
+      "sha256": "77c44027004b3b459aba85f73f24f0f9dccb494a947bbb461d76d329846c8357"
+    },
+    {
+      "bytes": 34294,
+      "path": "lib/libLLVMIRReader.a",
+      "sha256": "33162ce5e85ced24b00239fe33c7230795e8023ca5f9bb5179edc8aa19550b59"
+    },
+    {
+      "bytes": 3740976,
+      "path": "lib/libLLVMInstCombine.a",
+      "sha256": "8c68663b92433d3b20def711f48f07c611dfcf1743799975f3874b96a4eb5318"
+    },
+    {
+      "bytes": 3929488,
+      "path": "lib/libLLVMInstrumentation.a",
+      "sha256": "5748afc885de3a962a3ad21e51bef89594ccbb16dae000797e0565b251847ecb"
+    },
+    {
+      "bytes": 1171444,
+      "path": "lib/libLLVMLTO.a",
+      "sha256": "b691fe50305331c8ef9c37ea5e15d571addc22d09e714e39d6f71cc46672470a"
+    },
+    {
+      "bytes": 197882,
+      "path": "lib/libLLVMLinker.a",
+      "sha256": "8cc1830f86660b9e9e80603770a0e26ad4c0b2d6a1096e4282a981c404070308"
+    },
+    {
+      "bytes": 2651184,
+      "path": "lib/libLLVMMC.a",
+      "sha256": "38c3c67ee1268bf473dd59a92a4da784536061cd5fd4269212f5aca73b35b653"
+    },
+    {
+      "bytes": 47200,
+      "path": "lib/libLLVMMCDisassembler.a",
+      "sha256": "dddbf36fcf3628cc607e99a6a91f3dd80191ead1ea00c50bbd490dd271f8caef"
+    },
+    {
+      "bytes": 1172666,
+      "path": "lib/libLLVMMCParser.a",
+      "sha256": "ccb8d9a462523388aa669b942cef76c2efa076e4a4d702510bd7b24bdc945fed"
+    },
+    {
+      "bytes": 267348,
+      "path": "lib/libLLVMObjCARCOpts.a",
+      "sha256": "af78838618a6497a59574ca78e69ff97e6010f32ba7d6b506ca1b1491e09ca8d"
+    },
+    {
+      "bytes": 3822484,
+      "path": "lib/libLLVMObject.a",
+      "sha256": "c6128ec9f17b618d27fc9fc8286e4e75e2cd4b6d2fe9c4c06dd1067ef5f55c2e"
+    },
+    {
+      "bytes": 4618078,
+      "path": "lib/libLLVMObjectYAML.a",
+      "sha256": "c0d630ccc6cbccb0ecc99ca738c528e071e48f7255528f8a9ea9fb04d713404f"
+    },
+    {
+      "bytes": 152798,
+      "path": "lib/libLLVMOption.a",
+      "sha256": "938e4ba28c743f70e71dfdc943738f53a4d17a80d832978838d448b17bd860fb"
+    },
+    {
+      "bytes": 8826962,
+      "path": "lib/libLLVMPasses.a",
+      "sha256": "8ffc680bb885fcf9f2e35acc95c84449cf9ba43af6ca1580808c651789680ef6"
+    },
+    {
+      "bytes": 5734,
+      "path": "lib/libLLVMPlugins.a",
+      "sha256": "fceec2a369f18f576877e3ab0c91eb19a4b7edf0f3d35a2c3639b530ce60c761"
+    },
+    {
+      "bytes": 2961768,
+      "path": "lib/libLLVMProfileData.a",
+      "sha256": "b87bdddb834f4bf661738577ef7a46e356f57b3b1accd3503328247210788c58"
+    },
+    {
+      "bytes": 360608,
+      "path": "lib/libLLVMRemarks.a",
+      "sha256": "a8302dfd60d18af7d6307381496c1f3a541be07d0c76228075149c55d30516f3"
+    },
+    {
+      "bytes": 976286,
+      "path": "lib/libLLVMSandboxIR.a",
+      "sha256": "ecef247a883f13cc39501174cfc876f9e3c339290be19d81a71c2a655ec051b1"
+    },
+    {
+      "bytes": 7855856,
+      "path": "lib/libLLVMScalarOpts.a",
+      "sha256": "c1d07f4dc273ef09b13ddf31ab2ef83c750554213300af820fb9596bd1e5b408"
+    },
+    {
+      "bytes": 8469392,
+      "path": "lib/libLLVMSelectionDAG.a",
+      "sha256": "057dcade9656a5d1cdb027ecd3c16a135fda15a3eb476d428979d8b4f29033bb"
+    },
+    {
+      "bytes": 5379538,
+      "path": "lib/libLLVMSupport.a",
+      "sha256": "362e8318182b765895bbb134cb4620297c475ea302e928decfc08c23e2319a5e"
+    },
+    {
+      "bytes": 441290,
+      "path": "lib/libLLVMSymbolize.a",
+      "sha256": "f5b3aa26d2ff4986c2bce46e93d55beb37ee7e67114d620f8bcfd6c05ecdf275"
+    },
+    {
+      "bytes": 145874,
+      "path": "lib/libLLVMTarget.a",
+      "sha256": "94c5be569c77b859c478a68bbf0b98789a849f1fd3ac8762d801d1060a25f3b4"
+    },
+    {
+      "bytes": 920786,
+      "path": "lib/libLLVMTargetParser.a",
+      "sha256": "7ca157971d994fba3ce20a4207f72d0c2c43d3f82e57d1a30ee033cd7dbccabf"
+    },
+    {
+      "bytes": 711630,
+      "path": "lib/libLLVMTextAPI.a",
+      "sha256": "307ec85cfbf8e6b540ea487c5577388deae26ecd14c78db66a4dc146e6fc1ee5"
+    },
+    {
+      "bytes": 74566,
+      "path": "lib/libLLVMTextAPIBinaryReader.a",
+      "sha256": "1d77ccd00573d134ee94fc17048795b84f82cf13480dcb15284b09989d67d043"
+    },
+    {
+      "bytes": 6387842,
+      "path": "lib/libLLVMTransformUtils.a",
+      "sha256": "255f102f29f1aeec7cc6b1fcd59810a1c96c3d1858d825647f15f247aa98632d"
+    },
+    {
+      "bytes": 6591862,
+      "path": "lib/libLLVMVectorize.a",
+      "sha256": "4b08d00c39a6aa4532272888b7e3a06c7a564f834f58eb5074bf0e3b57f91d06"
+    },
+    {
+      "bytes": 43006,
+      "path": "lib/libLLVMWindowsDriver.a",
+      "sha256": "7291101a0426e196549339164727192290110f911fc311e06a80928685ef14eb"
+    },
+    {
+      "bytes": 1154280,
+      "path": "lib/libLLVMX86AsmParser.a",
+      "sha256": "800bd4a554c21043887ec6cd537ec7db974400637431f3d075e340e3f8e03ce8"
+    },
+    {
+      "bytes": 11718504,
+      "path": "lib/libLLVMX86CodeGen.a",
+      "sha256": "526ab8c7712c4ccc6341c5106d3292c0f950bfe6a2bdda2df2caf3c90a055d0d"
+    },
+    {
+      "bytes": 3887972,
+      "path": "lib/libLLVMX86Desc.a",
+      "sha256": "a17cb8674c23deecb85f936f37a2b84cf814f21b6757aeb5a5ff14fabb6ba1d1"
+    },
+    {
+      "bytes": 2970764,
+      "path": "lib/libLLVMX86Disassembler.a",
+      "sha256": "46210ee81e2ab742382e595840be76e5c0eb946dbd8fd3079c6ce4b5569a0c5b"
+    },
+    {
+      "bytes": 6348,
+      "path": "lib/libLLVMX86Info.a",
+      "sha256": "2752e10986c3190b2a29970c7272a1978ea25e6d4d62795ad4b7e8c996da7ede"
+    },
+    {
+      "bytes": 8852948,
+      "path": "lib/libLLVMipo.a",
+      "sha256": "0e719fe19aaf73c0abfac00cc4cd7595195d8dec63e9581053cb27724f816a51"
+    },
+    {
+      "bytes": 830608,
+      "path": "lib/libclangAPINotes.a",
+      "sha256": "f9df2e7269d1940c6b0eeff64a106e700cb3db975bdec3d24c077238931aed6f"
+    },
+    {
+      "bytes": 31647946,
+      "path": "lib/libclangAST.a",
+      "sha256": "d7a6966432b9cfb7a40e81352e38dd843fd43e44f9bc0f30d6034c69b9fbae25"
+    },
+    {
+      "bytes": 2240340,
+      "path": "lib/libclangASTMatchers.a",
+      "sha256": "c6c5def0f0916ae88c2a08bec841b3023b2c33dd015e27e1f1468b50bd5dbd24"
+    },
+    {
+      "bytes": 5579656,
+      "path": "lib/libclangAnalysis.a",
+      "sha256": "20d9dffa9dcf73db5337138371fe70b68c2e6adc2706f88b22a57fef30f8f8d0"
+    },
+    {
+      "bytes": 632026,
+      "path": "lib/libclangAnalysisLifetimeSafety.a",
+      "sha256": "3dc3b5e7809404691e14287781549cbfbf59349ab0072bbecd6a52b54eaa1ea2"
+    },
+    {
+      "bytes": 9662006,
+      "path": "lib/libclangBasic.a",
+      "sha256": "3c167e5c8109dd7483561b5b780c378ef59b7b2817d83cdbd7cf42d0dac050b9"
+    },
+    {
+      "bytes": 19080122,
+      "path": "lib/libclangCodeGen.a",
+      "sha256": "41c165672743ab5927207c53948fd9d32e79bec9ff692e1b918c62570c1c650e"
+    },
+    {
+      "bytes": 120442,
+      "path": "lib/libclangCrossTU.a",
+      "sha256": "fe0af9c72eea8cc59afc55f4ca06af03c165ff30a376b6e58e446af2a02e54fc"
+    },
+    {
+      "bytes": 8156032,
+      "path": "lib/libclangDriver.a",
+      "sha256": "b6148a5895da3d64e0061ea0fc1a37376e132179d28010eda9e08ce483b5284e"
+    },
+    {
+      "bytes": 97466,
+      "path": "lib/libclangEdit.a",
+      "sha256": "f54233f7f7edc8b848ac3124a6f44ebbaf3210a4b9e507ebce6a17165300c21e"
+    },
+    {
+      "bytes": 1878588,
+      "path": "lib/libclangExtractAPI.a",
+      "sha256": "9c0cdfa3636cac10ecad8e04543116542d410a31c08e0a6bcf2641e2018d02cb"
+    },
+    {
+      "bytes": 2030320,
+      "path": "lib/libclangFormat.a",
+      "sha256": "ce472637f44e994c1bb448272f11885870c0ea6fa483588df99c2591c5a12a3c"
+    },
+    {
+      "bytes": 4625060,
+      "path": "lib/libclangFrontend.a",
+      "sha256": "60466b0675dbbcdea55cd80b336308cd461947e0ce88b9babcbb71d1e7c06c4c"
+    },
+    {
+      "bytes": 26028,
+      "path": "lib/libclangFrontendTool.a",
+      "sha256": "aa054dd7d5afccf776d3dce09e3530be42c01792d92033eade600a746bfc8cfe"
+    },
+    {
+      "bytes": 949536,
+      "path": "lib/libclangIndex.a",
+      "sha256": "092f0c86579645d41586ce090b868332368ae454012fc6470a2cc71c9465a0dd"
+    },
+    {
+      "bytes": 931856,
+      "path": "lib/libclangInstallAPI.a",
+      "sha256": "62c84408c9dd72d7ae5fb35a5fe9493d2aaaecf16ba018a5065a6a21abf06c3f"
+    },
+    {
+      "bytes": 2281632,
+      "path": "lib/libclangLex.a",
+      "sha256": "9cc487368596aaa78ac3dbb50c255a01746c4a327b0fa2f4eb9616b768ff9f4b"
+    },
+    {
+      "bytes": 620632,
+      "path": "lib/libclangOptions.a",
+      "sha256": "f2cda79b3f333f70894ab30da0db512e44186e08b1b8629cb9489ff0801985fd"
+    },
+    {
+      "bytes": 2961274,
+      "path": "lib/libclangParse.a",
+      "sha256": "4e15c8c96fa0db22c38c9db28859853722a011395fdd4b3e38f1cf979f392a5d"
+    },
+    {
+      "bytes": 114266,
+      "path": "lib/libclangRewrite.a",
+      "sha256": "df9429a6a403954518b6639eabdc51447bf4ddd375e7911276d15d5353f281ff"
+    },
+    {
+      "bytes": 225912,
+      "path": "lib/libclangRewriteFrontend.a",
+      "sha256": "b271535bc4a995fd2d6eb48ea9154b0076f8f95ef4c906b8e605453daf4a3f34"
+    },
+    {
+      "bytes": 33671800,
+      "path": "lib/libclangSema.a",
+      "sha256": "b0eabfe3a9e8c2874c4bf78b95b001a8f09b633f2e2812f8f0e6c99c671a70de"
+    },
+    {
+      "bytes": 4338926,
+      "path": "lib/libclangSerialization.a",
+      "sha256": "31e3a970f06d7de57084d26afbc656efe54cd1da17623ba977347f6f6e3d515c"
+    },
+    {
+      "bytes": 18499256,
+      "path": "lib/libclangStaticAnalyzerCheckers.a",
+      "sha256": "c811476567c0398dca6283c76887699a0546692b18be92a4e7dffb7028bae81a"
+    },
+    {
+      "bytes": 7809724,
+      "path": "lib/libclangStaticAnalyzerCore.a",
+      "sha256": "3d684f5132646a5341dda3f48865d323b6511d092c629e45687085d3a64dd21f"
+    },
+    {
+      "bytes": 693890,
+      "path": "lib/libclangStaticAnalyzerFrontend.a",
+      "sha256": "c053d52a6ac84b8ece15377a6b96527e324dddbbd23984dd7cbc8fa8202b4ea3"
+    },
+    {
+      "bytes": 90000,
+      "path": "lib/libclangSupport.a",
+      "sha256": "8fe9d1cfd91e310aecfe7918639ab1628a0c38a373e5351be3ac89cb66400095"
+    },
+    {
+      "bytes": 111888,
+      "path": "lib/libclangToolingCore.a",
+      "sha256": "b767d012aa7af5bbe1a6406720be1b2f567556a928931cdc18cf066ed2942133"
+    },
+    {
+      "bytes": 83868,
+      "path": "lib/libclangToolingInclusions.a",
+      "sha256": "77c92581acb5bb92e8324988e6525655dd87b9fa4bfe8a5390fa3e12a15df518"
+    },
+    {
+      "bytes": 3541,
+      "path": "link.rsp",
+      "sha256": "f4c66cf0578e6ae5baa2d2a970017f0f591dfd6969dead9f0c16ece8446184de"
+    },
+    {
+      "bytes": 1632,
+      "path": "sysroot/Scrt1.o",
+      "sha256": "476c1939cbc572be9ca35ac2592e24a57c636003dd6c2d2ed4138cecde2a2ff9"
+    },
+    {
+      "bytes": 2712,
+      "path": "sysroot/crtbeginS.o",
+      "sha256": "ea07ef74efdb770abf4c8d0fa94f0cb38ea98a94daa97b5c98e8d0d2c59a452b"
+    },
+    {
+      "bytes": 1128,
+      "path": "sysroot/crtendS.o",
+      "sha256": "bc82295c36d62dc2c812964d3375302d0faa15833b8d28a8924357607d301a87"
+    },
+    {
+      "bytes": 1072,
+      "path": "sysroot/crti.o",
+      "sha256": "78acef26a7007f5320c98633376f2903e33895e694fbc2b91d189b38addbca8a"
+    },
+    {
+      "bytes": 648,
+      "path": "sysroot/crtn.o",
+      "sha256": "121f2a5f12b13471dd8c7dabe3ff334df08540c270564d1a2b3c47ecbd8d3101"
+    },
+    {
+      "bytes": 215000,
+      "path": "sysroot/ld-linux-x86-64.so.2",
+      "sha256": "02bcda52c1a5dfc236f94d9e5255b4a0e26347d8a372a5223b650e31f291ce3c"
+    },
+    {
+      "bytes": 227,
+      "path": "sysroot/libc.so",
+      "sha256": "808d7734f6e449d896ee34cd1db678ed666260d7cd19bd2ed6a1b2ee0e83f618"
+    },
+    {
+      "bytes": 1926232,
+      "path": "sysroot/libc.so.6",
+      "sha256": "6b4a45352fd0c540a9c7c718f35ce8c8e46a4e482f9d3885a910c32d1a0e1421"
+    },
+    {
+      "bytes": 5098,
+      "path": "sysroot/libc_nonshared.a",
+      "sha256": "22a836e3aff767b559a703d42bde40fdb0e550297dbd99dd565f6a68b3ae8dda"
+    },
+    {
+      "bytes": 8,
+      "path": "sysroot/libdl.a",
+      "sha256": "f0a17a43c74d2fe5474fa2fd29c8f14799e777d7d75a2cc4d11c20a6e7b161c5"
+    },
+    {
+      "bytes": 3080764,
+      "path": "sysroot/libgcc.a",
+      "sha256": "525f1bab26ddfe18ab442e3e51723b57417265f2804a65ddf3cc87b34eea856b"
+    },
+    {
+      "bytes": 135,
+      "path": "sysroot/libgcc_s.so",
+      "sha256": "8ecba4e125a2ce55a56ce526fa9096fefe92d841ab62dbde606ba56b5c833554"
+    },
+    {
+      "bytes": 125312,
+      "path": "sysroot/libgcc_s.so.1",
+      "sha256": "2bd1552c47799ef67e701e81d4383061fd76059868e446e63560f0dd0d5ec14e"
+    },
+    {
+      "bytes": 95,
+      "path": "sysroot/libm.so",
+      "sha256": "fcdcdd83297e09826e913692eff6774bbb82759559f9e5bf0b59f7d615287596"
+    },
+    {
+      "bytes": 911904,
+      "path": "sysroot/libm.so.6",
+      "sha256": "7f2ca87f652f56b094462474b076749e90e689d0ecb9cb63c7679820b271b4e7"
+    },
+    {
+      "bytes": 1019408,
+      "path": "sysroot/libmvec.so.1",
+      "sha256": "1d3a6cfc6a5699b323adf25b53b62e128447661ae8ea1d46de88d0743a9599c5"
+    },
+    {
+      "bytes": 8,
+      "path": "sysroot/librt.a",
+      "sha256": "f0a17a43c74d2fe5474fa2fd29c8f14799e777d7d75a2cc4d11c20a6e7b161c5"
+    },
+    {
+      "bytes": 2190440,
+      "path": "sysroot/libstdc++.so",
+      "sha256": "e7848e32af4932840ba775169041759a2a8dd5a008af360e5c55bce506eebcf4"
+    },
+    {
+      "bytes": 121280,
+      "path": "sysroot/libz.so",
+      "sha256": "7e2a72b4c4b38c61e6962de6e3f4a5e9ae692e732c68deead10a7ce2135a7f68"
+    },
+    {
+      "bytes": 763816,
+      "path": "sysroot/libzstd.so",
+      "sha256": "37412b7ac11063c25a375bdff6f4fdb340362f926cd9c3a55962e8a9c9bc702e"
+    },
+    {
+      "bytes": 63048,
+      "path": "tools/clang/tools/driver/CMakeFiles/clang.dir/cc1_main.cpp.o",
+      "sha256": "3a900cf876420f8b93915a493ba59cb3b687b4775c2ab2af035b996ce30f0ee6"
+    },
+    {
+      "bytes": 66176,
+      "path": "tools/clang/tools/driver/CMakeFiles/clang.dir/cc1as_main.cpp.o",
+      "sha256": "0dc498281b85dd90a4c5303508d5f9c14f97b9b1159620e74518923fece3772f"
+    },
+    {
+      "bytes": 36536,
+      "path": "tools/clang/tools/driver/CMakeFiles/clang.dir/cc1gen_reproducer_main.cpp.o",
+      "sha256": "53961bd6b5745136c2585c2e9ba40b8fbfffcab5d615919bdbbf1bb23c1cabd6"
+    },
+    {
+      "bytes": 1912,
+      "path": "tools/clang/tools/driver/CMakeFiles/clang.dir/clang-driver.cpp.o",
+      "sha256": "a1577d6dd1aa20409240c167ddaf4e842378a5a741b07979046c4a42e52e24a3"
+    },
+    {
+      "bytes": 42184,
+      "path": "tools/clang/tools/driver/CMakeFiles/clang.dir/driver.cpp.o",
+      "sha256": "1dedd0d2a57b72245bcc70214ba63484140fa69837c3e66ff1ed7979c9cf11c1"
+    }
+  ],
+  "link": {
+    "arguments": [
+      "--no-fork",
+      "-o",
+      "{OUTPUT}",
+      "@{CORPUS}/link.rsp"
+    ],
+    "cwd": ".",
+    "environment": {
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "/usr/bin:/bin"
+    },
+    "response_files": [
+      "link.rsp"
+    ],
+    "stderr_utf8": "",
+    "stdout_utf8": ""
+  },
+  "oracle": {
+    "arguments": [
+      "{OUTPUT}",
+      "-cc1",
+      "-triple",
+      "x86_64-unknown-linux-gnu",
+      "-emit-obj",
+      "-x",
+      "c",
+      "/dev/null",
+      "-o",
+      "/dev/null"
+    ],
+    "exit_code": 0,
+    "stderr_utf8": "",
+    "stdout_utf8": ""
+  },
+  "platform": "x86_64-unknown-linux-gnu",
+  "replay": {
+    "identity_runs_per_side": 2,
+    "target_seconds": 30.0,
+    "warmup_runs": 1
+  },
+  "schema_version": 1,
+  "source": {
+    "peeled_commit": "ca7933e47d3a3451d81e72ac174dcb5aa28b59d1",
+    "repository": "https://github.com/llvm/llvm-project.git",
+    "tag": "llvmorg-22.1.8",
+    "tag_object": "e013073558445169e8732e25fa86e9913bfdd24e"
+  }
+}

--- a/ci/clang-link-corpus.lock.json
+++ b/ci/clang-link-corpus.lock.json
@@ -2,7 +2,7 @@
   "archive": {
     "bytes": 73413916,
     "sha256": "beb1f73eaab4257572ff60d04f08391b605990e4377c5d137fbf254db8ad5440",
-    "url": null
+    "url": "https://github.com/zackees/reld/releases/download/clang-link-corpus-llvmorg-22.1.8-v1/reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.tar.zst"
   },
   "builder": {
     "build_argv": [
@@ -56,10 +56,10 @@
       "packages_full_sha256": "92cd621156f4cdaabe2cb93746efabb3919b1b6d6d4d82f3c770ef14954d773e",
       "post_strip_manifest_asset": "reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.post-strip-manifest.json",
       "post_strip_manifest_sha256": "b9d3c2ccaad7fce5e3bfb87b0b03bfd5ee9cc13ddadb881391de06f9fbd04386",
-      "post_strip_manifest_url": "pending",
+      "post_strip_manifest_url": "https://github.com/zackees/reld/releases/download/clang-link-corpus-llvmorg-22.1.8-v1/reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.post-strip-manifest.json",
       "pre_strip_manifest_asset": "reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.pre-strip-manifest.json",
       "pre_strip_manifest_sha256": "d3e152030d709c41d313b00c463e46218c246f7a60a8e9587e6694e20e9039ae",
-      "pre_strip_manifest_url": "pending",
+      "pre_strip_manifest_url": "https://github.com/zackees/reld/releases/download/clang-link-corpus-llvmorg-22.1.8-v1/reld-clang-link-corpus-llvmorg-22.1.8-x86_64-linux-gnu.pre-strip-manifest.json",
       "python": "Python 3.11.2",
       "source_tree": "1e4fdb95266974a0cbca9ec4c6f740488322f238",
       "strip": "GNU strip (GNU Binutils for Debian) 2.40",

--- a/ci/clang_link_replay.py
+++ b/ci/clang_link_replay.py
@@ -1,0 +1,657 @@
+"""Validate and replay the immutable Linux LLVM/Clang final-link corpus.
+
+This is intentionally separate from :mod:`ci.benchmark_runner`: the published benchmark matrix
+builds a small project on every supported platform, while this runner consumes one large,
+precompiled Linux corpus.  Archive acquisition, extraction, native execution, and evidence
+writing are outside every measured interval.  Only the final linker process is timed.
+
+The repository does not contain a placeholder URL or digest.  Until a real corpus is published,
+pass its lock with ``--lock`` and its local archive with ``--archive``.  A published lock may name
+an immutable GitHub Release URL, in which case ``--archive`` is optional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import shutil
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable
+
+from ci.benchmark_assets import extract_archive, sha256_file
+
+
+LOCK_SCHEMA_VERSION = 1
+OUTPUT_TOKEN = "{OUTPUT}"
+CORPUS_TOKEN = "{CORPUS}"
+TARGET_SECONDS = 30.0
+IDENTITY_RUNS_PER_SIDE = 2
+WARMUP_RUNS = 1
+CHUNK = 1 << 20
+
+
+class ReplayError(RuntimeError):
+    """The corpus lock, artifact gate, native oracle, or replay failed."""
+
+
+@dataclass(frozen=True)
+class NativeOracle:
+    arguments: tuple[str, ...]
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+
+
+@dataclass(frozen=True)
+class LinkRecipe:
+    arguments: tuple[str, ...]
+    cwd: str
+    environment: dict[str, str]
+    stdout: bytes
+    stderr: bytes
+
+
+def _require_dict(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReplayError(f"{name} must be an object")
+    return value
+
+
+def _require_list(value: object, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ReplayError(f"{name} must be an array")
+    return value
+
+
+def _require_string(value: object, name: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        suffix = " a string" if allow_empty else " a non-empty string"
+        raise ReplayError(f"{name} must be{suffix}")
+    return value
+
+
+def _require_int(value: object, name: str, *, minimum: int = 0) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise ReplayError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_sha256(value: object, name: str) -> str:
+    digest = _require_string(value, name)
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ReplayError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_git_oid(value: object, name: str) -> str:
+    oid = _require_string(value, name)
+    if len(oid) != 40 or any(character not in "0123456789abcdef" for character in oid):
+        raise ReplayError(f"{name} must be a full lowercase 40-character Git object ID")
+    return oid
+
+
+def _safe_relative_path(value: object, name: str, *, allow_dot: bool = False) -> str:
+    raw = _require_string(value, name)
+    path = PurePosixPath(raw)
+    if path.is_absolute() or ".." in path.parts or "\\" in raw:
+        raise ReplayError(f"{name} must be a safe POSIX path relative to the corpus root")
+    if (raw == "." and not allow_dot) or (raw != "." and str(path) != raw):
+        raise ReplayError(f"{name} must be a normalized POSIX relative path")
+    return raw
+
+
+def _require_string_map(value: object, name: str) -> dict[str, str]:
+    mapping = _require_dict(value, name)
+    result: dict[str, str] = {}
+    for key, item in mapping.items():
+        if not isinstance(key, str) or not key:
+            raise ReplayError(f"{name} keys must be non-empty strings")
+        result[key] = _require_string(item, f"{name}.{key}", allow_empty=True)
+    return result
+
+
+def validate_lock(lock: dict[str, Any]) -> None:
+    """Validate the complete immutable-corpus contract without touching the network."""
+    if lock.get("schema_version") != LOCK_SCHEMA_VERSION:
+        raise ReplayError(f"schema_version must be {LOCK_SCHEMA_VERSION}")
+    if lock.get("platform") != "x86_64-unknown-linux-gnu":
+        raise ReplayError("platform must be exactly 'x86_64-unknown-linux-gnu'")
+
+    source = _require_dict(lock.get("source"), "source")
+    for field in ("repository", "tag"):
+        _require_string(source.get(field), f"source.{field}")
+    _require_git_oid(source.get("tag_object"), "source.tag_object")
+    _require_git_oid(source.get("peeled_commit"), "source.peeled_commit")
+
+    builder = _require_dict(lock.get("builder"), "builder")
+    image = _require_string(builder.get("image"), "builder.image")
+    image_digest = image.rsplit("@sha256:", 1)[1] if "@sha256:" in image else ""
+    if len(image_digest) != 64 or any(
+        character not in "0123456789abcdef" for character in image_digest
+    ):
+        raise ReplayError("builder.image must pin an image by @sha256 digest")
+    packages = _require_list(builder.get("packages"), "builder.packages")
+    if not packages:
+        raise ReplayError("builder.packages must record at least one exact package version")
+    for index, package in enumerate(packages):
+        package = _require_string(package, f"builder.packages[{index}]")
+        if "=" not in package:
+            raise ReplayError(f"builder.packages[{index}] must include an exact version with '='")
+    for field in ("configure_argv", "build_argv"):
+        values = _require_list(builder.get(field), f"builder.{field}")
+        if not values:
+            raise ReplayError(f"builder.{field} must not be empty")
+        for index, value in enumerate(values):
+            _require_string(value, f"builder.{field}[{index}]")
+    toolchain = _require_string_map(builder.get("toolchain"), "builder.toolchain")
+    if not toolchain:
+        raise ReplayError("builder.toolchain must record the exact compiler and linker versions")
+
+    archive = _require_dict(lock.get("archive"), "archive")
+    _require_sha256(archive.get("sha256"), "archive.sha256")
+    _require_int(archive.get("bytes"), "archive.bytes", minimum=1)
+    url = archive.get("url")
+    if url is not None:
+        url = _require_string(url, "archive.url")
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https" or parsed.netloc != "github.com" or "/releases/download/" not in parsed.path:
+            raise ReplayError("archive.url must be an immutable HTTPS GitHub Release asset URL")
+
+    link = _require_dict(lock.get("link"), "link")
+    arguments = _require_list(link.get("arguments"), "link.arguments")
+    if not arguments:
+        raise ReplayError("link.arguments must contain the exact captured linker argument vector")
+    for index, argument in enumerate(arguments):
+        _require_string(argument, f"link.arguments[{index}]", allow_empty=True)
+    if sum(argument.count(OUTPUT_TOKEN) for argument in arguments) != 1:
+        raise ReplayError(f"link.arguments must contain {OUTPUT_TOKEN!r} exactly once")
+    for argument in arguments:
+        scrubbed = argument.replace(OUTPUT_TOKEN, "").replace(CORPUS_TOKEN, "")
+        if "{" in scrubbed or "}" in scrubbed:
+            raise ReplayError(f"link.arguments contains an unsupported template token: {argument!r}")
+    _safe_relative_path(link.get("cwd"), "link.cwd", allow_dot=True)
+    _require_string_map(link.get("environment"), "link.environment")
+    _require_string(link.get("stdout_utf8"), "link.stdout_utf8", allow_empty=True)
+    _require_string(link.get("stderr_utf8"), "link.stderr_utf8", allow_empty=True)
+
+    response_files = _require_list(link.get("response_files"), "link.response_files")
+    response_paths = {
+        _safe_relative_path(path, f"link.response_files[{index}]")
+        for index, path in enumerate(response_files)
+    }
+    if len(response_paths) != len(response_files):
+        raise ReplayError("link.response_files contains a duplicate path")
+
+    oracle = _require_dict(lock.get("oracle"), "oracle")
+    oracle_arguments = _require_list(oracle.get("arguments"), "oracle.arguments")
+    if not oracle_arguments:
+        raise ReplayError("oracle.arguments must not be empty")
+    for index, argument in enumerate(oracle_arguments):
+        _require_string(argument, f"oracle.arguments[{index}]", allow_empty=True)
+    if sum(argument.count(OUTPUT_TOKEN) for argument in oracle_arguments) != 1:
+        raise ReplayError(f"oracle.arguments must contain {OUTPUT_TOKEN!r} exactly once")
+    for argument in oracle_arguments:
+        scrubbed = argument.replace(OUTPUT_TOKEN, "").replace(CORPUS_TOKEN, "")
+        if "{" in scrubbed or "}" in scrubbed:
+            raise ReplayError(f"oracle.arguments contains an unsupported template token: {argument!r}")
+    _require_int(oracle.get("exit_code"), "oracle.exit_code")
+    _require_string(oracle.get("stdout_utf8"), "oracle.stdout_utf8", allow_empty=True)
+    _require_string(oracle.get("stderr_utf8"), "oracle.stderr_utf8", allow_empty=True)
+
+    replay = _require_dict(lock.get("replay"), "replay")
+    if replay.get("target_seconds") != TARGET_SECONDS:
+        raise ReplayError(f"replay.target_seconds must be exactly {TARGET_SECONDS}")
+    if replay.get("warmup_runs") != WARMUP_RUNS:
+        raise ReplayError(f"replay.warmup_runs must be exactly {WARMUP_RUNS}")
+    if replay.get("identity_runs_per_side") != IDENTITY_RUNS_PER_SIDE:
+        raise ReplayError(
+            f"replay.identity_runs_per_side must be exactly {IDENTITY_RUNS_PER_SIDE}"
+        )
+
+    files = _require_list(lock.get("files"), "files")
+    if not files:
+        raise ReplayError("files must contain the complete input closure")
+    file_paths: set[str] = set()
+    for index, raw_file in enumerate(files):
+        item = _require_dict(raw_file, f"files[{index}]")
+        path = _safe_relative_path(item.get("path"), f"files[{index}].path")
+        if path in file_paths:
+            raise ReplayError(f"files contains duplicate path {path!r}")
+        file_paths.add(path)
+        _require_sha256(item.get("sha256"), f"files[{index}].sha256")
+        _require_int(item.get("bytes"), f"files[{index}].bytes")
+    missing_responses = sorted(response_paths - file_paths)
+    if missing_responses:
+        raise ReplayError(f"response files are absent from the input closure: {missing_responses}")
+
+
+def load_lock(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ReplayError(
+            f"corpus lock does not exist: {path}; pass --lock for a real captured corpus"
+        )
+    try:
+        lock = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReplayError(f"unable to read corpus lock {path}: {error}") from error
+    lock = _require_dict(lock, "lock")
+    validate_lock(lock)
+    return lock
+
+
+def _download_archive(url: str, destination: Path) -> None:
+    request = urllib.request.Request(url, headers={"User-Agent": "reld-clang-link-replay/1"})
+    try:
+        with urllib.request.urlopen(request) as response, destination.open("wb") as output:  # noqa: S310
+            shutil.copyfileobj(response, output, length=CHUNK)
+    except OSError as error:
+        raise ReplayError(f"unable to download corpus archive {url}: {error}") from error
+
+
+def acquire_archive(lock: dict[str, Any], *, archive_override: Path | None, destination: Path) -> Path:
+    """Resolve a local override or immutable release URL, then verify size and SHA-256."""
+    archive = _require_dict(lock["archive"], "archive")
+    if archive_override is not None:
+        source = archive_override.resolve()
+        if not source.is_file():
+            raise ReplayError(f"corpus archive does not exist: {source}")
+    else:
+        url = archive.get("url")
+        if not url:
+            raise ReplayError(
+                "corpus archive is not published in this lock; pass --archive with the locally "
+                "built archive (the lock must still contain its real SHA-256 and byte size)"
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _download_archive(url, destination)
+        source = destination
+
+    actual_bytes = source.stat().st_size
+    if actual_bytes != archive["bytes"]:
+        raise ReplayError(
+            f"archive byte-size mismatch for {source}: expected {archive['bytes']}, got {actual_bytes}"
+        )
+    actual_sha256 = sha256_file(source)
+    if actual_sha256 != archive["sha256"]:
+        raise ReplayError(
+            f"archive SHA-256 mismatch for {source}: expected {archive['sha256']}, "
+            f"got {actual_sha256}"
+        )
+    return source
+
+
+def verify_input_closure(lock: dict[str, Any], corpus_root: Path) -> None:
+    """Require every archived regular file, and no unrecorded file, to match the lock."""
+    expected = {item["path"]: item for item in lock["files"]}
+    actual: dict[str, Path] = {}
+    for path in corpus_root.rglob("*"):
+        if path.is_symlink():
+            raise ReplayError(f"corpus input closure contains a symlink: {path}")
+        if path.is_file():
+            relative = path.relative_to(corpus_root).as_posix()
+            actual[relative] = path
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    if missing or extra:
+        raise ReplayError(f"corpus input closure differs from lock: missing={missing}, extra={extra}")
+    for relative, item in expected.items():
+        path = actual[relative]
+        actual_bytes = path.stat().st_size
+        if actual_bytes != item["bytes"]:
+            raise ReplayError(
+                f"input byte-size mismatch for {relative}: expected {item['bytes']}, got {actual_bytes}"
+            )
+        actual_sha256 = sha256_file(path)
+        if actual_sha256 != item["sha256"]:
+            raise ReplayError(
+                f"input SHA-256 mismatch for {relative}: expected {item['sha256']}, "
+                f"got {actual_sha256}"
+            )
+
+
+def extract_and_verify(lock: dict[str, Any], archive: Path, corpus_root: Path) -> None:
+    if corpus_root.exists() and any(corpus_root.iterdir()):
+        raise ReplayError(f"refusing to extract over non-empty corpus directory: {corpus_root}")
+    corpus_root.mkdir(parents=True, exist_ok=True)
+    try:
+        extract_archive(archive, corpus_root)
+    except (OSError, subprocess.SubprocessError, SystemExit) as error:
+        raise ReplayError(f"unable to extract corpus archive {archive}: {error}") from error
+    verify_input_closure(lock, corpus_root)
+
+
+def _expand(argument: str, *, corpus_root: Path, output: Path) -> str:
+    return argument.replace(CORPUS_TOKEN, str(corpus_root)).replace(OUTPUT_TOKEN, str(output))
+
+
+def link_recipe(lock: dict[str, Any]) -> LinkRecipe:
+    link = lock["link"]
+    return LinkRecipe(
+        arguments=tuple(link["arguments"]),
+        cwd=link["cwd"],
+        environment=dict(link["environment"]),
+        stdout=link["stdout_utf8"].encode("utf-8"),
+        stderr=link["stderr_utf8"].encode("utf-8"),
+    )
+
+
+def native_oracle(lock: dict[str, Any]) -> NativeOracle:
+    oracle = lock["oracle"]
+    return NativeOracle(
+        arguments=tuple(oracle["arguments"]),
+        exit_code=oracle["exit_code"],
+        stdout=oracle["stdout_utf8"].encode("utf-8"),
+        stderr=oracle["stderr_utf8"].encode("utf-8"),
+    )
+
+
+def _run_native_oracle(
+    output: Path,
+    *,
+    oracle: NativeOracle,
+    corpus_root: Path,
+    cwd: Path,
+    environment: dict[str, str],
+) -> None:
+    command = [_expand(argument, corpus_root=corpus_root, output=output) for argument in oracle.arguments]
+    try:
+        completed = subprocess.run(command, cwd=cwd, env=environment, capture_output=True, check=False)
+    except OSError as error:
+        raise ReplayError(f"unable to execute native oracle for {output}: {error}") from error
+    if (
+        completed.returncode != oracle.exit_code
+        or completed.stdout != oracle.stdout
+        or completed.stderr != oracle.stderr
+    ):
+        raise ReplayError(
+            f"native oracle mismatch for {output}: expected exit/stdout/stderr "
+            f"{oracle.exit_code}/{oracle.stdout!r}/{oracle.stderr!r}, got "
+            f"{completed.returncode}/{completed.stdout!r}/{completed.stderr!r}"
+        )
+
+
+def _link_and_validate(
+    linker: Path,
+    output: Path,
+    *,
+    recipe: LinkRecipe,
+    oracle: NativeOracle,
+    corpus_root: Path,
+    clock: Callable[[], float] = time.perf_counter,
+) -> float:
+    """Run one fixed final link and exact native oracle, timing only the linker subprocess."""
+    output.unlink(missing_ok=True)
+    cwd = corpus_root / recipe.cwd
+    arguments = [_expand(argument, corpus_root=corpus_root, output=output) for argument in recipe.arguments]
+    command = [str(linker), *arguments]
+    started = clock()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=recipe.environment,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as error:
+        raise ReplayError(f"unable to execute linker {linker}: {error}") from error
+    elapsed = clock() - started
+    if completed.returncode != 0 or completed.stdout != recipe.stdout or completed.stderr != recipe.stderr:
+        raise ReplayError(
+            f"link failed exact exit/stdout/stderr validation for {linker}: "
+            f"{completed.returncode}/{completed.stdout!r}/{completed.stderr!r}"
+        )
+    if not output.is_file() or output.stat().st_size == 0:
+        raise ReplayError(f"linker produced no non-empty output: {output}")
+    _run_native_oracle(
+        output,
+        oracle=oracle,
+        corpus_root=corpus_root,
+        cwd=cwd,
+        environment=recipe.environment,
+    )
+    return elapsed
+
+
+def first_differing_offset(left: Path, right: Path) -> int | None:
+    """Return the first raw-byte difference, including the common-prefix EOF offset."""
+    offset = 0
+    with left.open("rb") as left_handle, right.open("rb") as right_handle:
+        while True:
+            left_chunk = left_handle.read(CHUNK)
+            right_chunk = right_handle.read(CHUNK)
+            common = min(len(left_chunk), len(right_chunk))
+            for index in range(common):
+                if left_chunk[index] != right_chunk[index]:
+                    return offset + index
+            if len(left_chunk) != len(right_chunk):
+                return offset + common
+            if not left_chunk:
+                return None
+            offset += len(left_chunk)
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _identity_gate(
+    baseline: Path,
+    candidate: Path,
+    *,
+    lock: dict[str, Any],
+    corpus_root: Path,
+    output: Path,
+    artifact_dir: Path,
+) -> dict[str, Any]:
+    recipe = link_recipe(lock)
+    oracle = native_oracle(lock)
+    artifacts: list[Path] = []
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    for label, linker in (("baseline", baseline), ("candidate", candidate)):
+        for run in range(1, IDENTITY_RUNS_PER_SIDE + 1):
+            _link_and_validate(
+                linker,
+                output,
+                recipe=recipe,
+                oracle=oracle,
+                corpus_root=corpus_root,
+            )
+            retained = artifact_dir / f"{label}-{run}"
+            shutil.copyfile(output, retained)
+            artifacts.append(retained)
+
+    reference = artifacts[0]
+    hashes = {path.name: sha256_file(path) for path in artifacts}
+    for contender in artifacts[1:]:
+        difference = first_differing_offset(reference, contender)
+        if difference is not None:
+            failure = {
+                "status": "failed",
+                "reason": "raw artifact mismatch",
+                "reference": str(reference),
+                "contender": str(contender),
+                "first_differing_offset": difference,
+                "sha256": hashes,
+            }
+            _write_json(artifact_dir / "identity-failure.json", failure)
+            raise ReplayError(
+                f"raw artifact mismatch at offset {difference}: {reference} vs {contender}; "
+                f"all four artifacts and {artifact_dir / 'identity-failure.json'} were retained"
+            )
+    return {"status": "passed", "sha256": hashes, "artifacts": [str(path) for path in artifacts]}
+
+
+def run_replay(
+    lock: dict[str, Any],
+    *,
+    baseline: Path,
+    candidate: Path,
+    corpus_root: Path,
+    workdir: Path,
+    report_path: Path,
+    max_replays: int = 10_000,
+) -> dict[str, Any]:
+    """Gate two baseline/two candidate outputs, then time ~30 seconds of candidate links."""
+    validate_lock(lock)
+    if sys.platform != "linux":
+        raise ReplayError("the immutable Clang corpus replay is Linux-only")
+    for label, linker in (("baseline", baseline), ("candidate", candidate)):
+        if not linker.is_file():
+            raise ReplayError(f"{label} linker does not exist: {linker}")
+    if max_replays < 1:
+        raise ReplayError("max_replays must be positive")
+    verify_input_closure(lock, corpus_root)
+
+    output_dir = workdir / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / "clang"
+    identity = _identity_gate(
+        baseline,
+        candidate,
+        lock=lock,
+        corpus_root=corpus_root,
+        output=output,
+        artifact_dir=workdir / "identity-artifacts",
+    )
+
+    recipe = link_recipe(lock)
+    oracle = native_oracle(lock)
+    calibration_seconds = _link_and_validate(
+        candidate,
+        output,
+        recipe=recipe,
+        oracle=oracle,
+        corpus_root=corpus_root,
+    )
+    if not math.isfinite(calibration_seconds) or calibration_seconds <= 0:
+        raise ReplayError(f"invalid warmup calibration duration: {calibration_seconds}")
+    replay_count = max(1, round(TARGET_SECONDS / calibration_seconds))
+    if replay_count > max_replays:
+        raise ReplayError(
+            f"calibration requested {replay_count} replays, exceeding --max-replays={max_replays}"
+        )
+
+    samples: list[float] = []
+    for _ in range(replay_count):
+        samples.append(
+            _link_and_validate(
+                candidate,
+                output,
+                recipe=recipe,
+                oracle=oracle,
+                corpus_root=corpus_root,
+            )
+        )
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "status": "passed",
+        "timing_scope": "final linker subprocess only",
+        "target_seconds": TARGET_SECONDS,
+        "warmup_runs": WARMUP_RUNS,
+        "calibration_seconds": calibration_seconds,
+        "fixed_replay_count": replay_count,
+        "sample_seconds": samples,
+        "timed_total_seconds": sum(samples),
+        "identity": identity,
+        "baseline": {"path": str(baseline), "sha256": sha256_file(baseline)},
+        "candidate": {"path": str(candidate), "sha256": sha256_file(candidate)},
+        "corpus_archive_sha256": lock["archive"]["sha256"],
+        "source": lock["source"],
+        "builder": lock["builder"],
+        "link_arguments": list(recipe.arguments),
+        "link_environment": recipe.environment,
+        "native_oracle_after_every_link": True,
+        "runner": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": sys.version,
+        },
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _write_json(report_path, report)
+    return report
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    lock = load_lock(args.lock)
+    print(
+        f"valid Clang corpus lock: {args.lock} "
+        f"({len(lock['files'])} files, archive {lock['archive']['sha256']})"
+    )
+    return 0
+
+
+def _cmd_replay(args: argparse.Namespace) -> int:
+    lock = load_lock(args.lock)
+    workdir = args.workdir.resolve()
+    corpus_root = workdir / "corpus"
+    archive_url = lock["archive"].get("url")
+    archive_name = (
+        Path(urllib.parse.urlparse(archive_url).path).name
+        if archive_url
+        else "clang-link-corpus.tar.zst"
+    )
+    archive = acquire_archive(
+        lock,
+        archive_override=args.archive,
+        destination=workdir / "download" / archive_name,
+    )
+    extract_and_verify(lock, archive, corpus_root)
+    report = run_replay(
+        lock,
+        baseline=args.baseline.resolve(),
+        candidate=args.candidate.resolve(),
+        corpus_root=corpus_root,
+        workdir=workdir,
+        report_path=args.report.resolve(),
+        max_replays=args.max_replays,
+    )
+    print(
+        f"artifact gate passed; {report['fixed_replay_count']} link-only samples totaled "
+        f"{report['timed_total_seconds']:.3f}s; evidence: {args.report}"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-lock")
+    validate.add_argument("--lock", type=Path, required=True)
+    validate.set_defaults(func=_cmd_validate)
+
+    replay = subparsers.add_parser("replay")
+    replay.add_argument("--lock", type=Path, required=True)
+    replay.add_argument(
+        "--archive",
+        type=Path,
+        help="local archive override; required while lock.archive.url is unpublished",
+    )
+    replay.add_argument("--baseline", type=Path, required=True)
+    replay.add_argument("--candidate", type=Path, required=True)
+    replay.add_argument("--workdir", type=Path, required=True)
+    replay.add_argument("--report", type=Path, required=True)
+    replay.add_argument("--max-replays", type=int, default=10_000)
+    replay.set_defaults(func=_cmd_replay)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except ReplayError as error:
+        parser.exit(1, f"clang link replay failed: {error}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/clang_link_replay.py
+++ b/ci/clang_link_replay.py
@@ -172,6 +172,8 @@ def validate_lock(lock: dict[str, Any]) -> None:
         raise ReplayError("link.arguments must contain the exact captured linker argument vector")
     for index, argument in enumerate(arguments):
         _require_string(argument, f"link.arguments[{index}]", allow_empty=True)
+    if "--no-fork" not in arguments:
+        raise ReplayError("link.arguments must include '--no-fork' for link-process-only timing")
     if sum(argument.count(OUTPUT_TOKEN) for argument in arguments) != 1:
         raise ReplayError(f"link.arguments must contain {OUTPUT_TOKEN!r} exactly once")
     for argument in arguments:

--- a/ci/tests/test_clang_link_replay.py
+++ b/ci/tests/test_clang_link_replay.py
@@ -55,7 +55,7 @@ def _lock(
             "bytes": archive_bytes,
         },
         "link": {
-            "arguments": [f"@{{CORPUS}}/link.rsp", "-o", "{OUTPUT}"],
+            "arguments": ["--no-fork", f"@{{CORPUS}}/link.rsp", "-o", "{OUTPUT}"],
             "cwd": ".",
             "environment": {"LC_ALL": "C", "PATH": "/usr/bin"},
             "stdout_utf8": "",
@@ -119,12 +119,20 @@ def test_lock_requires_pinned_provenance_and_fixed_replay_contract(corpus_files)
 
 def test_lock_requires_exact_output_placeholder_and_complete_response_closure(corpus_files) -> None:
     lock = _lock(corpus_files)
-    lock["link"]["arguments"] = ["@{CORPUS}/link.rsp"]
+    lock["link"]["arguments"] = ["--no-fork", "@{CORPUS}/link.rsp"]
     with pytest.raises(ReplayError, match="exactly once"):
         validate_lock(lock)
 
     lock = _lock({"objects/input.o": b"ELF-object"})
     with pytest.raises(ReplayError, match="response files are absent"):
+        validate_lock(lock)
+
+
+def test_lock_requires_no_fork_for_link_process_timing(corpus_files) -> None:
+    lock = _lock(corpus_files)
+    lock["link"]["arguments"].remove("--no-fork")
+
+    with pytest.raises(ReplayError, match="must include '--no-fork'"):
         validate_lock(lock)
 
 

--- a/ci/tests/test_clang_link_replay.py
+++ b/ci/tests/test_clang_link_replay.py
@@ -1,0 +1,317 @@
+import hashlib
+import json
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+import ci.clang_link_replay as replay_module
+from ci.clang_link_replay import (
+    ReplayError,
+    _identity_gate,
+    _link_and_validate,
+    acquire_archive,
+    extract_and_verify,
+    first_differing_offset,
+    link_recipe,
+    native_oracle,
+    run_replay,
+    validate_lock,
+    verify_input_closure,
+)
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _lock(
+    files: dict[str, bytes],
+    *,
+    archive_sha256: str | None = None,
+    archive_bytes: int = 1,
+    archive_url: str | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "platform": "x86_64-unknown-linux-gnu",
+        "source": {
+            "repository": "https://github.com/llvm/llvm-project.git",
+            "tag": "llvmorg-22.1.8",
+            "tag_object": "a" * 40,
+            "peeled_commit": "b" * 40,
+        },
+        "builder": {
+            "image": f"example.invalid/builder@sha256:{'c' * 64}",
+            "packages": ["clang=22.1.8-1", "cmake=4.0.0-1"],
+            "configure_argv": ["cmake", "-G", "Ninja"],
+            "build_argv": ["ninja", "clang"],
+            "toolchain": {"cc": "clang version 22.1.8", "ld": "GNU ld 2.44"},
+        },
+        "archive": {
+            "url": archive_url,
+            "sha256": archive_sha256 or "d" * 64,
+            "bytes": archive_bytes,
+        },
+        "link": {
+            "arguments": [f"@{{CORPUS}}/link.rsp", "-o", "{OUTPUT}"],
+            "cwd": ".",
+            "environment": {"LC_ALL": "C", "PATH": "/usr/bin"},
+            "stdout_utf8": "",
+            "stderr_utf8": "",
+            "response_files": ["link.rsp"],
+        },
+        "oracle": {
+            "arguments": ["{OUTPUT}", "--version"],
+            "exit_code": 0,
+            "stdout_utf8": "clang version pinned\n",
+            "stderr_utf8": "",
+        },
+        "replay": {
+            "target_seconds": 30.0,
+            "warmup_runs": 1,
+            "identity_runs_per_side": 2,
+        },
+        "files": [
+            {"path": path, "sha256": _digest(data), "bytes": len(data)}
+            for path, data in sorted(files.items())
+        ],
+    }
+
+
+def _write_corpus(root: Path, files: dict[str, bytes]) -> None:
+    for relative, data in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+
+def _archive(tmp_path: Path, files: dict[str, bytes]) -> Path:
+    corpus = tmp_path / "source-corpus"
+    _write_corpus(corpus, files)
+    archive = tmp_path / "clang-link-corpus.tar.gz"
+    with tarfile.open(archive, "w:gz") as handle:
+        for path in sorted(corpus.rglob("*")):
+            if path.is_file():
+                handle.add(path, arcname=path.relative_to(corpus))
+    return archive
+
+
+@pytest.fixture
+def corpus_files() -> dict[str, bytes]:
+    return {"objects/input.o": b"ELF-object", "link.rsp": b"objects/input.o\n"}
+
+
+def test_lock_requires_pinned_provenance_and_fixed_replay_contract(corpus_files) -> None:
+    lock = _lock(corpus_files)
+    validate_lock(lock)
+
+    lock["builder"]["image"] = "ubuntu:24.04"
+    with pytest.raises(ReplayError, match="pin an image"):
+        validate_lock(lock)
+
+    lock = _lock(corpus_files)
+    lock["replay"]["target_seconds"] = 29.0
+    with pytest.raises(ReplayError, match="exactly 30.0"):
+        validate_lock(lock)
+
+
+def test_lock_requires_exact_output_placeholder_and_complete_response_closure(corpus_files) -> None:
+    lock = _lock(corpus_files)
+    lock["link"]["arguments"] = ["@{CORPUS}/link.rsp"]
+    with pytest.raises(ReplayError, match="exactly once"):
+        validate_lock(lock)
+
+    lock = _lock({"objects/input.o": b"ELF-object"})
+    with pytest.raises(ReplayError, match="response files are absent"):
+        validate_lock(lock)
+
+
+def test_unpublished_archive_requires_explicit_local_override(tmp_path, corpus_files) -> None:
+    lock = _lock(corpus_files)
+    validate_lock(lock)
+    with pytest.raises(ReplayError, match="pass --archive"):
+        acquire_archive(lock, archive_override=None, destination=tmp_path / "download.tar.gz")
+
+
+def test_local_archive_is_hashed_then_complete_closure_is_verified(tmp_path, corpus_files) -> None:
+    archive = _archive(tmp_path, corpus_files)
+    lock = _lock(
+        corpus_files,
+        archive_sha256=replay_module.sha256_file(archive),
+        archive_bytes=archive.stat().st_size,
+    )
+    validate_lock(lock)
+
+    acquired = acquire_archive(
+        lock,
+        archive_override=archive,
+        destination=tmp_path / "unused.tar.gz",
+    )
+    corpus = tmp_path / "extracted"
+    extract_and_verify(lock, acquired, corpus)
+    verify_input_closure(lock, corpus)
+
+    (corpus / "unrecorded.a").write_bytes(b"extra")
+    with pytest.raises(ReplayError, match=r"extra=\['unrecorded.a'\]"):
+        verify_input_closure(lock, corpus)
+
+
+def test_archive_tampering_fails_before_extraction(tmp_path, corpus_files) -> None:
+    archive = _archive(tmp_path, corpus_files)
+    lock = _lock(
+        corpus_files,
+        archive_sha256=replay_module.sha256_file(archive),
+        archive_bytes=archive.stat().st_size,
+    )
+    archive.write_bytes(b"x" * archive.stat().st_size)
+    with pytest.raises(ReplayError, match="SHA-256 mismatch"):
+        acquire_archive(lock, archive_override=archive, destination=tmp_path / "unused")
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [(b"same", b"same", None), (b"abc", b"axc", 1), (b"abc", b"abcd", 3)],
+)
+def test_first_differing_offset_includes_length_mismatch(tmp_path, left, right, expected) -> None:
+    left_path = tmp_path / "left"
+    right_path = tmp_path / "right"
+    left_path.write_bytes(left)
+    right_path.write_bytes(right)
+    assert first_differing_offset(left_path, right_path) == expected
+
+
+def test_link_timer_excludes_native_oracle(tmp_path, corpus_files, monkeypatch) -> None:
+    corpus = tmp_path / "corpus"
+    _write_corpus(corpus, corpus_files)
+    lock = _lock(corpus_files)
+    recipe = link_recipe(lock)
+    oracle = native_oracle(lock)
+    output = tmp_path / "output" / "clang"
+    output.parent.mkdir()
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        assert kwargs["capture_output"] is True
+        if len(calls) == 1:
+            output.write_bytes(b"ELF-executable")
+            return subprocess.CompletedProcess(command, 0, b"", b"")
+        return subprocess.CompletedProcess(command, 0, b"clang version pinned\n", b"")
+
+    ticks = iter((10.0, 10.25))
+    monkeypatch.setattr(replay_module.subprocess, "run", fake_run)
+    elapsed = _link_and_validate(
+        tmp_path / "reld",
+        output,
+        recipe=recipe,
+        oracle=oracle,
+        corpus_root=corpus,
+        clock=lambda: next(ticks),
+    )
+
+    assert elapsed == 0.25
+    assert calls[0][0] == str(tmp_path / "reld")
+    assert calls[1] == [str(output), "--version"]
+
+
+def test_native_oracle_requires_exact_bytes(tmp_path, corpus_files, monkeypatch) -> None:
+    corpus = tmp_path / "corpus"
+    _write_corpus(corpus, corpus_files)
+    output = tmp_path / "clang"
+    output.write_bytes(b"ELF")
+
+    monkeypatch.setattr(
+        replay_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, b"wrong\n", b""),
+    )
+    with pytest.raises(ReplayError, match="native oracle mismatch"):
+        replay_module._run_native_oracle(
+            output,
+            oracle=native_oracle(_lock(corpus_files)),
+            corpus_root=corpus,
+            cwd=corpus,
+            environment={},
+        )
+
+
+def test_identity_gate_retains_all_four_outputs_and_first_offset(tmp_path, corpus_files, monkeypatch) -> None:
+    corpus = tmp_path / "corpus"
+    _write_corpus(corpus, corpus_files)
+    output = tmp_path / "output"
+    artifacts = tmp_path / "artifacts"
+    payloads = iter((b"aa", b"aa", b"ab", b"ab"))
+
+    def fake_link(*args, **kwargs):
+        del args
+        kwargs.pop("recipe")
+        kwargs.pop("oracle")
+        kwargs.pop("corpus_root")
+        output.write_bytes(next(payloads))
+        return 1.0
+
+    monkeypatch.setattr(replay_module, "_link_and_validate", fake_link)
+    with pytest.raises(ReplayError, match="offset 1"):
+        _identity_gate(
+            tmp_path / "baseline",
+            tmp_path / "candidate",
+            lock=_lock(corpus_files),
+            corpus_root=corpus,
+            output=output,
+            artifact_dir=artifacts,
+        )
+
+    assert {path.name for path in artifacts.iterdir()} == {
+        "baseline-1",
+        "baseline-2",
+        "candidate-1",
+        "candidate-2",
+        "identity-failure.json",
+    }
+    failure = json.loads((artifacts / "identity-failure.json").read_text())
+    assert failure["first_differing_offset"] == 1
+
+
+def test_replay_uses_one_warmup_to_fix_count_and_times_only_candidate_links(
+    tmp_path, corpus_files, monkeypatch
+) -> None:
+    corpus = tmp_path / "corpus"
+    _write_corpus(corpus, corpus_files)
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.write_bytes(b"baseline-binary")
+    candidate.write_bytes(b"candidate-binary")
+    report_path = tmp_path / "report.json"
+    durations = iter((10.0, 9.0, 10.0, 11.0))
+    calls: list[Path] = []
+
+    monkeypatch.setattr(
+        replay_module,
+        "_identity_gate",
+        lambda *args, **kwargs: {"status": "passed", "sha256": {}, "artifacts": []},
+    )
+
+    def fake_link(linker, *args, **kwargs):
+        del args, kwargs
+        calls.append(linker)
+        return next(durations)
+
+    monkeypatch.setattr(replay_module, "_link_and_validate", fake_link)
+    report = run_replay(
+        _lock(corpus_files),
+        baseline=baseline,
+        candidate=candidate,
+        corpus_root=corpus,
+        workdir=tmp_path / "work",
+        report_path=report_path,
+    )
+
+    assert calls == [candidate, candidate, candidate, candidate]
+    assert report["calibration_seconds"] == 10.0
+    assert report["fixed_replay_count"] == 3
+    assert report["sample_seconds"] == [9.0, 10.0, 11.0]
+    assert report["timed_total_seconds"] == 30.0
+    assert report["timing_scope"] == "final linker subprocess only"
+    assert json.loads(report_path.read_text())["native_oracle_after_every_link"] is True

--- a/ci/tests/test_clang_link_workflow.py
+++ b/ci/tests/test_clang_link_workflow.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "clang-link-replay.yml"
+
+
+def test_clang_replay_is_a_separate_manual_linux_workflow() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in text
+    assert "pull_request:" not in text
+    assert "schedule:" not in text
+    assert "benchmark-stats.yml" in text
+    assert "runs-on: ubuntu-24.04" in text
+    assert "windows" not in text.lower()
+    assert "macos" not in text.lower()
+
+
+def test_clang_replay_pins_baseline_toolchain_and_lock() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "6ec92be6674d026e74f7524271fbcbce68b50a39" in text
+    assert (
+        "rust:1.95.0-bookworm@sha256:"
+        "6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1"
+    ) in text
+    assert "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" in text
+    assert "astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d" in text
+    assert "python-version: \"3.12.11\"" in text
+    assert "CORPUS_LOCK: ci/clang-link-corpus.lock.json" in text
+    assert "validate-lock --lock \"$CORPUS_LOCK\"" in text
+
+
+def test_clang_replay_builds_matching_non_git_version_provenance() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'git archive "$BASELINE_SHA" | tar -xf -' in text
+    assert "git archive HEAD | tar -xf -" in text
+    assert 'test ! -e "$RUNNER_TEMP/reld-baseline/.git"' in text
+    assert 'test ! -e "$RUNNER_TEMP/reld-candidate/.git"' in text
+    assert text.count("cargo build --locked --release --package reld --bin reld") == 2
+    assert 'cmp "$EVIDENCE_DIR/baseline-version.txt"' in text
+    assert 'grep -F "non-git-build"' in text
+
+
+def test_clang_replay_acquires_locked_asset_and_uploads_failure_evidence() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    validate_at = text.index("validate-lock")
+    replay_at = text.index("ci.clang_link_replay replay")
+
+    assert validate_at < replay_at
+    assert "--archive" not in text
+    assert '--baseline "$EVIDENCE_DIR/baseline-reld"' in text
+    assert '--candidate "$EVIDENCE_DIR/candidate-reld"' in text
+    assert '--report "$EVIDENCE_DIR/replay-report.json"' in text
+    assert "if: always()" in text
+    assert "target/clang-link-replay/identity-artifacts/" in text
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in text
+
+
+def test_clang_replay_never_builds_llvm_or_times_compilation() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "llvm-project" not in text
+    assert "ninja" not in text
+    assert "cmake" not in text
+    assert "benchmark_runner" not in text
+    assert "--trials" not in text

--- a/ci/tests/test_clang_link_workflow.py
+++ b/ci/tests/test_clang_link_workflow.py
@@ -27,6 +27,8 @@ def test_clang_replay_pins_baseline_toolchain_and_lock() -> None:
     assert "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" in text
     assert "astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d" in text
     assert "python-version: \"3.12.11\"" in text
+    assert "zstd=1.5.4+dfsg2-5" in text
+    assert "SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt" in text
     assert "CORPUS_LOCK: ci/clang-link-corpus.lock.json" in text
     assert "validate-lock --lock \"$CORPUS_LOCK\"" in text
 

--- a/crates/reld-core/src/compression.rs
+++ b/crates/reld-core/src/compression.rs
@@ -363,7 +363,7 @@ fn build_regular_debug_section<A: Arch<Platform = Elf>>(
         .group_layouts
         .iter()
         .map(|group| {
-            let size: usize = group.file_sizes[part_range.clone()].iter().sum();
+            let size: usize = group.file_sizes.values_in_range(part_range.clone()).sum();
             let group_buf = remaining.split_off_mut(..size).unwrap();
             (group, group_buf)
         })

--- a/crates/reld-core/src/elf.rs
+++ b/crates/reld-core/src/elf.rs
@@ -710,7 +710,7 @@ impl platform::Platform for Elf {
     }
 
     fn validate_sizes(mem_sizes: &OutputSectionPartMap<u64>) -> Result {
-        if *mem_sizes.get(part_id::GNU_VERSION) > 0 {
+        if mem_sizes.get(part_id::GNU_VERSION) > 0 {
             let num_dynamic_symbols =
                 mem_sizes.get(part_id::DYNSYM) / crate::elf::SYMTAB_ENTRY_SIZE;
             let num_versym = mem_sizes.get(part_id::GNU_VERSION) / size_of::<Versym>() as u64;
@@ -727,7 +727,7 @@ impl platform::Platform for Elf {
 
     fn finalise_group_layout(memory_offsets: &OutputSectionPartMap<u64>) -> Self::GroupLayoutExt {
         GroupLayoutExt {
-            eh_frame_start_address: *memory_offsets.get(part_id::EH_FRAME),
+            eh_frame_start_address: memory_offsets.get(part_id::EH_FRAME),
         }
     }
 
@@ -735,7 +735,7 @@ impl platform::Platform for Elf {
         // References to symbols defined in .eh_frame are a bit weird, since it's a section where
         // we're GCing stuff, but crtbegin.o and crtend.o use them in order to find the start and
         // end of the whole .eh_frame section.
-        *memory_offsets.get(part_id::EH_FRAME)
+        memory_offsets.get(part_id::EH_FRAME)
     }
 
     fn finalise_find_required_sections<'data>(
@@ -845,7 +845,7 @@ impl platform::Platform for Elf {
                 .section_layouts
                 .get(output_section_id::GNU_VERSION_R);
 
-            is_last_verneed = *memory_offsets.get(part_id::GNU_VERSION_R)
+            is_last_verneed = memory_offsets.get(part_id::GNU_VERSION_R)
                 == version_r_layout.mem_offset + version_r_layout.mem_size;
         }
 
@@ -1629,7 +1629,7 @@ impl platform::Platform for Elf {
         format_specific: &Self::FinaliseSizesExt<'_>,
         args: &ElfArgs,
     ) -> Result {
-        if format_specific.has_eh_frame_input || *current_sizes.get(part_id::EH_FRAME) != 0 {
+        if format_specific.has_eh_frame_input || current_sizes.get(part_id::EH_FRAME) != 0 {
             extra_sizes.increment(part_id::EH_FRAME, size_of::<u32>() as u64);
             state.needs_eh_frame_terminator = true;
         }
@@ -1638,7 +1638,7 @@ impl platform::Platform for Elf {
             allocate_sysv_hash(state, current_sizes, extra_sizes, dynamic_symbol_defs)?;
         }
         if args.is_relr_enabled() {
-            let got_relr_size = *current_sizes.get(part_id::GOT_RELR);
+            let got_relr_size = current_sizes.get(part_id::GOT_RELR);
             let n = got_relr_size / RELR_ENTRY_SIZE;
             let relr_entries = got_relr_bitmap_relr_count(n);
             if relr_entries > 0 {
@@ -1653,7 +1653,7 @@ impl platform::Platform for Elf {
         extra_sizes: &mut OutputSectionPartMap<u64>,
         args: &ElfArgs,
     ) -> Result {
-        if args.should_write_eh_frame_hdr && *current_sizes.get(part_id::EH_FRAME_HDR) != 0 {
+        if args.should_write_eh_frame_hdr && current_sizes.get(part_id::EH_FRAME_HDR) != 0 {
             extra_sizes.increment(part_id::EH_FRAME_HDR, size_of::<EhFrameHdr>() as u64);
         }
         Ok(())
@@ -1956,7 +1956,7 @@ impl platform::Platform for Elf {
         }
 
         let tlsld_got_entry = prelude.format_specific.needs_tlsld_got_entry.then(|| {
-            let address = NonZeroU64::new(*memory_offsets.get(part_id::GOT))
+            let address = NonZeroU64::new(memory_offsets.get(part_id::GOT))
                 .expect("GOT address must never be zero");
             memory_offsets.increment(part_id::GOT, elf::GOT_ENTRY_SIZE * 2);
             address
@@ -2590,7 +2590,7 @@ impl platform::Platform for Elf {
         let locals = group_sizes.get(part_id::SYMTAB_LOCAL) / symtab_entry_size;
         let globals = group_sizes.get(part_id::SYMTAB_GLOBAL) / symtab_entry_size;
 
-        let mut extra_sizes = OutputSectionPartMap::with_size(group_sizes.num_parts());
+        let mut extra_sizes = group_sizes.new_empty_like();
         extra_sizes.increment(
             part_id::SYMTAB_SHNDX_LOCAL,
             locals * symtab_shndx_entry_size,
@@ -3443,7 +3443,7 @@ fn allocate_sysv_hash(
     let bucket_count = (num_defs / 2).max(1).next_power_of_two() as u32;
     // Whereas `num_defs` above is the number of definitions, this is the number of dynamic
     // symbols, which also includes undefined dynamic symbols.
-    let num_dynsym = *current_sizes.get(part_id::DYNSYM) / SYMTAB_ENTRY_SIZE;
+    let num_dynsym = current_sizes.get(part_id::DYNSYM) / SYMTAB_ENTRY_SIZE;
     let chain_count = num_dynsym
         .try_into()
         .context("Too many dynamic symbols for .hash")?;
@@ -5939,19 +5939,19 @@ fn got_relr_bitmap_relr_count(n: u64) -> u64 {
 }
 
 fn allocate_got(num_entries: u64, memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT)).unwrap();
+    let got_address = NonZeroU64::new(memory_offsets.get(part_id::GOT)).unwrap();
     memory_offsets.increment(part_id::GOT, elf::GOT_ENTRY_SIZE * num_entries);
     got_address
 }
 
 fn allocate_got_relr(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT_RELR)).unwrap();
+    let got_address = NonZeroU64::new(memory_offsets.get(part_id::GOT_RELR)).unwrap();
     memory_offsets.increment(part_id::GOT_RELR, elf::GOT_ENTRY_SIZE);
     got_address
 }
 
 fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let plt_address = NonZeroU64::new(*memory_offsets.get(part_id::PLT_GOT)).unwrap();
+    let plt_address = NonZeroU64::new(memory_offsets.get(part_id::PLT_GOT)).unwrap();
     memory_offsets.increment(part_id::PLT_GOT, elf::PLT_ENTRY_SIZE);
     plt_address
 }

--- a/crates/reld-core/src/elf_writer.rs
+++ b/crates/reld-core/src/elf_writer.rs
@@ -691,7 +691,7 @@ impl<'out> VersionWriter<'out> {
             return Err(excessive_allocation(
                 ".gnu.version",
                 versym.len() as u64 * elf::GNU_VERSION_ENTRY_SIZE,
-                *mem_sizes.get(part_id::GNU_VERSION),
+                mem_sizes.get(part_id::GNU_VERSION),
             ));
         }
         if !self.version_r.is_empty() {
@@ -861,7 +861,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         {
             *got_entry = 0;
             debug_assert_bail!(
-                *compute_allocations::<Elf>(res, self.output_kind, args)
+                compute_allocations::<Elf>(res, self.output_kind, args)
                     .get(part_id::RELA_DYN_GENERAL)
                     > 0,
                 "Tried to write glob-dat with no allocation. {}",
@@ -941,7 +941,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             *got_entry = address.wrapping_sub(A::tp_offset_start(layout));
         } else {
             debug_assert_bail!(
-                *compute_allocations::<Elf>(res, self.output_kind, layout.args())
+                compute_allocations::<Elf>(res, self.output_kind, layout.args())
                     .get(part_id::RELA_DYN_GENERAL)
                     > 0,
                 "Tried to write tpoff with no allocation. {}",
@@ -965,7 +965,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             *got_entry = 0;
             let dynamic_symbol_index = res.dynamic_symbol_index.map_or(0, std::num::NonZero::get);
             debug_assert_bail!(
-                *compute_allocations::<Elf>(res, self.output_kind, args)
+                compute_allocations::<Elf>(res, self.output_kind, args)
                     .get(part_id::RELA_DYN_GENERAL)
                     > 0,
                 "Tried to write dtpmod with no allocation. {}",
@@ -1009,7 +1009,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
 
         let dynamic_symbol_index = res.dynamic_symbol_index.map_or(0, std::num::NonZero::get);
         debug_assert_bail!(
-            *compute_allocations::<Elf>(res, self.output_kind, args).get(part_id::RELA_DYN_GENERAL)
+            compute_allocations::<Elf>(res, self.output_kind, args).get(part_id::RELA_DYN_GENERAL)
                 > 0,
             "Tried to write TLS descriptor with no allocation. {}",
             res.flags
@@ -1096,28 +1096,28 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             return Err(excessive_allocation(
                 ".got",
                 self.got.len() as u64 * elf::GOT_ENTRY_SIZE,
-                *mem_sizes.get(part_id::GOT),
+                mem_sizes.get(part_id::GOT),
             ));
         }
         if !self.got_relr.is_empty() {
             return Err(excessive_allocation(
                 ".got (relr)",
                 self.got_relr.len() as u64 * elf::GOT_ENTRY_SIZE,
-                *mem_sizes.get(part_id::GOT_RELR),
+                mem_sizes.get(part_id::GOT_RELR),
             ));
         }
         if !self.rela_dyn_relative.is_empty() {
             return Err(excessive_allocation(
                 ".rela.dyn (relative)",
                 self.rela_dyn_relative.len() as u64 * elf::RELA_ENTRY_SIZE,
-                *mem_sizes.get(part_id::RELA_DYN_RELATIVE),
+                mem_sizes.get(part_id::RELA_DYN_RELATIVE),
             ));
         }
         if !self.rela_dyn_general.is_empty() {
             return Err(excessive_allocation(
                 ".rela.dyn (general)",
                 self.rela_dyn_general.len() as u64 * elf::RELA_ENTRY_SIZE,
-                *mem_sizes.get(part_id::RELA_DYN_GENERAL),
+                mem_sizes.get(part_id::RELA_DYN_GENERAL),
             ));
         }
         if let Some(relr_dyn) = &self.relr_dyn
@@ -1126,7 +1126,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             return Err(excessive_allocation(
                 ".relr.dyn",
                 relr_dyn.len() as u64 * elf::RELR_ENTRY_SIZE,
-                *mem_sizes.get(part_id::RELR_DYN),
+                mem_sizes.get(part_id::RELR_DYN),
             ));
         }
         self.dynsym_writer.check_exhausted()?;
@@ -1136,21 +1136,21 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             return Err(excessive_allocation(
                 ".eh_frame",
                 self.eh_frame.len() as u64,
-                *mem_sizes.get(part_id::EH_FRAME),
+                mem_sizes.get(part_id::EH_FRAME),
             ));
         }
         if !self.eh_frame_hdr.is_empty() {
             return Err(excessive_allocation(
                 ".eh_frame_hdr",
                 self.eh_frame_hdr.len() as u64,
-                *mem_sizes.get(part_id::EH_FRAME_HDR),
+                mem_sizes.get(part_id::EH_FRAME_HDR),
             ));
         }
         if !self.dynamic.out.is_empty() {
             return Err(excessive_allocation(
                 ".dynamic",
                 std::mem::size_of_val(self.dynamic.out) as u64,
-                *mem_sizes.get(part_id::DYNAMIC),
+                mem_sizes.get(part_id::DYNAMIC),
             ));
         }
         Ok(())

--- a/crates/reld-core/src/layout.rs
+++ b/crates/reld-core/src/layout.rs
@@ -193,7 +193,6 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
 
     finalise_all_sizes::<P, A>(
         &mut group_states,
-        &output_sections,
         &atomic_per_symbol_flags,
         &finalise_sizes_resources,
     )?;
@@ -242,7 +241,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
 
     let got_relr_n = A::Platform::GOT_RELR_SECTION_ID
         .and_then(A::Platform::single_part_id)
-        .map_or(0, |part_id| *section_part_sizes.get(part_id) / 8);
+        .map_or(0, |part_id| section_part_sizes.get(part_id) / 8);
 
     let thunk_blocks = thunk_layout_builder
         .map(|builder| {
@@ -326,10 +325,12 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
     {
         let last_part_id =
             PartId::from_usize(last_section_id.part_id_range::<P>().end.as_usize() - 1);
+
         let extra_file_size = A::Platform::last_part_size_to_extend(
-            section_part_layouts.get(last_part_id),
+            &section_part_layouts.get(last_part_id),
             last_part_id,
         )?;
+
         if extra_file_size > 0 {
             section_part_sizes.increment(last_part_id, extra_file_size as u64);
 
@@ -631,7 +632,6 @@ fn update_dynamic_symbol_resolutions<'data, P: Platform>(
 
 fn finalise_all_sizes<'data, P: Platform, A: Arch<Platform = P>>(
     group_states: &mut [GroupState<'data, P>],
-    output_sections: &OutputSections<P>,
     per_symbol_flags: &AtomicPerSymbolFlags,
     resources: &FinaliseSizesResources<'data, '_, P>,
 ) -> Result {
@@ -639,7 +639,7 @@ fn finalise_all_sizes<'data, P: Platform, A: Arch<Platform = P>>(
 
     group_states.par_iter_mut().try_for_each(|state| {
         verbose_timing_phase!("Finalise sizes for group");
-        state.finalise_sizes::<A>(output_sections, per_symbol_flags, resources)
+        state.finalise_sizes::<A>(per_symbol_flags, resources)
     })
 }
 
@@ -1035,7 +1035,7 @@ pub(crate) fn compute_allocations<P: Platform>(
     args: &P::Args,
 ) -> OutputSectionPartMap<u64> {
     let mut sizes =
-        OutputSectionPartMap::with_size(crate::part_id::regular_part_base::<P>().as_usize());
+        OutputSectionPartMap::with_dense_size(crate::part_id::regular_part_base::<P>().as_usize());
     P::allocate_resolution(resolution.flags, &mut sizes, output_kind, args);
     sizes
 }
@@ -1286,7 +1286,7 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
         .flatten()
         {
             if let Some(part_id) = P::single_part_id(section_id) {
-                memory_offsets.increment(part_id, *self.mem_sizes.get(part_id));
+                memory_offsets.increment(part_id, self.mem_sizes.get(part_id));
             }
         }
 
@@ -1813,11 +1813,7 @@ fn compute_start_offsets_by_group<P: Platform>(
 
     group_states
         .iter()
-        .map(|group| {
-            let group_mem_starts = mem_offsets.clone();
-            mem_offsets.merge(&group.common.mem_sizes);
-            group_mem_starts
-        })
+        .map(|group| mem_offsets.merge_and_return_start_offsets(&group.common.mem_sizes))
         .collect_vec()
 }
 
@@ -2146,8 +2142,7 @@ fn allocate_thunk_block_space<P: Platform>(
     let emit_symbols = !symbol_db.args.should_strip_all();
 
     for group_state in group_states.iter_mut() {
-        let mut extra_thunk_sizes: OutputSectionPartMap<u64> =
-            OutputSectionPartMap::with_size(total_sizes.num_parts());
+        let mut extra_thunk_sizes: OutputSectionPartMap<u64> = total_sizes.new_empty_like();
         for file in &group_state.files {
             if let FileLayoutState::Object(obj) = file
                 && let Some(config) = P::file_thunk_config(obj.object)
@@ -2468,17 +2463,11 @@ impl<'data, P: Platform> GroupState<'data, P> {
 
     fn finalise_sizes<A: Arch<Platform = P>>(
         &mut self,
-        output_sections: &OutputSections<P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         for file_state in &mut self.files {
-            file_state.finalise_sizes::<A>(
-                &mut self.common,
-                output_sections,
-                per_symbol_flags,
-                resources,
-            )?;
+            file_state.finalise_sizes::<A>(&mut self.common, per_symbol_flags, resources)?;
         }
 
         self.common.validate_sizes()?;
@@ -2529,7 +2518,7 @@ impl<'data, P: Platform> GroupState<'data, P> {
                 let start = (memory_offsets.get(part_id)
                     - resources.section_layouts.get(section_id).mem_offset)
                     as u32;
-                memory_offsets.increment(part_id, *self.common.mem_sizes.get(part_id));
+                memory_offsets.increment(part_id, self.common.mem_sizes.get(part_id));
                 start
             });
 
@@ -2678,13 +2667,12 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
     fn finalise_sizes<A: Arch<Platform = P>>(
         &mut self,
         common: &mut CommonGroupState<'data, P>,
-        output_sections: &OutputSections<P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         match self {
             FileLayoutState::Object(s) => {
-                s.finalise_sizes(common, output_sections, per_symbol_flags, resources)?;
+                s.finalise_sizes(common, per_symbol_flags, resources)?;
                 s.finalise_symbol_sizes::<A>(common, per_symbol_flags, resources)?;
             }
             FileLayoutState::Dynamic(s) => {
@@ -3226,7 +3214,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
         // Total section  sizes have already been computed. So any allocations we do need to update
         // both `total_sizes` and the size records in `common`. We track the extra sizes in
         // `extra_sizes` which we can then later add to both.
-        let mut extra_sizes = OutputSectionPartMap::with_size(common.mem_sizes.num_parts());
+        let mut extra_sizes = common.mem_sizes.new_empty_like();
 
         self.determine_header_sizes(
             total_sizes,
@@ -3916,7 +3904,7 @@ impl<'data, P: Platform> EpilogueLayoutState<P> {
         total_sizes: &mut OutputSectionPartMap<u64>,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
-        let mut extra_sizes = OutputSectionPartMap::with_size(common.mem_sizes.num_parts());
+        let mut extra_sizes = common.mem_sizes.new_empty_like();
         for sec in resources.script_sorted_sections {
             extra_sizes.increment(sec.part_id, sec.size);
         }
@@ -4289,11 +4277,9 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
     fn finalise_sizes(
         &mut self,
         common: &mut CommonGroupState<'data, P>,
-        output_sections: &OutputSections<P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
-        common.mem_sizes.resize(output_sections.num_parts());
         if !resources.symbol_db.args.should_strip_all() {
             self.allocate_symtab_space(common, resources.symbol_db, per_symbol_flags)?;
         }
@@ -4349,7 +4335,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         for (slot, &part_id) in self.sections.iter_mut().zip(object_part_ids) {
             let resolution = match slot {
                 SectionSlot::Loaded(sec) => {
-                    let address = *memory_offsets.get(part_id);
+                    let address = memory_offsets.get(part_id);
 
                     // TODO: We probably need to be able to handle sections that are ifuncs and
                     // sections that need a TLS GOT struct.
@@ -4371,7 +4357,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                 },
 
                 &mut SectionSlot::LoadedDebugInfo(sec) => {
-                    let address = *memory_offsets.get(part_id);
+                    let address = memory_offsets.get(part_id);
                     *memory_offsets.get_mut(part_id) +=
                         sec.capacity(part_id, resources.output_sections);
                     SectionResolution { address }
@@ -4915,7 +4901,7 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                                         object::SectionIndex(sec_idx),
                                         &symbol_db.section_part_ids,
                                     );
-                                    addresses[sec_idx] = *offsets.get(part_id);
+                                    addresses[sec_idx] = offsets.get(part_id);
                                     *offsets.get_mut(part_id) +=
                                         sec.capacity(part_id, output_sections);
                                 }
@@ -5018,8 +5004,7 @@ fn relaxation_scan_pass<'data, A: Arch>(
             .par_iter_mut()
             .enumerate()
             .map(|(group_idx, group)| {
-                let mut reductions =
-                    OutputSectionPartMap::with_size(section_part_sizes.num_parts());
+                let mut reductions = section_part_sizes.new_empty_like();
                 let mut file_rescans: Vec<SmallVec<[(usize, u64); 16]>> =
                     Vec::with_capacity(group.files.len());
 
@@ -5137,9 +5122,8 @@ fn relaxation_scan_pass<'data, A: Arch>(
     let mut total_deleted = 0u64;
     let mut next_rescan_candidates: RescanCandidates = Vec::with_capacity(group_results.len());
     for (reduction, file_rescans) in group_results {
-        for (idx, &amount) in reduction.parts.iter().enumerate() {
+        for (part_id, &amount) in reduction.iter() {
             if amount > 0 {
-                let part_id = PartId::from_usize(idx);
                 section_part_sizes.decrement(part_id, amount);
                 total_deleted += amount;
             }
@@ -5430,119 +5414,131 @@ fn compute_layout_sections<'data, P: Platform>(
                 }
                 lma_offset = mem_offset;
 
-                records_out[part_id_range.clone()]
-                    .iter_mut()
-                    .zip(&sizes[part_id_range.clone()])
-                    .enumerate()
-                    .try_for_each(|(offset, (part_layout, &part_size))| -> Result {
-                        let part_id = part_id_range.start.offset(offset);
-                        let alignment = part_id.alignment(output_sections).min(max_alignment);
-                        let merge_target = output_sections.primary_output_section(section_id);
-                        let section_flags = output_sections.section_flags(merge_target);
-                        let mem_size = if Some(section_id) == P::RELRO_PADDING_SECTION_ID {
-                            let page_alignment = args.loadable_segment_alignment();
-                            let aligned_offset = page_alignment.align_up(mem_offset);
-                            aligned_offset - mem_offset
-                        } else {
-                            part_size
-                        };
+                let mut is_first_part = true;
 
-                        // Note, we align up even if our size is zero, otherwise our section will
-                        // start at an unaligned address. We don't however align up for NOBITS
-                        // sections.
-                        if output_sections.has_data_in_file(merge_target) {
-                            file_offset = alignment.align_up_usize(file_offset);
-                        }
+                let merge_target = output_sections.primary_output_section(section_id);
+                let section_flags = output_sections.section_flags(merge_target);
 
-                        if section_flags.is_alloc() {
-                            if args.should_output_partial_object() {
-                                let file_size = if output_sections.has_data_in_file(merge_target) {
-                                    mem_size as usize
-                                } else {
-                                    0
-                                };
+                let mut part_sizes = sizes
+                    .in_range(part_id_range.clone())
+                    .map(|(id, &size)| (id, size))
+                    .peekable();
 
-                                let section_id = part_id.output_section_id::<P>();
-                                let part_mem_offset =
-                                    alignment.align_up(*reloc_alloc_mem_offsets.get(section_id));
-                                *reloc_alloc_mem_offsets.get_mut(section_id) =
-                                    part_mem_offset + mem_size;
+                // For sections with only empty parts, make sure we run the loop below at least once
+                // so as to properly initialise the section's layout.
+                let empty_part = part_sizes
+                    .peek()
+                    .is_none()
+                    .then_some((part_id_range.start, 0));
 
-                                *part_layout = OutputRecordLayout {
-                                    file_size,
-                                    mem_size,
-                                    alignment,
-                                    file_offset,
-                                    mem_offset: part_mem_offset,
-                                    lma_offset: part_mem_offset,
-                                };
+                for (part_id, part_size) in part_sizes.chain(empty_part) {
+                    let part_layout = records_out.get_mut(part_id);
+                    let alignment = part_id.alignment(output_sections).min(max_alignment);
+                    let mem_size = if Some(section_id) == P::RELRO_PADDING_SECTION_ID {
+                        let page_alignment = args.loadable_segment_alignment();
+                        let aligned_offset = page_alignment.align_up(mem_offset);
+                        aligned_offset - mem_offset
+                    } else {
+                        part_size
+                    };
 
-                                file_offset += file_size;
+                    // Note, we align up even if our size is zero, otherwise our section will
+                    // start at an unaligned address. We don't however align up for NOBITS
+                    // sections.
+                    if output_sections.has_data_in_file(merge_target) {
+                        file_offset = alignment.align_up_usize(file_offset);
+                    }
+
+                    if section_flags.is_alloc() {
+                        if args.should_output_partial_object() {
+                            let file_size = if output_sections.has_data_in_file(merge_target) {
+                                mem_size as usize
                             } else {
-                                mem_offset = alignment.align_up(mem_offset);
-                                lma_offset = alignment.align_up(lma_offset);
+                                0
+                            };
 
-                                let file_size = if output_sections.has_data_in_file(merge_target) {
-                                    mem_size as usize
-                                } else {
-                                    0
-                                };
-
-                                *part_layout = OutputRecordLayout {
-                                    file_size,
-                                    mem_size,
-                                    alignment,
-                                    file_offset,
-                                    mem_offset,
-                                    lma_offset,
-                                };
-
-                                file_offset += file_size;
-                                mem_offset += mem_size;
-                                lma_offset += mem_size;
-                            }
-                        } else {
                             let section_id = part_id.output_section_id::<P>();
-                            let mem_offset =
-                                alignment.align_up(*nonalloc_mem_offsets.get(section_id));
-
-                            *nonalloc_mem_offsets.get_mut(section_id) += mem_size;
+                            let part_mem_offset =
+                                alignment.align_up(*reloc_alloc_mem_offsets.get(section_id));
+                            *reloc_alloc_mem_offsets.get_mut(section_id) =
+                                part_mem_offset + mem_size;
 
                             *part_layout = OutputRecordLayout {
-                                file_size: mem_size as usize,
+                                file_size,
+                                mem_size,
+                                alignment,
+                                file_offset,
+                                mem_offset: part_mem_offset,
+                                lma_offset: part_mem_offset,
+                            };
+
+                            file_offset += file_size;
+                        } else {
+                            mem_offset = alignment.align_up(mem_offset);
+                            lma_offset = alignment.align_up(lma_offset);
+
+                            let file_size = if output_sections.has_data_in_file(merge_target) {
+                                mem_size as usize
+                            } else {
+                                0
+                            };
+
+                            *part_layout = OutputRecordLayout {
+                                file_size,
                                 mem_size,
                                 alignment,
                                 file_offset,
                                 mem_offset,
-                                lma_offset: mem_offset,
+                                lma_offset,
                             };
-                            file_offset += mem_size as usize;
-                        }
-                        layout_section_from_part_layouts(
-                            part_layout,
-                            section_layouts.get_mut(section_id),
-                            section_info,
-                            offset == 0,
-                        );
 
-                        if let Some(expr) = section_info
-                            .location_info
-                            .as_ref()
-                            .and_then(|info| info.at_location.as_ref())
-                        {
-                            lma_offset = expression_eval(
-                                expr,
-                                &SymbolLoc::None,
-                                memory_regions,
-                                &section_layouts,
-                                &resolved_lc,
-                            )?;
-                            part_layout.lma_offset = lma_offset;
-                            let section_layout = section_layouts.get_mut(section_id);
-                            section_layout.lma_offset = lma_offset;
+                            file_offset += file_size;
+                            mem_offset += mem_size;
+                            lma_offset += mem_size;
                         }
-                        Ok(())
-                    })?;
+                    } else {
+                        let section_id = part_id.output_section_id::<P>();
+                        let mem_offset = alignment.align_up(*nonalloc_mem_offsets.get(section_id));
+
+                        *nonalloc_mem_offsets.get_mut(section_id) += mem_size;
+
+                        *part_layout = OutputRecordLayout {
+                            file_size: mem_size as usize,
+                            mem_size,
+                            alignment,
+                            file_offset,
+                            mem_offset,
+                            lma_offset: mem_offset,
+                        };
+                        file_offset += mem_size as usize;
+                    }
+
+                    layout_section_from_part_layouts(
+                        part_layout,
+                        section_layouts.get_mut(section_id),
+                        section_info,
+                        is_first_part,
+                    );
+
+                    if let Some(expr) = section_info
+                        .location_info
+                        .as_ref()
+                        .and_then(|info| info.at_location.as_ref())
+                    {
+                        lma_offset = expression_eval(
+                            expr,
+                            &SymbolLoc::None,
+                            memory_regions,
+                            &section_layouts,
+                            &resolved_lc,
+                        )?;
+                        part_layout.lma_offset = lma_offset;
+                        let section_layout = section_layouts.get_mut(section_id);
+                        section_layout.lma_offset = lma_offset;
+                    }
+
+                    is_first_part = false;
+                }
 
                 if let Some(region_name) = section_info.region_name
                     && let Some(region) = memory_regions.get_mut(region_name)

--- a/crates/reld-core/src/macho.rs
+++ b/crates/reld-core/src/macho.rs
@@ -1888,13 +1888,13 @@ pub(crate) struct ResolutionExt {
 }
 
 fn allocate_got(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT)).unwrap();
+    let got_address = NonZeroU64::new(memory_offsets.get(part_id::GOT)).unwrap();
     memory_offsets.increment(part_id::GOT, GOT_ENTRY_SIZE);
     got_address
 }
 
 fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let plt_address = NonZeroU64::new(*memory_offsets.get(part_id::PLT_GOT)).unwrap();
+    let plt_address = NonZeroU64::new(memory_offsets.get(part_id::PLT_GOT)).unwrap();
     memory_offsets.increment(part_id::PLT_GOT, PLT_ENTRY_SIZE);
     plt_address
 }

--- a/crates/reld-core/src/output_section_id.rs
+++ b/crates/reld-core/src/output_section_id.rs
@@ -448,13 +448,14 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         self.section_infos.iter()
     }
 
-    pub(crate) fn num_parts(&self) -> usize {
-        crate::part_id::regular_part_base::<P>().as_usize()
-            + (self.num_sections() - regular_section_base::<P>().as_usize()) * NUM_ALIGNMENTS
-    }
-
+    // TODO: Experiment with adjusting the balance between dense and sparse sections. If we decide
+    // not to make it dynamic, then remove this method and construct part maps more directly.
+    #[allow(clippy::unused_self)]
     pub(crate) fn new_part_map<T: Default>(&self) -> OutputSectionPartMap<T> {
-        OutputSectionPartMap::with_size(self.num_parts())
+        OutputSectionPartMap::with_dense_size(
+            P::NUM_SINGLE_PART_SECTIONS as usize
+                + P::NUM_BUILT_IN_REGULAR_SECTIONS * NUM_ALIGNMENTS,
+        )
     }
 
     pub(crate) fn new_section_map<T: Default>(&self) -> OutputSectionMap<T> {

--- a/crates/reld-core/src/output_section_part_map.rs
+++ b/crates/reld-core/src/output_section_part_map.rs
@@ -5,10 +5,9 @@ use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputSections;
 use crate::part_id::PartId;
 use crate::platform::Platform;
+use std::collections::BTreeMap;
 use std::mem::take;
 use std::ops::AddAssign;
-use std::ops::Index;
-use std::ops::IndexMut;
 use std::ops::Range;
 
 /// A map from each part of each output section to some value. Different sections are split into
@@ -22,42 +21,93 @@ pub(crate) struct OutputSectionPartMap<T> {
     // This may be due to an extra pointer indirection and/or bounds checking. Experiment with
     // storing all our built-in parts in an array.
     #[debug(skip)]
-    pub(crate) parts: Vec<T>,
+    parts: Vec<T>,
+
+    #[debug(skip)]
+    sparse: Option<Box<SparsePartMap<T>>>,
+}
+
+#[derive(Clone, PartialEq, Eq, Default)]
+struct SparsePartMap<T> {
+    contents: BTreeMap<PartId, T>,
 }
 
 impl<T: Default> OutputSectionPartMap<T> {
-    pub(crate) fn with_size(size: usize) -> Self {
+    pub(crate) fn with_dense_size(size: usize) -> Self {
         let mut parts = Vec::new();
         parts.resize_with(size, Default::default);
-        Self { parts }
+        Self {
+            parts,
+            sparse: None,
+        }
     }
 }
 
-impl<T> Index<Range<PartId>> for OutputSectionPartMap<T> {
-    type Output = [T];
+pub(crate) enum RangeIterator<'a, T> {
+    Dense(PartId, &'a [T]),
+    Sparse(std::collections::btree_map::Range<'a, PartId, T>),
+}
 
-    fn index(&self, index: Range<PartId>) -> &Self::Output {
-        &self.parts[index.start.as_usize()..index.end.as_usize()]
+impl<'a, T> Iterator for RangeIterator<'a, T> {
+    type Item = (PartId, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            RangeIterator::Dense(part_id, items) => {
+                let item = items.split_off_first()?;
+                let id = *part_id;
+                *part_id = part_id.offset(1);
+                Some((id, item))
+            }
+            RangeIterator::Sparse(range) => range.next().map(|(&id, item)| (id, item)),
+        }
     }
 }
 
-impl<T> IndexMut<Range<PartId>> for OutputSectionPartMap<T> {
-    fn index_mut(&mut self, index: Range<PartId>) -> &mut Self::Output {
-        &mut self.parts[index.start.as_usize()..index.end.as_usize()]
-    }
-}
-
-impl<T> OutputSectionPartMap<T> {
-    pub(crate) fn num_parts(&self) -> usize {
-        self.parts.len()
+impl<T: Default> OutputSectionPartMap<T> {
+    pub(crate) fn new_empty_like<U: Default>(&self) -> OutputSectionPartMap<U> {
+        OutputSectionPartMap::with_dense_size(self.parts.len())
     }
 
     pub(crate) fn get_mut(&mut self, part_id: PartId) -> &mut T {
-        &mut self.parts[part_id.as_usize()]
+        self.parts.get_mut(part_id.as_usize()).unwrap_or_else(|| {
+            self.sparse
+                .get_or_insert_default()
+                .contents
+                .entry(part_id)
+                .or_default()
+        })
     }
 
-    pub(crate) fn get(&self, part_id: PartId) -> &T {
-        &self.parts[part_id.as_usize()]
+    /// Note, range must be either entirely dense or entirely sparse. Itended use-case is to get all
+    /// parts for a single section.
+    pub(crate) fn in_range(&self, range: Range<PartId>) -> RangeIterator<'_, T> {
+        if let Some(values) = self.parts.get(range.start.as_usize()..range.end.as_usize()) {
+            RangeIterator::Dense(range.start, values)
+        } else if let Some(sparse) = self.sparse.as_ref() {
+            RangeIterator::Sparse(sparse.contents.range(range))
+        } else {
+            RangeIterator::Sparse(Default::default())
+        }
+    }
+
+    pub(crate) fn values_in_range(&self, range: Range<PartId>) -> impl Iterator<Item = &T> {
+        self.in_range(range).map(|(_, v)| v)
+    }
+}
+
+impl<T: Default + Copy> OutputSectionPartMap<T> {
+    pub(crate) fn get(&self, part_id: PartId) -> T {
+        self.parts
+            .get(part_id.as_usize())
+            .copied()
+            .unwrap_or_else(|| {
+                self.sparse
+                    .as_ref()
+                    .and_then(|sparse| sparse.contents.get(&part_id))
+                    .copied()
+                    .unwrap_or_default()
+            })
     }
 }
 
@@ -80,6 +130,15 @@ impl OutputSectionPartMap<u64> {
         );
         *v -= size;
     }
+
+    /// Increment `self` by `sizes`, returning pre-increment values for the entries in `sizes`.
+    pub(crate) fn merge_and_return_start_offsets(&mut self, sizes: &Self) -> Self {
+        self.mut_with_map(sizes, |offset, size| {
+            let start = *offset;
+            *offset += *size;
+            start
+        })
+    }
 }
 
 impl<T: Default + PartialEq> OutputSectionPartMap<T> {
@@ -96,6 +155,15 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
                 .enumerate()
                 .map(|(i, value)| cb(PartId::from_usize(i), value))
                 .collect(),
+            sparse: self.sparse.as_ref().map(|sparse| {
+                Box::new(SparsePartMap {
+                    contents: sparse
+                        .contents
+                        .iter()
+                        .map(|(id, value)| (*id, cb(*id, value)))
+                        .collect(),
+                })
+            }),
         }
     }
 
@@ -110,7 +178,10 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
     ) -> OutputSectionPartMap<U> {
         let mut parts_out = Vec::new();
         parts_out.resize_with(self.parts.len(), U::default);
-        let mut output = OutputSectionPartMap { parts: parts_out };
+        let mut output = OutputSectionPartMap {
+            parts: parts_out,
+            sparse: None,
+        };
 
         for event in output_order {
             let OrderEvent::Section(section_id) = event else {
@@ -119,15 +190,11 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
 
             let part_id_range = section_id.part_id_range::<P>();
             let max_alignment = self.max_alignment(part_id_range.clone(), output_sections);
-            output[part_id_range.clone()]
-                .iter_mut()
-                .zip(&self[part_id_range.clone()])
-                .enumerate()
-                .for_each(|(offset, (out, input))| {
-                    let part_id = part_id_range.start.offset(offset);
-                    let alignment = part_id.alignment(output_sections).min(max_alignment);
-                    *out = cb(part_id, alignment, input);
-                });
+
+            for (part_id, input) in self.in_range(part_id_range.clone()) {
+                let alignment = part_id.alignment(output_sections).min(max_alignment);
+                *output.get_mut(part_id) = cb(part_id, alignment, input);
+            }
         }
 
         output
@@ -141,11 +208,10 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
         range: Range<PartId>,
         output_sections: &OutputSections<P>,
     ) -> Alignment {
-        self[range.clone()]
-            .iter()
-            .position(|p| *p != T::default())
-            .map_or(alignment::MIN, |o| {
-                range.start.offset(o).alignment(output_sections)
+        self.in_range(range.clone())
+            .find(|(_, value)| **value != T::default())
+            .map_or(alignment::MIN, |(part_id, _)| {
+                part_id.alignment(output_sections)
             })
             .max(
                 range
@@ -158,7 +224,7 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
     /// Zip mutable references to values in `self` with shared references from `other` producing a
     /// new map with the returned values. For custom sections, `other` must be a subset of `self`.
     /// Values not in `other` will not be in the returned map.
-    fn mut_with_map<U, V: Default>(
+    fn mut_with_map<U: Default, V: Default>(
         &mut self,
         other: &OutputSectionPartMap<U>,
         mut cb: impl FnMut(&mut T, &U) -> V,
@@ -170,23 +236,60 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
             .map(|(t, u)| cb(t, u))
             .collect();
 
-        OutputSectionPartMap { parts }
-    }
-}
+        let Some(other_sparse) = other.sparse.as_ref() else {
+            return OutputSectionPartMap {
+                parts,
+                sparse: None,
+            };
+        };
 
-impl<T: Default> OutputSectionPartMap<T> {
-    pub(crate) fn resize(&mut self, num_parts: usize) {
-        self.parts.resize_with(num_parts, Default::default);
+        let self_sparse = self.sparse.get_or_insert_with(|| {
+            Box::new(SparsePartMap {
+                contents: BTreeMap::new(),
+            })
+        });
+
+        let contents = other_sparse
+            .contents
+            .iter()
+            .map(|(part_id, right_value)| {
+                let left_value = self_sparse.contents.entry(*part_id).or_default();
+                (*part_id, cb(left_value, right_value))
+            })
+            .collect();
+
+        OutputSectionPartMap {
+            parts,
+            sparse: Some(Box::new(SparsePartMap { contents })),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (PartId, &T)> {
+        self.parts
+            .iter()
+            .enumerate()
+            .map(|(i, value)| (PartId::from_usize(i), value))
+            .chain(
+                self.sparse
+                    .as_ref()
+                    .map(|sparse| sparse.contents.iter())
+                    .unwrap_or_default()
+                    .map(|(part_id, value)| (*part_id, value)),
+            )
     }
 }
 
 impl<T: AddAssign + Copy + Default> OutputSectionPartMap<T> {
     pub(crate) fn merge(&mut self, rhs: &Self) {
-        if self.num_parts() < rhs.num_parts() {
-            self.resize(rhs.num_parts());
-        }
         for (left, right) in self.parts.iter_mut().zip(rhs.parts.iter()) {
             *left += *right;
+        }
+
+        if let Some(rhs_sparse) = rhs.sparse.as_ref() {
+            let lhs_sparse = self.sparse.get_or_insert_default();
+            for (part_id, right) in &rhs_sparse.contents {
+                *lhs_sparse.contents.entry(*part_id).or_default() += *right;
+            }
         }
     }
 }
@@ -224,7 +327,11 @@ fn test_merge_parts() {
         },
     );
 
-    let num_regular_sections = output_sections.num_regular_sections();
+    let num_regular_sections = output_sections
+        .ids_with_info()
+        .map(|(section_id, _)| section_id)
+        .filter(|section_id| section_id.is_regular::<Elf64>() && !section_id.is_custom::<Elf64>())
+        .count();
     let mut num_sections_with_17 = 0;
 
     let mut sum_of_1s = output_sections.new_section_map::<u32>();
@@ -235,7 +342,7 @@ fn test_merge_parts() {
             return;
         }
         let range = section_id.part_id_range::<Elf64>();
-        *sum = all_1[range].iter().sum();
+        *sum = all_1.values_in_range(range).sum();
     });
 
     let mut sum_of_sums = 0;
@@ -244,9 +351,13 @@ fn test_merge_parts() {
         if *sum == 17 {
             num_sections_with_17 += 1;
         }
+        let absent_custom_part = section_id.is_custom::<Elf64>();
         let unsupported_single_part = !section_id.is_regular::<Elf64>()
             && <Elf64 as crate::platform::Platform>::single_part_id(section_id).is_none();
-        if section_id == crate::output_section_id::UNMAPPED || unsupported_single_part {
+        if section_id == crate::output_section_id::UNMAPPED
+            || absent_custom_part
+            || unsupported_single_part
+        {
             assert!(*sum == 0, "Expected zero sum for section {section_id:?}");
         } else {
             assert!(*sum > 0, "Expected non-zero sum for section {section_id:?}");
@@ -266,7 +377,7 @@ fn test_merge_parts() {
             return;
         }
         let range = section_id.part_id_range::<Elf64>();
-        *sum = headers_only[range].iter().sum();
+        *sum = headers_only.values_in_range(range).sum();
     });
 
     assert_eq!(*merged.get(crate::output_section_id::FILE_HEADER), 42);
@@ -298,14 +409,27 @@ fn test_merge() {
 
 #[test]
 fn test_merge_with_custom_sections() {
-    let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf64>::for_testing();
+    use crate::elf::Elf64;
+
+    let output_sections = OutputSections::<Elf64>::for_testing();
     let mut m1 = output_sections.new_part_map::<u32>();
     let mut m2 = output_sections.new_part_map::<u32>();
-    assert_eq!(m2.num_parts(), output_sections.num_parts());
-    m2.resize(output_sections.num_parts() + 2);
+
+    let custom_parts = output_sections
+        .ids_with_info()
+        .map(|(section_id, _)| section_id)
+        .filter(|section_id| section_id.is_custom::<Elf64>())
+        .map(|section_id| section_id.part_id_with_alignment::<Elf64>(alignment::MIN))
+        .collect::<Vec<_>>();
+    assert!(!custom_parts.is_empty());
+    for (value, part_id) in custom_parts.iter().copied().rev().enumerate() {
+        *m2.get_mut(part_id) = (value + 1) as u32;
+    }
+
     m1.merge(&m2);
-    assert_eq!(m1.num_parts(), output_sections.num_parts() + 2);
+    for (value, part_id) in custom_parts.iter().copied().rev().enumerate() {
+        assert_eq!(m1.get(part_id), (value + 1) as u32);
+    }
 }
 
 /// Custom output sections are discovered from input files and may be extremely numerous. Their
@@ -315,7 +439,17 @@ fn test_custom_sections_do_not_expand_dense_prefix() {
     use crate::elf::Elf64;
 
     let output_sections = OutputSections::<Elf64>::for_testing();
-    let part_map = output_sections.new_part_map::<u32>();
+    let mut part_map = output_sections.new_part_map::<u32>();
+
+    let custom_sections = output_sections
+        .ids_with_info()
+        .map(|(section_id, _)| section_id)
+        .filter(|section_id| section_id.is_custom::<Elf64>())
+        .collect::<Vec<_>>();
+
+    for section_id in custom_sections.into_iter().rev() {
+        let _ = part_map.get_mut(section_id.part_id_with_alignment::<Elf64>(crate::alignment::MIN));
+    }
 
     assert_eq!(
         part_map.parts.len(),
@@ -343,7 +477,17 @@ fn test_output_order_map_consistent() {
             &[],
         )
         .unwrap();
-    let part_map = output_sections.new_part_map::<u32>();
+    let mut part_map = output_sections.new_part_map::<u32>();
+
+    let custom_sections = output_sections
+        .ids_with_info()
+        .map(|(section_id, _)| section_id)
+        .filter(|section_id| section_id.is_custom::<Elf64>())
+        .collect_vec();
+
+    for section_id in custom_sections.into_iter().rev() {
+        let _ = part_map.get_mut(section_id.part_id_with_alignment::<Elf64>(crate::alignment::MIN));
+    }
 
     // First, make sure that all our built-in part-ids are here. If they're not, we'd fail anyway,
     // but we can give a much better failure message if we check first.

--- a/crates/reld-core/src/output_section_part_map.rs
+++ b/crates/reld-core/src/output_section_part_map.rs
@@ -308,6 +308,22 @@ fn test_merge_with_custom_sections() {
     assert_eq!(m1.num_parts(), output_sections.num_parts() + 2);
 }
 
+/// Custom output sections are discovered from input files and may be extremely numerous. Their
+/// presence must not grow the eagerly allocated prefix of a new part map.
+#[test]
+fn test_custom_sections_do_not_expand_dense_prefix() {
+    use crate::elf::Elf64;
+
+    let output_sections = OutputSections::<Elf64>::for_testing();
+    let part_map = output_sections.new_part_map::<u32>();
+
+    assert_eq!(
+        part_map.parts.len(),
+        crate::part_id::built_in_part_ids::<Elf64>().count(),
+        "custom sections must be stored lazily rather than extending the dense prefix"
+    );
+}
+
 /// output_order_map and `OutputSections::sections_and_segments_events` used to each independently
 /// define the output order. This test made sure that they were consistent. Now the former uses the
 /// latter, so this test is less important. It's kept for the time being anyway.

--- a/crates/reld-core/src/string_merging.rs
+++ b/crates/reld-core/src/string_merging.rs
@@ -1115,7 +1115,7 @@ impl MergedStringStartAddresses {
             // We already have the offsets of each bucket relative to the start of the section. So
             // now we just need to add the section's start address to all of these.
             let base =
-                *internal_start_offsets.get(section_id.part_id_with_alignment::<P>(alignment::MIN));
+                internal_start_offsets.get(section_id.part_id_with_alignment::<P>(alignment::MIN));
             let bucket_offsets_out = addresses.get_mut(section_id);
             *bucket_offsets_out = sec.bucket_offsets;
             for offset in bucket_offsets_out {

--- a/crates/reld-core/src/thunks.rs
+++ b/crates/reld-core/src/thunks.rs
@@ -185,7 +185,7 @@ impl ThunkLayoutBuilder {
                 (0..section_id.num_parts::<P>()).map(move |i| base.offset(i))
             })
             .filter(|&part_id| part_id != self.primary_function_part_id)
-            .map(|part_id| *section_part_sizes.get(part_id))
+            .map(|part_id| section_part_sizes.get(part_id))
             .sum();
         non_primary_text_bytes
     }

--- a/crates/reld-core/src/verification.rs
+++ b/crates/reld-core/src/verification.rs
@@ -77,8 +77,7 @@ impl OffsetVerifier {
     }
 
     fn alignments_ok<P: Platform>(&self, output_sections: &OutputSections<P>) -> bool {
-        self.sizes.parts.iter().enumerate().all(|(i, size)| {
-            let part_id = PartId::from_usize(i);
+        self.sizes.iter().all(|(part_id, size)| {
             size.is_multiple_of(part_id.alignment(output_sections).value())
                 || should_ignore_alignment::<P>(part_id)
         })

--- a/crates/reld/tests/acceptance.rs
+++ b/crates/reld/tests/acceptance.rs
@@ -110,6 +110,8 @@
 //!
 //! RunEnabled:{bool} Defaults to true. Set to false to disable execution of the resulting binary.
 //!
+//! ExpectRunOutputEmpty:{bool} Require the executed binary to write no bytes to stdout or stderr.
+//!
 //! RunDynSym:{string} If set and RunEnabled:true, then, instead of executing the binary normally,
 //! the binary is loaded as a shared library and the function specified by the string is called. The
 //! function must return an integer to indicate status (status != 42 is an error). Such run is
@@ -574,7 +576,6 @@ fn is_deferred_legacy_directive(name: &str) -> bool {
             | "NoDynamic"
             | "NoProgramHeader"
             | "ReldExtraLinkArgs"
-            | "Relocatable"
             | "RelrCount"
             | "RemoveSection"
             | "RunDynSym"
@@ -649,6 +650,7 @@ struct ProgramInputs {
 struct Program<'a> {
     link_output: LinkOutput,
     assertions: &'a Assertions,
+    intermediates: Vec<LinkerInput>,
     shared_objects: Vec<LinkerInput>,
 }
 
@@ -1040,6 +1042,7 @@ struct Config {
     should_diff: bool,
     diff_match_any: bool,
     should_run: bool,
+    expect_run_output_empty: bool,
     run_dyn_sym: Option<String>,
     should_error: bool,
     expect_stderr: Vec<ErrorMatcher>,
@@ -1747,6 +1750,7 @@ impl Config {
             compiler: platform.default_c_compiler().to_owned(),
             should_diff: platform.diff_supported(),
             should_run: platform.can_execute_on_host(),
+            expect_run_output_empty: false,
             diff_match_any: false,
             run_dyn_sym: None,
             should_error: false,
@@ -1845,6 +1849,22 @@ fn parse_configs(src_filename: &Path, default_config: &Config) -> Result<Vec<Con
         bail!("Missing non-abstract Config");
     }
 
+    for config in &configs {
+        if config.expect_run_output_empty && !config.should_run {
+            bail!(
+                "Config `{}` sets ExpectRunOutputEmpty:true with RunEnabled:false",
+                config.config_name
+            );
+        }
+        if config.expect_run_output_empty && config.run_dyn_sym.is_some() {
+            bail!(
+                "Config `{}` sets ExpectRunOutputEmpty:true with RunDynSym, which does not capture \
+                 process output",
+                config.config_name
+            );
+        }
+    }
+
     Ok(configs)
 }
 
@@ -1864,6 +1884,7 @@ fn is_frozen_directive(name: &str) -> bool {
         "Config"
             | "AbstractConfig"
             | "Object"
+            | "Relocatable"
             | "Archive"
             | "Shared"
             | "LinkerScript"
@@ -1887,6 +1908,7 @@ fn is_frozen_directive(name: &str) -> bool {
             | "ExpectError"
             | "Contains"
             | "RunEnabled"
+            | "ExpectRunOutputEmpty"
             | "DiffEnabled"
             | "DiffIgnore"
             | "DiffMatchAny"
@@ -2158,6 +2180,11 @@ fn process_directive(
             config.diff_match_any = arg.parse().context("Invalid bool for DiffMatchAny")?
         }
         "RunEnabled" => config.should_run = arg.parse().context("Invalid bool for RunEnabled")?,
+        "ExpectRunOutputEmpty" => {
+            config.expect_run_output_empty = arg
+                .parse()
+                .context("Invalid bool for ExpectRunOutputEmpty")?
+        }
         "RunDynSym" => {
             config.run_dyn_sym = Some(arg.parse().context("Invalid string for RunDynSym")?)
         }
@@ -2402,9 +2429,14 @@ impl ProgramInputs {
             self.run_update_in_place_test(&inputs, config, cross_arch, &link_output)?;
         }
 
-        let shared_objects = inputs
+        let intermediates: Vec<_> = inputs
             .into_iter()
+            .filter(|input| input.command.is_some())
+            .collect();
+        let shared_objects = intermediates
+            .iter()
             .filter(|input| input.path.extension().is_some_and(|ext| ext == "so"))
+            .cloned()
             .collect();
 
         if !config.remove_sections.is_empty() {
@@ -2414,6 +2446,7 @@ impl ProgramInputs {
         Ok(Program {
             link_output,
             assertions: &config.assertions,
+            intermediates,
             shared_objects,
         })
     }
@@ -2602,7 +2635,7 @@ const TEST_BINARY_TIMEOUT: Duration = std::time::Duration::from_secs(10);
 const EXIT_SUCCESS: i32 = 42;
 
 impl Program<'_> {
-    fn run(&self, cross_arch: Option<Architecture>) -> Result {
+    fn run(&self, cross_arch: Option<Architecture>, expect_output_empty: bool) -> Result {
         let mut command = if let Some(arch) = cross_arch {
             let mut c = Command::new(format!("qemu-{arch}"));
             c.arg("-L");
@@ -2620,11 +2653,9 @@ impl Program<'_> {
             Command::new(&self.link_output.binary)
         };
 
-        // Similarly to cargo test, capture all the run-time output, since it may contain useful
-        // error messages. We only show it if the exit status is a failure since otherwise messages
-        // that are expected, e.g. panic messages, would be potentially confusing to see.
-        let (mut recv, send) = std::io::pipe()?;
-        command.stdout(send.try_clone()?).stderr(send);
+        // Similarly to cargo test, capture all run-time output so it can be checked or included in
+        // a failure diagnostic. Keep the streams separate so fixtures can require exact silence.
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         let spawn_result = spawn_with_retry(&mut command, Duration::from_secs(10));
 
@@ -2635,30 +2666,62 @@ impl Program<'_> {
             )
         })?;
 
-        // Drop pipes from command. While they are open, our `recv_to_end` call below can't finish.
-        command.stdout(Stdio::null());
-        command.stderr(Stdio::null());
-
-        let mut output = Vec::new();
+        let mut stdout_pipe = child
+            .stdout
+            .take()
+            .context("Failed to capture binary stdout")?;
+        let mut stderr_pipe = child
+            .stderr
+            .take()
+            .context("Failed to capture binary stderr")?;
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
 
         let status = std::thread::scope(|scope| -> Result<ExitStatus> {
-            scope.spawn(|| {
-                let _ = recv.read_to_end(&mut output);
+            let stdout_reader = scope.spawn(|| {
+                stdout_pipe
+                    .read_to_end(&mut stdout)
+                    .context("Failed to read binary stdout")
+            });
+            let stderr_reader = scope.spawn(|| {
+                stderr_pipe
+                    .read_to_end(&mut stderr)
+                    .context("Failed to read binary stderr")
             });
 
-            match child.wait_timeout(TEST_BINARY_TIMEOUT)? {
-                Some(s) => Ok(s),
+            let status = match child.wait_timeout(TEST_BINARY_TIMEOUT)? {
+                Some(s) => s,
                 None => {
                     child.kill()?;
                     bail!("Binary ran for too long");
                 }
-            }
+            };
+
+            stdout_reader
+                .join()
+                .map_err(|_| error!("Binary stdout reader panicked"))??;
+            stderr_reader
+                .join()
+                .map_err(|_| error!("Binary stderr reader panicked"))??;
+
+            Ok(status)
         })?;
 
-        let output = String::from_utf8_lossy(&output);
+        let stdout_display = String::from_utf8_lossy(&stdout);
+        let stderr_display = String::from_utf8_lossy(&stderr);
 
         if status.code() != Some(EXIT_SUCCESS) {
-            bail!("Binary exited with unexpected {status}: {output}\nCommand:\n  {command:?}");
+            bail!(
+                "Binary exited with unexpected {status}:\n-- stdout --\n{stdout_display}\n\
+                 -- stderr --\n{stderr_display}\nCommand:\n  {command:?}"
+            );
+        }
+
+        if expect_output_empty && (!stdout.is_empty() || !stderr.is_empty()) {
+            bail!(
+                "Binary produced output but exact silence was required:\n\
+                 -- stdout --\n{stdout_display}\n-- stderr --\n{stderr_display}\nCommand:\n  {command:?}"
+            );
         }
 
         Ok(())
@@ -6341,7 +6404,7 @@ fn run_with_config(
                 }
             } else {
                 program
-                    .run(cross_arch)
+                    .run(cross_arch, config.expect_run_output_empty)
                     .with_context(|| format!("Failed to run program. {program}"))?;
             }
         } else if config.run_dyn_sym.is_some() {
@@ -6402,14 +6465,14 @@ fn check_unexpected_intermediate_output(
 ) -> Result {
     let intermediate_count = programs
         .iter()
-        .map(|program| program.shared_objects.len())
+        .map(|program| program.intermediates.len())
         .max()
         .unwrap_or(0);
 
     for index in 0..intermediate_count {
         let intermediates = programs
             .iter()
-            .filter_map(|program| program.shared_objects.get(index))
+            .filter_map(|program| program.intermediates.get(index))
             .collect_vec();
 
         let reld = intermediates.last().unwrap();

--- a/crates/reld/tests/sources/elf/custom-section-relocatable/custom-section-relocatable-parts.c
+++ b/crates/reld/tests/sources/elf/custom-section-relocatable/custom-section-relocatable-parts.c
@@ -1,0 +1,4 @@
+int custom_alpha __attribute__((section(".reld.custom.alpha"))) = 7;
+int custom_beta __attribute__((section(".reld.custom.beta"))) = 35;
+
+int custom_section_sum(void) { return custom_alpha + custom_beta; }

--- a/crates/reld/tests/sources/elf/custom-section-relocatable/custom-section-relocatable.c
+++ b/crates/reld/tests/sources/elf/custom-section-relocatable/custom-section-relocatable.c
@@ -1,0 +1,18 @@
+//#SkipArch: ppc64le
+//#Object:runtime.c
+//#Object:custom-section-relocatable-parts.c
+//#ExpectSym:custom_alpha section=".reld.custom.alpha"
+//#ExpectSym:custom_beta section=".reld.custom.beta"
+//#ExpectSym:custom_section_sum section=".text"
+
+#include "../common/runtime.h"
+
+int custom_section_sum(void);
+
+void _start(void) {
+  runtime_init();
+  if (custom_section_sum() != 42) {
+    exit_syscall(1);
+  }
+  exit_syscall(42);
+}

--- a/crates/reld/tests/sources/elf/custom-section-relocatable/custom-section-relocatable.c
+++ b/crates/reld/tests/sources/elf/custom-section-relocatable/custom-section-relocatable.c
@@ -1,6 +1,7 @@
 //#SkipArch: ppc64le
 //#Object:runtime.c
-//#Object:custom-section-relocatable-parts.c
+//#Relocatable:custom-section-relocatable-parts.c
+//#ExpectRunOutputEmpty:true
 //#ExpectSym:custom_alpha section=".reld.custom.alpha"
 //#ExpectSym:custom_beta section=".reld.custom.beta"
 //#ExpectSym:custom_section_sum section=".text"

--- a/docs/plan/03-PHASE-1-HARNESS.md
+++ b/docs/plan/03-PHASE-1-HARNESS.md
@@ -24,13 +24,14 @@ one directive outside the proposed set.** `ReferenceLinkers:` alone has 126 uses
 `Malfunction:` directive was not in the set — so P1-T5's fixtures would fail to parse under
 P1-T1's own reject-unknown parser, within a single phase.
 
-**Freeze at the following 30.** Still far below wild's 77-in-use, and still rejecting the two
+**Freeze at the following 32.** Still far below wild's 77-in-use, and still rejecting the two
 deprecated spellings (`SkipLinker:`, `EnableLinker:`), but expressible against the inherited
 corpus:
 
 ```
 Config:{name}[:{inherits}]     AbstractConfig:{name}[:{inherits}]
-Object:{file}[:args]           Archive:{file}        Shared:{file}[:args]
+Object:{file}[:args]           Relocatable:{file}[:args]
+Archive:{file}                 Shared:{file}[:args]
 LinkerScript:{file}
 CompArgs:...                   LinkArgs:...          LinkerDriver:gcc|clang|none
 Compiler:gcc|g++|clang|clang++
@@ -40,7 +41,8 @@ ExpectSym:{name} [props]       NoSym:{name}
 ExpectDynSym:{name} [props]    NoDynSym:{name}
 ExpectSection:{name}           NoSection:{name}      ExpectSectionBytes:{name}=0x{hex}
 ExpectDynamic:{tag}            ExpectError:{regex}   Contains:{string}
-RunEnabled:{bool}              DiffEnabled:{bool}    DiffMatchAny:{bool}
+RunEnabled:{bool}              ExpectRunOutputEmpty:{bool}
+DiffEnabled:{bool}             DiffMatchAny:{bool}
 DiffIgnore:{key} #{issue} [arch={a}[,{b}...]]
 Malfunction:{id}               Requires{Glibc,NightlyRustc,LinkerPlugin,...}:{bool}
 ```
@@ -48,6 +50,12 @@ Malfunction:{id}               Requires{Glibc,NightlyRustc,LinkerPlugin,...}:{bo
 `Requires*` is a family, not one directive — and it is load-bearing: `RELD_VERIFY_PLATFORM_
 REQUIREMENTS` (P1-T8) exists precisely to assert that `Requires*`-gated skips were unnecessary.
 Delete the family and the escape hatch has nothing to verify.
+
+`Relocatable:` compiles its inputs, performs a linker-specific partial link (`-r` for ELF), checks
+that intermediate for linker diagnostics and object validity, and feeds it to the final link.
+`ExpectRunOutputEmpty:true` keeps the exit-code-42 oracle and additionally requires exact empty
+stdout and stderr from normal executable execution. It is rejected with `RunEnabled:false` or
+`RunDynSym:` rather than becoming a silent no-op.
 
 Directives still deliberately dropped, with their fixture cost accepted: `TestUpdateInPlace:`
 (17), `ExpectProgramHeader:` (16), `AutoAddObjects:`, `RemoveSection:`, `DriverMode:`,


### PR DESCRIPTION
## Summary

- keep built-in output-section parts in the existing dense prefix while storing discovered custom-section parts lazily in an ordered standard-library `BTreeMap`
- preserve deterministic part order and empty-custom-section layout behavior across ELF, Mach-O, compression, thunk, verification, and writer callers
- add committed RED→GREEN map coverage plus a native ELF relocatable/custom-section acceptance fixture
- publish and lock an LLVM/Clang `llvmorg-22.1.8` final-link corpus, with a separate manual Linux workflow that times only repeated final links for about 30 seconds
- enforce two baseline and two candidate raw-artifact comparisons plus an exact native Clang oracle before reporting timing

Closes #101

## Artifact and performance evidence

Controlled 71,604-custom-section ELF replay, same `non-git-build` version provenance:

- two baseline and two candidate outputs are byte-identical: SHA-256 `8003e4465e75f7e1ca6f35ca44645a0c8d2bc82620655b6c7c562cd24724c423`
- every output exits 42 with empty stdout/stderr
- 10 balanced samples: median wall 0.320→0.190 s (40.6% lower)
- mean peak RSS 334,336→101,704 KiB (69.6% lower)
- phase trace: total 305.18→181.75 ms; Layout 172.95→108.81 ms; total sizes 34.71→8.64 ms; group offsets 23.53→3.78 ms; buffer split 44.70→4.07 ms

Published Clang corpus: https://github.com/zackees/reld/releases/tag/clang-link-corpus-llvmorg-22.1.8-v1

- archive: 73,413,916 bytes, locked SHA-256 `beb1f73eaab4257572ff60d04f08391b605990e4377c5d137fbf254db8ad5440`
- true pinned baseline/candidate URL replay: 204 fixed `--no-fork` samples totaling 31.675 s after one excluded calibration link
- all four Clang artifacts are byte-identical: SHA-256 `3a2654c7294db5865f387d1dd2df465b94433d957ce89a2de28161bc353ff9e5`
- exact native Clang oracle passed after every identity, calibration, and timed link
- compilation, download, extraction, native execution, and evidence writing are outside timing
- copied `.o`/`.a` inputs use documented GNU binutils 2.40 `strip --strip-debug` with attached pre/post manifests so the hosted workload fits; it is explicitly non-debug representative

## Validation

- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `cargo test -p reld-core --lib`: 173 functional tests passed; only the two tidy subprocess checks could not run in the diagnostic image because `taplo` and `clang-format` were absent
- exact acceptance `elf/x86_64/custom-section-relocatable/default`: passed, native exit 42
- full Python CI suite: 213 passed
- focused Clang lock/workflow tests: 18 passed
- dependency-policy check: passed; no manifest, lockfile, baseline, or crate dependency change
- actionlint and `git diff --check`: passed
- `/clud-review`: clean after one medium timing-invariant finding was fixed with a negative `--no-fork` lock test

Issue evidence and corpus provenance are also recorded at https://github.com/zackees/reld/issues/101#issuecomment-5486467701.