### PR TITLE
feat(bench): group Linux link time and RSS bars

### DIFF
--- a/.github/workflows/linux-linker-competition.yml
+++ b/.github/workflows/linux-linker-competition.yml
@@ -165,7 +165,7 @@ jobs:
             --report "$REPORT" \
             --samples 12 --warmups 2
 
-      - name: Render paired wall-time and peak-RSS evidence
+      - name: Render grouped dual-axis wall-time and peak-RSS evidence
         shell: bash
         run: |
           set -euo pipefail
@@ -186,7 +186,7 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload report, raw samples, provenance, and paired graph
+      - name: Upload report, raw samples, provenance, and grouped dual-axis graph
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/README.md
+++ b/README.md
@@ -54,37 +54,40 @@ requires every published chart to name the source SHA and current generation tim
 ## Linux linker competition: final-link time and peak RSS
 
 <p align="center">
-<a href="https://github.com/zackees/reld/releases/tag/linux-linker-competition-v1"><img alt="Linux ELF linker competition with wall link time in the first panel and peak process-tree RSS in the second panel" src="https://github.com/zackees/reld/releases/download/linux-linker-competition-v1/competition.png" width="100%"></a>
+<a href="https://github.com/zackees/reld/releases/tag/linux-linker-competition-v2"><img alt="Grouped dual-axis Linux ELF linker competition: each linker has a solid wall-time bar first on the left seconds axis and a hatched peak-RSS bar second on the right MiB axis" src="https://github.com/zackees/reld/releases/download/linux-linker-competition-v2/competition.png" width="100%"></a>
 </p>
 
 This is the competitive Linux measurement, separate from the cross-platform trend charts above.
 It links a frozen LLVM/Clang C++ corpus that was compiled in advance, so **compilation is excluded**
 and only the final linker invocation is timed. Bars are medians from 12 measured trials in two
 balanced six-linker Williams blocks after two warmups; whiskers are bootstrap 95% confidence
-intervals. Peak RSS is the maximum summed resident memory of the linker process tree, sampled in
-a fresh cgroup-v2 subtree for every trial.
+intervals. Within each linker group, the solid wall-time bar comes first and uses the zero-based
+left seconds axis; the adjacent hatched peak-RSS bar comes second and uses the independent
+zero-based right MiB axis. Peak RSS is the maximum summed resident memory of the linker process
+tree, sampled in a fresh cgroup-v2 subtree for every trial. The metrics are not normalized or
+combined into one score.
 
 | Linker | Median link time | Median peak RSS |
 |---|---:|---:|
-| GNU bfd | 3.449 s | 894.984 MiB |
-| LLD | 0.402 s | 753.713 MiB |
-| mold | 0.275 s | 760.311 MiB |
-| Wild | 0.250 s | 529.805 MiB |
-| reld baseline | 0.241 s | 530.217 MiB |
-| **reld candidate** | **0.242 s** | **529.973 MiB** |
+| GNU bfd | 3.643 s | 894.660 MiB |
+| LLD | 0.417 s | 753.797 MiB |
+| mold | 0.295 s | 760.838 MiB |
+| Wild | 0.262 s | 529.902 MiB |
+| reld baseline | 0.247 s | 530.152 MiB |
+| **reld candidate** | **0.250 s** | **530.344 MiB** |
 
 On this workload, the paired 95% intervals show reld reducing link time and peak RSS versus GNU
-bfd (92.9–93.0% and 40.7–40.9%), LLD (39.4–41.4% and 29.6–29.8%), and mold (11.0–12.4% and
-30.1–30.5%). Against Wild, reld is 2.7–4.2% faster on wall time but statistically tied on RSS;
+bfd (93.0–93.2% and 40.6–40.8%), LLD (38.7–42.1% and 29.5–29.8%), and mold (13.3–16.8% and
+30.1–30.5%). Against Wild, reld is 2.2–5.6% faster on wall time but statistically tied on RSS;
 against the exact pre-change reld baseline, both intervals cross zero. So this evidence supports
 clear two-metric wins over bfd, LLD, and mold, but **does not support claiming that reld is way
 better than Wild or that this candidate is a performance breakthrough over its baseline**.
 
-The [hosted run](https://github.com/zackees/reld/actions/runs/33465040361) passed output identity,
+The [hosted run](https://github.com/zackees/reld/actions/runs/33496554602) passed output identity,
 external self-determinism, native execution, and live RSS-calibration gates. The permanent
-[evidence release](https://github.com/zackees/reld/releases/tag/linux-linker-competition-v1)
-includes the [structured report](https://github.com/zackees/reld/releases/download/linux-linker-competition-v1/report.json),
-[raw samples](https://github.com/zackees/reld/releases/download/linux-linker-competition-v1/raw-samples.jsonl),
+[evidence release](https://github.com/zackees/reld/releases/tag/linux-linker-competition-v2)
+includes the [structured report](https://github.com/zackees/reld/releases/download/linux-linker-competition-v2/report.json),
+[raw samples](https://github.com/zackees/reld/releases/download/linux-linker-competition-v2/raw-samples.jsonl),
 provenance, locks, and the sealed rendering manifest.
 
 ## What it is

--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -143,11 +143,25 @@ Wild is an external performance comparator only: the exact pre-change reld basel
 artifact reference, and no Wild/reld artifact-equivalence claim is made because reld intentionally
 changed its build-ID/output-layout policy in PR #76.
 
-The renderer produces one paired wall-time/RSS graph with separate zero-based scales, confidence
-intervals, and fixed contender order. The workflow uploads the schema-versioned report, raw JSONL,
-provenance, accessible HTML, PNG, generated job summary, and (only on failure) retained mismatch
-artifacts. It has no schedule and never writes benchmark history; hosted results support only
-same-run comparisons.
+The renderer produces one grouped dual-axis wall-time/RSS graph. Its fixed contender order is
+`bfd`, `lld`, `mold`, `wild`, `reld baseline`, then `reld candidate`. Each contender group has a
+solid wall-time bar first, read against the zero-based left axis in seconds, followed by a
+diagonally hatched peak process-tree RSS bar, read against the independent zero-based right axis
+in MiB. The matching contender hue is retained for both bars; solid versus hatch is the required
+non-colour metric distinction. Exact medians and bootstrap 95% confidence intervals are annotated
+on both bars. The accessible HTML figure description and full exact-value table are required
+nonvisual sources for the same values, units, bar order, and axis ownership.
+
+This grouped presentation is not normalization or scalarization: it adds no combined, weighted,
+or composite score, and performance claims still require the independent confidence rules for both
+metrics. The workflow uploads the schema-versioned report, raw JSONL, provenance, accessible HTML,
+PNG, generated job summary, and (only on failure) retained mismatch artifacts. Inspect the hosted
+PNG before publication for bar order, left/right zero-based axis labels, solid/hatched legend,
+exact median/CI annotations, clipping, and non-overlap. A successful combined-layout run is
+published as an immutable `linux-linker-competition-v2` evidence bundle (PNG, HTML, report, raw
+samples, provenance, locks, summary, and completion manifest); v1 remains available as its
+historical two-panel evidence. The workflow has no schedule and never writes benchmark history;
+hosted results support only same-run comparisons.
 
 Prefer the complete `RelWithDebInfo` closure. The standard public `ubuntu-24.04` runner has a
 measured 16 GB RAM and 14 GB SSD, and each GitHub Release asset must remain below 2 GiB; the checked
@@ -202,7 +216,7 @@ run `xsv count`, the full pinned PCRE2 CTest suite, and the C++ name-mangling CT
 - Benchmark replay and execution oracle: `ci/benchmark_runner.py`
 - Immutable Clang corpus lock/replay: `ci/clang_link_replay.py` and
   `.github/workflows/clang-link-replay.yml`
-- Competitive Linux replay and paired renderer: `ci/linux_linker_competition.py`,
+- Competitive Linux replay and grouped dual-axis renderer: `ci/linux_linker_competition.py`,
   `ci/linux_linker_competition_render.py`, and
   `.github/workflows/linux-linker-competition.yml`
 - Consumer acceptance driver: `ci/consumer_acceptance.py`

--- a/agents/platforms/linux.md
+++ b/agents/platforms/linux.md
@@ -157,11 +157,11 @@ or composite score, and performance claims still require the independent confide
 metrics. The workflow uploads the schema-versioned report, raw JSONL, provenance, accessible HTML,
 PNG, generated job summary, and (only on failure) retained mismatch artifacts. Inspect the hosted
 PNG before publication for bar order, left/right zero-based axis labels, solid/hatched legend,
-exact median/CI annotations, clipping, and non-overlap. A successful combined-layout run is
-published as an immutable `linux-linker-competition-v2` evidence bundle (PNG, HTML, report, raw
-samples, provenance, locks, summary, and completion manifest); v1 remains available as its
-historical two-panel evidence. The workflow has no schedule and never writes benchmark history;
-hosted results support only same-run comparisons.
+exact median/CI annotations, clipping, and non-overlap. Publish successful combined-layout
+evidence as an immutable `linux-linker-competition-v2` bundle (PNG, HTML, report, raw samples,
+provenance, locks, summary, and completion manifest); retain v1 as the historical two-panel
+evidence. The workflow has no schedule and never writes benchmark history; hosted results support
+only same-run comparisons.
 
 Prefer the complete `RelWithDebInfo` closure. The standard public `ubuntu-24.04` runner has a
 measured 16 GB RAM and 14 GB SSD, and each GitHub Release asset must remain below 2 GiB; the checked

--- a/ci/linux_linker_competition_render.py
+++ b/ci/linux_linker_competition_render.py
@@ -361,12 +361,64 @@ def _draw_diagonal_hatch(
             draw.line((points[0], points[1]), fill=color, width=width)
 
 
-def _annotation_box(draw: Any, text: str, font: Any, *, center: float, y: float, scale: int) -> dict[str, float]:
-    """Return a base-pixel text bounding box for machine-checkable overlap tests."""
-    box = draw.textbbox((0, 0), text, font=font)
+def _annotation_extent(draw: Any, text: str, font: Any, *, scale: int) -> tuple[float, float]:
+    """Return multiline base-pixel dimensions so placement follows the rendered glyphs."""
+    box = draw.multiline_textbbox((0, 0), text, font=font, spacing=scale)
     width = (box[2] - box[0]) / scale
     height = (box[3] - box[1]) / scale
-    return {"x": center - width / 2, "y": y, "width": width, "height": height}
+    return width, height
+
+
+def _wrap_annotation_text(draw: Any, text: str, font: Any, *, max_width: float, scale: int) -> str | None:
+    """Wrap exact annotation tokens without abbreviating their values or units."""
+    lines: list[str] = []
+    line = ""
+    for token in text.split(" "):
+        proposed = token if not line else f"{line} {token}"
+        width, _ = _annotation_extent(draw, proposed, font, scale=scale)
+        if width <= max_width:
+            line = proposed
+            continue
+        if not line:
+            return None
+        lines.append(line)
+        line = token
+        width, _ = _annotation_extent(draw, line, font, scale=scale)
+        if width > max_width:
+            return None
+    lines.append(line)
+    return "\n".join(lines)
+
+
+def _fit_annotation_text(
+    draw: Any,
+    text: str,
+    *,
+    max_width: float,
+    scale: int,
+) -> tuple[Any, str, int]:
+    """Use the largest readable 8–11 px font and exact word wrapping for one column."""
+    for font_size in range(11, 7, -1):
+        font = _font(font_size * scale)
+        wrapped = _wrap_annotation_text(draw, text, font, max_width=max_width, scale=scale)
+        if wrapped is not None:
+            return font, wrapped, font_size
+    raise CompetitionRenderError(f"annotation cannot fit a {max_width:.1f}px metric column: {text}")
+
+
+def _annotation_box(
+    draw: Any,
+    text: str,
+    font: Any,
+    *,
+    center: float,
+    y: float,
+    scale: int,
+    font_size: int,
+) -> dict[str, float | int]:
+    """Return a base-pixel text bounding box for machine-checkable overlap tests."""
+    width, height = _annotation_extent(draw, text, font, scale=scale)
+    return {"x": center - width / 2, "y": y, "width": width, "height": height, "font_size": font_size}
 
 
 def render_png(report: dict[str, Any], path: Path) -> None:
@@ -380,7 +432,6 @@ def render_png(report: dict[str, Any], path: Path) -> None:
     title_font = _font(30 * scale)
     label_font = _font(15 * scale)
     small_font = _font(12 * scale)
-    annotation_font = _font(11 * scale)
     fg, muted, grid = "#e6edf3", "#9da7b3", "#30363d"
     draw.text((48 * scale, 30 * scale), "Linux ELF competitive linker evidence", font=title_font, fill=fg)
     draw.text(
@@ -424,7 +475,11 @@ def render_png(report: dict[str, Any], path: Path) -> None:
     draw.text((int(1330 * scale), 186 * scale), "Peak process-tree RSS (MiB, right axis)", font=small_font, fill=fg)
 
     group_width = (chart_right - chart_left) / len(CONTENDER_ORDER)
-    bar_width, bar_offset = 70, 60
+    # Each group is split into two fixed annotation columns. Every annotation is word-wrapped
+    # and, only if needed, reduced to an eight-pixel minimum before it is drawn. Thus large but
+    # host-feasible values retain their exact text without spilling into an adjacent metric.
+    annotation_column_width = group_width / 2 - 4
+    bar_width, bar_offset = 70, group_width / 4
     annotation_boxes: list[dict[str, object]] = []
     for index, contender in enumerate(CONTENDER_ORDER):
         group_center = chart_left + group_width * (index + 0.5)
@@ -466,16 +521,37 @@ def render_png(report: dict[str, Any], path: Path) -> None:
                 if metric == "wall_seconds"
                 else f"CI {float(summary['bootstrap_95_ci'][0]) / 1024:.3f} – {float(summary['bootstrap_95_ci'][1]) / 1024:.3f} MiB"
             )
-            text_y = max(chart_top + 4, high_y - 37)
-            for row, text, fill in ((0, value_label, fg), (16, ci_label, muted)):
-                annotation = _annotation_box(draw, text, annotation_font, center=center, y=text_y + row, scale=scale)
-                annotation["x"] = min(
-                    max(float(annotation["x"]), chart_left),
-                    chart_right - float(annotation["width"]),
+            value_font, wrapped_value, value_font_size = _fit_annotation_text(
+                draw, value_label, max_width=annotation_column_width, scale=scale
+            )
+            ci_font, wrapped_ci, ci_font_size = _fit_annotation_text(
+                draw, ci_label, max_width=annotation_column_width, scale=scale
+            )
+            _, value_height = _annotation_extent(draw, wrapped_value, value_font, scale=scale)
+            _, ci_height = _annotation_extent(draw, wrapped_ci, ci_font, scale=scale)
+            text_y = max(chart_top + 4, high_y - value_height - ci_height - 7)
+            for row, text, font, font_size, fill in (
+                (0, wrapped_value, value_font, value_font_size, fg),
+                (value_height + 2, wrapped_ci, ci_font, ci_font_size, muted),
+            ):
+                annotation = _annotation_box(
+                    draw,
+                    text,
+                    font,
+                    center=center,
+                    y=text_y + row,
+                    scale=scale,
+                    font_size=font_size,
                 )
                 annotation.update({"contender": contender, "metric": metric, "text": text})
                 annotation_boxes.append(annotation)
-                draw.text((int(annotation["x"] * scale), int((text_y + row) * scale)), text, font=annotation_font, fill=fill)
+                draw.multiline_text(
+                    (int(float(annotation["x"]) * scale), int((text_y + row) * scale)),
+                    text,
+                    font=font,
+                    fill=fill,
+                    spacing=scale,
+                )
         contender_label = CONTENDER_LABELS[contender]
         box = draw.textbbox((0, 0), contender_label, font=label_font)
         draw.text(

--- a/ci/linux_linker_competition_render.py
+++ b/ci/linux_linker_competition_render.py
@@ -335,16 +335,49 @@ def _rendered_values(report: dict[str, Any]) -> dict[str, dict[str, dict[str, ob
     }
 
 
+def _draw_diagonal_hatch(
+    draw: Any,
+    *,
+    left: int,
+    top: int,
+    right: int,
+    bottom: int,
+    color: str,
+    width: int,
+    spacing: int,
+) -> None:
+    """Draw clipped, deterministic `/` hatching inside one RSS bar.
+
+    ``ImageDraw`` has no rectangle clip.  The four edge intersections of ``x + y = c``
+    let us draw only the segment inside the bar, so the RSS texture can never leak into a
+    neighboring contender's wall-time bar.
+    """
+    for intercept in range(left + top, right + bottom + 1, spacing):
+        points = []
+        for x, y in ((left, intercept - left), (right, intercept - right), (intercept - top, top), (intercept - bottom, bottom)):
+            if left <= x <= right and top <= y <= bottom and (x, y) not in points:
+                points.append((x, y))
+        if len(points) >= 2:
+            draw.line((points[0], points[1]), fill=color, width=width)
+
+
+def _annotation_box(draw: Any, text: str, font: Any, *, center: float, y: float, scale: int) -> dict[str, float]:
+    """Return a base-pixel text bounding box for machine-checkable overlap tests."""
+    box = draw.textbbox((0, 0), text, font=font)
+    width = (box[2] - box[0]) / scale
+    height = (box[3] - box[1]) / scale
+    return {"x": center - width / 2, "y": y, "width": width, "height": height}
+
+
 def render_png(report: dict[str, Any], path: Path) -> None:
-    """Render wall time and RSS as aligned panels with independent zero-based scales."""
+    """Render each contender's wall-time and RSS bars in one grouped dual-axis chart."""
     from PIL import Image, ImageDraw, PngImagePlugin
 
     validate_report(report)
-    width, height, scale = 1800, 920, 2
+    width, height, scale = 1800, 980, 2
     image = Image.new("RGB", (width * scale, height * scale), "#0d1117")
     draw = ImageDraw.Draw(image)
     title_font = _font(30 * scale)
-    panel_font = _font(22 * scale)
     label_font = _font(15 * scale)
     small_font = _font(12 * scale)
     annotation_font = _font(11 * scale)
@@ -357,73 +390,119 @@ def render_png(report: dict[str, Any], path: Path) -> None:
         fill=muted,
     )
 
-    panels = (("wall_seconds", "Wall link time (seconds)"), ("peak_rss_kib", "Peak process-tree RSS (MiB)"))
-    panel_width, left_margin, panel_stride, top, chart_height = 810, 60, 885, 165, 540
-    bar_width = 78
-    for panel_index, (metric, title) in enumerate(panels):
-        x0 = left_margin + panel_index * panel_stride
-        y_axis = top + chart_height
-        values = _summary_values(report, metric)
-        raw_max = max(float(item["summary"]["bootstrap_95_ci"][1]) for item in values)
-        if metric == "peak_rss_kib":
-            raw_max /= 1024
-        axis_max = max(raw_max * 1.20, 0.001)
-        draw.text((x0 * scale, 120 * scale), title, font=panel_font, fill=fg)
-        draw.rectangle((x0 * scale, top * scale, (x0 + panel_width) * scale, y_axis * scale), outline=grid, width=2 * scale)
-        for tick in range(6):
-            value = axis_max * tick / 5
-            y = y_axis - chart_height * tick / 5
-            draw.line((x0 * scale, int(y * scale), (x0 + panel_width) * scale, int(y * scale)), fill=grid, width=1 * scale)
-            unit = "s" if metric == "wall_seconds" else "MiB"
-            draw.text((x0 * scale, int(y * scale) - 13 * scale), f"{value:.2f} {unit}", font=small_font, fill=muted)
-        gap = panel_width / len(values)
-        for index, item in enumerate(values):
-            summary = item["summary"]
+    # One shared x-axis makes each contender's two independent measurements directly adjacent.
+    # The y-axes intentionally remain independent, linear, and anchored at zero: a normalized
+    # or shared numeric scale would create a composite performance claim.
+    chart_left, chart_right, chart_top, chart_height = 170, 1630, 215, 510
+    chart_bottom = chart_top + chart_height
+    draw.text((chart_left * scale, 120 * scale), "Grouped dual-axis chart: wall time first, peak RSS second", font=label_font, fill=fg)
+    legend = (
+        "Legend — first bar: wall link time, solid, seconds, left axis; "
+        "second bar: peak process-tree RSS, diagonal hatch, MiB, right axis"
+    )
+    draw.text((chart_left * scale, 148 * scale), legend, font=small_font, fill=muted)
+    draw.rectangle(
+        (chart_left * scale, chart_top * scale, chart_right * scale, chart_bottom * scale),
+        outline=grid,
+        width=2 * scale,
+    )
+
+    wall_values = _summary_values(report, "wall_seconds")
+    rss_values = _summary_values(report, "peak_rss_kib")
+    wall_axis_max = max(float(item["summary"]["bootstrap_95_ci"][1]) for item in wall_values) * 1.20
+    rss_axis_max = max(float(item["summary"]["bootstrap_95_ci"][1]) / 1024 for item in rss_values) * 1.20
+    wall_axis_max = max(wall_axis_max, 0.001)
+    rss_axis_max = max(rss_axis_max, 0.001)
+    for tick in range(6):
+        fraction = tick / 5
+        y = chart_bottom - chart_height * fraction
+        draw.line((chart_left * scale, int(y * scale), chart_right * scale, int(y * scale)), fill=grid, width=scale)
+        draw.text((34 * scale, int(y * scale) - 12 * scale), f"{wall_axis_max * fraction:.2f} s", font=small_font, fill=muted)
+        right_label = f"{rss_axis_max * fraction:.0f} MiB"
+        draw.text((int((chart_right + 14) * scale), int(y * scale) - 12 * scale), right_label, font=small_font, fill=muted)
+    draw.text((34 * scale, 186 * scale), "Wall link time (seconds, left axis)", font=small_font, fill=fg)
+    draw.text((int(1330 * scale), 186 * scale), "Peak process-tree RSS (MiB, right axis)", font=small_font, fill=fg)
+
+    group_width = (chart_right - chart_left) / len(CONTENDER_ORDER)
+    bar_width, bar_offset = 70, 60
+    annotation_boxes: list[dict[str, object]] = []
+    for index, contender in enumerate(CONTENDER_ORDER):
+        group_center = chart_left + group_width * (index + 0.5)
+        # The two reserved columns make every annotation deterministic and non-overlapping even
+        # when wall and RSS bar heights (or neighboring contender heights) are nearly identical.
+        for metric, axis_max, center in (
+            ("wall_seconds", wall_axis_max, group_center - bar_offset),
+            ("peak_rss_kib", rss_axis_max, group_center + bar_offset),
+        ):
+            summary = report["contenders"][contender]["summaries"][metric]
             median = float(summary["median"])
             low, high = (float(value) for value in summary["bootstrap_95_ci"])
             if metric == "peak_rss_kib":
                 median, low, high = median / 1024, low / 1024, high / 1024
-            center = x0 + gap * (index + 0.5)
-            bar_top = y_axis - chart_height * median / axis_max
-            color = _hex_rgb(COLORS[item["name"]])
-            draw.rectangle(
-                (int((center - bar_width / 2) * scale), int(bar_top * scale), int((center + bar_width / 2) * scale), y_axis * scale),
-                fill=color,
-            )
-            low_y = y_axis - chart_height * low / axis_max
-            high_y = y_axis - chart_height * high / axis_max
+            bar_top = chart_bottom - chart_height * median / axis_max
+            color = COLORS[contender]
+            left, right = int((center - bar_width / 2) * scale), int((center + bar_width / 2) * scale)
+            top, bottom = int(bar_top * scale), int(chart_bottom * scale)
+            draw.rectangle((left, top, right, bottom), fill=color)
+            if metric == "peak_rss_kib":
+                _draw_diagonal_hatch(
+                    draw,
+                    left=left,
+                    top=top,
+                    right=right,
+                    bottom=bottom,
+                    color="#0d1117",
+                    width=2 * scale,
+                    spacing=10 * scale,
+                )
+            low_y = chart_bottom - chart_height * low / axis_max
+            high_y = chart_bottom - chart_height * high / axis_max
             draw.line((int(center * scale), int(low_y * scale), int(center * scale), int(high_y * scale)), fill=fg, width=2 * scale)
             draw.line((int((center - 10) * scale), int(low_y * scale), int((center + 10) * scale), int(low_y * scale)), fill=fg, width=2 * scale)
             draw.line((int((center - 10) * scale), int(high_y * scale), int((center + 10) * scale), int(high_y * scale)), fill=fg, width=2 * scale)
             value_label = _format_metric(metric, float(summary["median"]))
-            # The panel heading owns the unit.  Avoid repeating it twice in the CI so each
-            # contender keeps a distinct, readable annotation column.
-            if metric == "wall_seconds":
-                ci_label = f"CI {float(summary['bootstrap_95_ci'][0]):.3f} – {float(summary['bootstrap_95_ci'][1]):.3f}"
-            else:
-                ci_label = f"CI {float(summary['bootstrap_95_ci'][0]) / 1024:.3f} – {float(summary['bootstrap_95_ci'][1]) / 1024:.3f}"
-            # Similar contenders naturally have similar bar heights.  Alternate their
-            # annotation rows so adjacent exact values and intervals never print over one
-            # another; the footer identifies every displayed interval as a bootstrap 95% CI.
-            text_y = max(top + 3, high_y - 39 - (index % 2) * 34)
-            value_box = draw.textbbox((0, 0), value_label, font=annotation_font)
-            ci_box = draw.textbbox((0, 0), ci_label, font=annotation_font)
-            value_x = center * scale - (value_box[2] - value_box[0]) / 2
-            ci_x = center * scale - (ci_box[2] - ci_box[0]) / 2
-            draw.text((int(value_x), int(text_y * scale)), value_label, font=annotation_font, fill=fg)
-            draw.text((int(ci_x), int((text_y + 16) * scale)), ci_label, font=annotation_font, fill=muted)
-            label = item["label"]
-            box = draw.textbbox((0, 0), label, font=label_font)
-            draw.text((int((center - (box[2] - box[0]) / scale / 2) * scale), int((y_axis + 12) * scale)), label, font=label_font, fill=fg)
+            ci_label = (
+                f"CI {float(summary['bootstrap_95_ci'][0]):.3f} – {float(summary['bootstrap_95_ci'][1]):.3f} s"
+                if metric == "wall_seconds"
+                else f"CI {float(summary['bootstrap_95_ci'][0]) / 1024:.3f} – {float(summary['bootstrap_95_ci'][1]) / 1024:.3f} MiB"
+            )
+            text_y = max(chart_top + 4, high_y - 37)
+            for row, text, fill in ((0, value_label, fg), (16, ci_label, muted)):
+                annotation = _annotation_box(draw, text, annotation_font, center=center, y=text_y + row, scale=scale)
+                annotation["x"] = min(
+                    max(float(annotation["x"]), chart_left),
+                    chart_right - float(annotation["width"]),
+                )
+                annotation.update({"contender": contender, "metric": metric, "text": text})
+                annotation_boxes.append(annotation)
+                draw.text((int(annotation["x"] * scale), int((text_y + row) * scale)), text, font=annotation_font, fill=fill)
+        contender_label = CONTENDER_LABELS[contender]
+        box = draw.textbbox((0, 0), contender_label, font=label_font)
+        draw.text(
+            (int(group_center * scale - (box[2] - box[0]) / 2), int((chart_bottom + 14) * scale)),
+            contender_label,
+            font=label_font,
+            fill=fg,
+        )
 
-    footer_y = 790
-    draw.text((48 * scale, footer_y * scale), "Bars = median. Whiskers = per-contender bootstrap 95% CI. Metrics are intentionally not scalarized.", font=label_font, fill=muted)
+    footer_y = 865
+    draw.text(
+        (48 * scale, footer_y * scale),
+        "Bars = median. Whiskers and annotations = per-contender bootstrap 95% CI. Metrics are intentionally not scalarized.",
+        font=label_font,
+        fill=muted,
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     metadata = PngImagePlugin.PngInfo()
     metadata.add_text("workload", _workload_label(report))
+    metadata.add_text("layout", "grouped-dual-axis-v1")
+    metadata.add_text("bar_order", "wall_seconds,peak_rss_kib")
+    metadata.add_text("left_axis", "wall_seconds")
+    metadata.add_text("right_axis", "peak_rss_kib")
     metadata.add_text("contender_order", ",".join(CONTENDER_ORDER))
     metadata.add_text("metrics", "wall_seconds,peak_rss_kib")
     metadata.add_text("rendered_values", json.dumps(_rendered_values(report), sort_keys=True, separators=(",", ":")))
+    metadata.add_text("annotation_boxes", json.dumps(annotation_boxes, sort_keys=True, separators=(",", ":")))
     image.resize((width, height), Image.Resampling.LANCZOS).save(path, "PNG", pnginfo=metadata)
 
 
@@ -455,9 +534,9 @@ table{{border-collapse:collapse;width:100%}}th,td{{border:1px solid #30363d;padd
 .swatch{{display:inline-block;width:.8rem;height:.8rem;border-radius:50%;margin-right:.4rem}}figure{{margin:1.5rem 0}}img{{max-width:100%;height:auto}}
 </style></head><body>
 <h1>Linux ELF competitive linker evidence</h1>
-<p>Workload: <code>{html.escape(_workload_label(report))}</code>. Wall link time and peak process-tree RSS use independent zero-based scales. No scalar combined score is produced.</p>
+<p>Workload: <code>{html.escape(_workload_label(report))}</code>. The figure is a grouped dual-axis chart: for each contender, wall time first is the solid bar on the left seconds axis and peak process-tree RSS second is the diagonally hatched bar on the right MiB axis. The separate zero-based axes preserve both real units; no scalar combined score is produced.</p>
 <aside><strong>Artifact comparison policy:</strong> {html.escape(_artifact_disclaimer(report))}</aside>
-<figure aria-label=\"Competitive linker measurements\"><img src=\"competition.png\" alt=\"Aligned panels for wall link time in seconds and peak process-tree RSS in MiB, in the same fixed contender order.\"><figcaption>Bars show medians; whiskers and labels show per-contender 95% confidence intervals.</figcaption></figure>
+<figure aria-label=\"Grouped dual-axis competitive linker measurements\"><img src=\"competition.png\" alt=\"Grouped dual-axis chart in fixed contender order: wall link time is the first solid bar for each contender on the left zero-based seconds axis; peak process-tree RSS is the second diagonally hatched bar on the right zero-based MiB axis.\"><figcaption>For each contender, wall time comes first and peak process-tree RSS second. Bars show medians; whiskers and labels show per-contender bootstrap 95% confidence intervals. The exact-value table below is the nonvisual source of the measurements.</figcaption></figure>
 <h2>Accessible data table</h2>
 <table><thead><tr><th>Linker</th><th>Wall link time (seconds)</th><th>Wall 95% CI</th><th>Peak process-tree RSS (MiB)</th><th>RSS 95% CI</th></tr></thead>
 <tbody>{_html_table(report)}</tbody></table>
@@ -481,7 +560,7 @@ def render_summary(report: dict[str, Any]) -> str:
     lines = [
         "### Linux ELF competitive linker evidence",
         "",
-        f"Workload: `{_workload_label(report)}`. Wall time and peak RSS are co-primary; No scalar combined score.",
+        f"Workload: `{_workload_label(report)}`. The grouped figure places wall time first and peak RSS second with separate zero-based axes; both remain co-primary. No scalar combined score is produced.",
         "",
         "#### Artifact comparison policy",
         "",

--- a/ci/tests/test_linux_linker_competition_render.py
+++ b/ci/tests/test_linux_linker_competition_render.py
@@ -217,7 +217,7 @@ def test_render_surfaces_have_aligned_wall_and_rss_values(tmp_path: Path):
     assert paths.summary.is_file()
     assert "Wall link time (seconds)" in html
     assert "Peak process-tree RSS (MiB)" in html
-    assert 'aria-label="Competitive linker measurements"' in html
+    assert 'aria-label="Grouped dual-axis competitive linker measurements"' in html
     assert "GNU bfd" in html
     assert "3.570 s" in html
     assert "983.000 MiB" in html
@@ -228,6 +228,51 @@ def test_render_surfaces_have_aligned_wall_and_rss_values(tmp_path: Path):
     assert ARTIFACT_COMPARISON_DISCLAIMER in html
     assert ARTIFACT_COMPARISON_DISCLAIMER in summary
     assert json.loads(paths.json.read_text(encoding="utf-8"))["contender_order"] == list(CONTENDER_ORDER)
+
+
+def test_png_and_html_contract_require_one_grouped_dual_axis_chart(tmp_path: Path):
+    """Issue #105 RED/GREEN contract: time is first and RSS is second in every group."""
+    paths = render_report(_report(), tmp_path)
+    html = paths.html.read_text(encoding="utf-8")
+
+    with Image.open(paths.png) as image:
+        assert image.text["layout"] == "grouped-dual-axis-v1"
+        assert image.text["bar_order"] == "wall_seconds,peak_rss_kib"
+        assert image.text["left_axis"] == "wall_seconds"
+        assert image.text["right_axis"] == "peak_rss_kib"
+        assert image.text["contender_order"].split(",") == list(CONTENDER_ORDER)
+        assert image.text["metrics"] == "wall_seconds,peak_rss_kib"
+
+    assert "grouped dual-axis chart" in html
+    assert "wall time first" in html
+    assert "peak process-tree RSS second" in html
+    assert "separate zero-based axes" in html
+
+
+def test_grouped_chart_annotation_boxes_are_in_bounds_and_non_overlapping(tmp_path: Path):
+    """Close six-contender values still get separate deterministic annotation columns."""
+    report = _report()
+    for contender in CONTENDER_ORDER:
+        report["contenders"][contender]["summaries"] = {
+            "wall_seconds": _summary(1.000),
+            "peak_rss_kib": _summary(512.000 * 1024),
+        }
+
+    paths = render_report(report, tmp_path)
+    with Image.open(paths.png) as image:
+        boxes = json.loads(image.text["annotation_boxes"])
+
+    assert len(boxes) == len(CONTENDER_ORDER) * 2 * 2  # median and CI for both metric bars
+    for box in boxes:
+        assert 170 <= box["x"]
+        assert box["x"] + box["width"] <= 1630
+        assert 215 <= box["y"]
+        assert box["y"] + box["height"] <= 725
+    for index, first in enumerate(boxes):
+        for second in boxes[index + 1 :]:
+            overlap_x = first["x"] < second["x"] + second["width"] and second["x"] < first["x"] + first["width"]
+            overlap_y = first["y"] < second["y"] + second["height"] and second["y"] < first["y"] + first["height"]
+            assert not (overlap_x and overlap_y), (first, second)
 
 
 def test_complete_manifest_seals_the_same_json_html_png_and_summary(tmp_path: Path):
@@ -294,8 +339,8 @@ def test_realistic_measurement_schema_and_every_surface_stay_in_parity(tmp_path:
     markdown = paths.summary.read_text(encoding="utf-8")
     with Image.open(paths.png) as image:
         png_values = json.loads(image.text["rendered_values"])
-        # The paired panels reserve a readable annotation column for all six contenders.
-        assert image.size == (1800, 920)
+        # The single grouped chart reserves a readable annotation column for each metric bar.
+        assert image.size == (1800, 980)
         assert image.text["contender_order"].split(",") == list(CONTENDER_ORDER)
         assert image.text["metrics"] == "wall_seconds,peak_rss_kib"
 

--- a/ci/tests/test_linux_linker_competition_render.py
+++ b/ci/tests/test_linux_linker_competition_render.py
@@ -275,6 +275,27 @@ def test_grouped_chart_annotation_boxes_are_in_bounds_and_non_overlapping(tmp_pa
             assert not (overlap_x and overlap_y), (first, second)
 
 
+def test_grouped_chart_long_value_annotations_stay_readable_and_non_overlapping(tmp_path: Path):
+    """Host-feasible long seconds/MiB labels cannot collide across metric columns."""
+    report = _report()
+    for contender in CONTENDER_ORDER:
+        report["contenders"][contender]["summaries"] = {
+            "wall_seconds": _summary(9_000.000),
+            "peak_rss_kib": _summary(13 * 1024 * 1024),
+        }
+
+    paths = render_report(report, tmp_path)
+    with Image.open(paths.png) as image:
+        boxes = json.loads(image.text["annotation_boxes"])
+
+    assert all(box["font_size"] >= 8 for box in boxes)
+    for index, first in enumerate(boxes):
+        for second in boxes[index + 1 :]:
+            overlap_x = first["x"] < second["x"] + second["width"] and second["x"] < first["x"] + first["width"]
+            overlap_y = first["y"] < second["y"] + second["height"] and second["y"] < first["y"] + first["height"]
+            assert not (overlap_x and overlap_y), (first, second)
+
+
 def test_complete_manifest_seals_the_same_json_html_png_and_summary(tmp_path: Path):
     paths = render_report(_report(), tmp_path / "published")
     manifest = json.loads(paths.manifest.read_text(encoding="utf-8"))

--- a/ci/tests/test_linux_linker_competition_workflow.py
+++ b/ci/tests/test_linux_linker_competition_workflow.py
@@ -103,6 +103,10 @@ def test_competition_workflow_renders_and_uploads_same_run_evidence_without_hist
     text = workflow_text()
 
     assert "ci.linux_linker_competition_render" in text
+    assert "Render grouped dual-axis wall-time and peak-RSS evidence" in text
+    assert "Upload report, raw samples, provenance, and grouped dual-axis graph" in text
+    assert "paired wall-time" not in text
+    assert "and paired graph" not in text
     assert '--report "$REPORT"' in text
     assert '--output-dir "$RENDER_DIR"' in text
     assert '--summary-output "$SUMMARY_OUTPUT"' in text


### PR DESCRIPTION
Closes #105.

## Design

- replaces the two separate Linux benchmark panels with one grouped dual-axis plotting area
- renders exactly two adjacent bars per linker: solid wall time first on the zero-based left seconds axis, then hatched peak process-tree RSS on the independent zero-based right MiB axis
- retains exact median and bootstrap 95% CI labels, with deterministic wrapping for long values
- adds accessible HTML wording/table and machine-readable PNG layout/order/axis metadata
- preserves the report schema, raw samples, measurement harness, correctness gates, and artifact-equivalence policy

## Local validation

- 258 CI tests passed
- Ruff passed
- compileall passed
- dependency policy check passed
- generated README benchmark block check passed
- git diff check passed
- realistic published report rendered and visually inspected
- clud-review clean with one reviewer

## Hosted evidence

The pinned same-run benchmark passed in [run 33496554602](https://github.com/zackees/reld/actions/runs/33496554602). Its hosted PNG was visually inspected for adjacent bar order, axis ownership, CI readability, clipping, and overlap; its metadata, 72 raw samples, byte-identical report copy, and sealed manifest hashes were also verified.

The immutable [linux-linker-competition-v2 release](https://github.com/zackees/reld/releases/tag/linux-linker-competition-v2) targets the exact measured merge commit and includes the PNG, accessible HTML, structured reports, raw samples, provenance, pinned locks, summary, and completion manifest.
